### PR TITLE
Issue 560

### DIFF
--- a/.github/workflows/update-learndd.yml
+++ b/.github/workflows/update-learndd.yml
@@ -1,0 +1,30 @@
+name: Update learndd
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12
+            - run: npm install
+            - run: npm run build
+            
+    FTP-Deploy-Action:
+        name: FTP-Deploy-Action
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2.1.0
+              with:
+                  fetch-depth: 2
+            - name: FTP-Deploy-Action
+              uses: SamKirkland/FTP-Deploy-Action@3.1.1
+              with:
+                  ftp-server: ftp://35.207.148.34:21/wp-content/plugins/
+                  ftp-username: learndd
+                  ftp-password: o1aEZIS2hyJ%uH0XexD8UF@&

--- a/.github/workflows/update-learndd.yml
+++ b/.github/workflows/update-learndd.yml
@@ -25,6 +25,7 @@ jobs:
             - name: FTP-Deploy-Action
               uses: SamKirkland/FTP-Deploy-Action@3.1.1
               with:
-                  ftp-server: ftp://35.207.148.34:21/wp-content/plugins/
+                  ftp-server: ftps://35.207.148.34:21/wp-content/plugins/
                   ftp-username: learndd
                   ftp-password: o1aEZIS2hyJ%uH0XexD8UF@&
+                  git-ftp-args: --insecure # test


### PR DESCRIPTION
Closes #560 

Not sure if the ftp action will work properly. I think we should at least improve 2 things:
1. FTP server: is suggested by the script creator to use a standard like: 'ftp://ftp.samkirkland.com/destinationPath/' instead of 'ftp://35.207.148.34:21/wp-content/plugins/'. Check the documentation [here](https://github.com/marketplace/actions/ftp-deploy#settings).
2. Password should be saved as a secret, so Admin of Github has to do it. Can follow the [instructions](https://github.com/marketplace/actions/ftp-deploy#setup-steps).

Please @elzadj, have a look to this.