### PR TITLE
Fix #875

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -35,6 +35,7 @@ class edit extends MaxiBlock {
 	state = {
 		isResizing: false,
 	};
+
 	get getStylesObject() {
 		return getStyles(this.props.attributes);
 	}

--- a/src/components/toolbar/components/mover/index.js
+++ b/src/components/toolbar/components/mover/index.js
@@ -15,8 +15,7 @@ import { castArray, first, last } from 'lodash';
  * Icons
  */
 import './editor.scss';
-import { toolbarMove } from '../../../../icons';
-import { moveUp, moveDown } from '../../../../icons';
+import { toolbarMove, moveUp, moveDown } from '../../../../icons';
 
 /**
  * Mover
@@ -46,10 +45,10 @@ const Mover = props => {
 				? getTemplateLock(rootClientId)
 				: null;
 			const clientIds = getSelectedBlockClientIds();
-			const blockOrder = getBlockOrder(blockRootClientId);
 			const normalizedClientIds = castArray(clientIds);
 			const firstClientId = first(normalizedClientIds);
 			const blockRootClientId = getBlockRootClientId(firstClientId);
+			const blockOrder = getBlockOrder(blockRootClientId);
 			const firstBlockIndex = getBlockIndex(
 				firstClientId,
 				blockRootClientId

--- a/src/components/transform-control/index.js
+++ b/src/components/transform-control/index.js
@@ -51,177 +51,78 @@ const TransformControl = props => {
 			`.maxi-block[uniqueid="${uniqueID}"]`
 		);
 		if (node) {
-			let transformStr = '';
-			let originStr = '';
+			let transformString = '';
+			let transformOriginString = '';
 
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-scale-x',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `scaleX(${
-					getLastBreakpointAttribute(
-						'transform-scale-x',
-						breakpoint,
-						transformOptions
-					) / 100
-				}) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-scale-y',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `scaleY(${
-					getLastBreakpointAttribute(
-						'transform-scale-y',
-						breakpoint,
-						transformOptions
-					) / 100
-				}) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-translate-x',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `translateX(${getLastBreakpointAttribute(
-					'transform-translate-x',
-					breakpoint,
-					transformOptions
-				)}${getLastBreakpointAttribute(
-					'transform-translate-x-unit',
-					breakpoint,
-					transformOptions
-				)}) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-translate-y',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `translateY(${getLastBreakpointAttribute(
-					'transform-translate-y',
-					breakpoint,
-					transformOptions
-				)}${getLastBreakpointAttribute(
-					'transform-translate-y-unit',
-					breakpoint,
-					transformOptions
-				)}) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-rotate-x',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `rotateX(${getLastBreakpointAttribute(
-					'transform-rotate-x',
-					breakpoint,
-					transformOptions
-				)}deg) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-rotate-y',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `rotateY(${getLastBreakpointAttribute(
-					'transform-rotate-y',
-					breakpoint,
-					transformOptions
-				)}deg) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-rotate-z',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				transformStr += `rotateZ(${getLastBreakpointAttribute(
-					'transform-rotate-z',
-					breakpoint,
-					transformOptions
-				)}deg) `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-origin-x',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				originStr += `${getLastBreakpointAttribute(
-					'transform-origin-x',
-					breakpoint,
-					transformOptions
-				)}% `;
-			if (
-				isNumber(
-					getLastBreakpointAttribute(
-						'transform-origin-y',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				originStr += `${getLastBreakpointAttribute(
-					'transform-origin-y',
-					breakpoint,
-					transformOptions
-				)}% `;
-			if (
-				isString(
-					getLastBreakpointAttribute(
-						'transform-origin-x',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				originStr += `${getLastBreakpointAttribute(
-					'transform-origin-x',
-					breakpoint,
-					transformOptions
-				)} `;
-			if (
-				isString(
-					getLastBreakpointAttribute(
-						'transform-origin-y',
-						breakpoint,
-						transformOptions
-					)
-				)
-			)
-				originStr += `${getLastBreakpointAttribute(
-					'transform-origin-y',
-					breakpoint,
-					transformOptions
-				)} `;
+			const scaleX = getLastBreakpointAttribute(
+				'transform-scale-x',
+				breakpoint,
+				transformOptions
+			);
+			const scaleY = getLastBreakpointAttribute(
+				'transform-scale-y',
+				breakpoint,
+				transformOptions
+			);
+			const translateX = getLastBreakpointAttribute(
+				'transform-translate-x',
+				breakpoint,
+				transformOptions
+			);
+			const translateXUnit = getLastBreakpointAttribute(
+				'transform-translate-x-unit',
+				breakpoint,
+				transformOptions
+			);
+			const translateY = getLastBreakpointAttribute(
+				'transform-translate-y',
+				breakpoint,
+				transformOptions
+			);
+			const translateYUnit = getLastBreakpointAttribute(
+				'transform-translate-y-unit',
+				breakpoint,
+				transformOptions
+			);
+			const rotateX = getLastBreakpointAttribute(
+				'transform-rotate-x',
+				breakpoint,
+				transformOptions
+			);
+			const rotateY = getLastBreakpointAttribute(
+				'transform-rotate-y',
+				breakpoint,
+				transformOptions
+			);
+			const rotateZ = getLastBreakpointAttribute(
+				'transform-rotate-z',
+				breakpoint,
+				transformOptions
+			);
+			const originX = getLastBreakpointAttribute(
+				'transform-origin-x',
+				breakpoint,
+				transformOptions
+			);
+			const originY = getLastBreakpointAttribute(
+				'transform-origin-y',
+				breakpoint,
+				transformOptions
+			);
 
-			node.style = `transform: ${transformStr}; transform-origin: ${originStr}`;
+			if (isNumber(scaleX)) transformString += `scaleX(${scaleX / 100}) `;
+			if (isNumber(scaleY)) transformString += `scaleY(${scaleY / 100}) `;
+			if (isNumber(translateX) && translateX > 0)
+				transformString += `translateX(${translateX}${translateXUnit}) `;
+			if (isNumber(translateY) && translateY > 0)
+				transformString += `translateY(${translateY}${translateYUnit}) `;
+			if (isNumber(rotateX)) transformString += `rotateX(${rotateX}deg) `;
+			if (isNumber(rotateY)) transformString += `rotateY(${rotateY}deg) `;
+			if (isNumber(rotateZ)) transformString += `rotateZ(${rotateZ}deg) `;
+			if (isString(originX)) transformOriginString += `${originX}% `;
+			if (isString(originY)) transformOriginString += `${originY}% `;
+
+			node.style = `transform: ${transformString}; transform-origin: ${transformOriginString}`;
 		}
 	};
 

--- a/src/extensions/styles/helpers/getTransformStyles.js
+++ b/src/extensions/styles/helpers/getTransformStyles.js
@@ -25,156 +25,73 @@ const getTransformStyles = obj => {
 		let transformString = '';
 		let transformOriginString = '';
 
-		if (
-			isNumber(
-				getLastBreakpointAttribute('transform-scale-x', breakpoint, obj)
-			)
-		)
-			transformString += `scaleX(${
-				getLastBreakpointAttribute(
-					'transform-scale-x',
-					breakpoint,
-					obj
-				) / 100
-			}) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute('transform-scale-y', breakpoint, obj)
-			)
-		)
-			transformString += `scaleY(${
-				getLastBreakpointAttribute(
-					'transform-scale-y',
-					breakpoint,
-					obj
-				) / 100
-			}) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-translate-x',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformString += `translateX(${getLastBreakpointAttribute(
-				'transform-translate-x',
-				breakpoint,
-				obj
-			)}${getLastBreakpointAttribute(
-				'transform-translate-x-unit',
-				breakpoint,
-				obj
-			)}) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-translate-y',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformString += `translateY(${getLastBreakpointAttribute(
-				'transform-translate-y',
-				breakpoint,
-				obj
-			)}${getLastBreakpointAttribute(
-				'transform-translate-y-unit',
-				breakpoint,
-				obj
-			)}) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-rotate-x',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformString += `rotateX(${getLastBreakpointAttribute(
-				'transform-rotate-x',
-				breakpoint,
-				obj
-			)}deg) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-rotate-y',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformString += `rotateY(${getLastBreakpointAttribute(
-				'transform-rotate-y',
-				breakpoint,
-				obj
-			)}deg) `;
-		if (isNumber(getLastBreakpointAttribute('rotateZ', breakpoint, obj)))
-			transformString += `rotateZ(${getLastBreakpointAttribute(
-				'rotateZ',
-				breakpoint,
-				obj
-			)}deg) `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-origin-x',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformOriginString += `${getLastBreakpointAttribute(
-				'transform-origin-x',
-				breakpoint,
-				obj
-			)}% `;
-		if (
-			isNumber(
-				getLastBreakpointAttribute(
-					'transform-origin-y',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformOriginString += `${getLastBreakpointAttribute(
-				'transform-origin-y',
-				breakpoint,
-				obj
-			)}% `;
-		if (
-			isString(
-				getLastBreakpointAttribute(
-					'transform-origin-x',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformOriginString += `${getLastBreakpointAttribute(
-				'transform-origin-x',
-				breakpoint,
-				obj
-			)} `;
-		if (
-			isString(
-				getLastBreakpointAttribute(
-					'transform-origin-y',
-					breakpoint,
-					obj
-				)
-			)
-		)
-			transformOriginString += `${getLastBreakpointAttribute(
-				'transform-origin-y',
-				breakpoint,
-				obj
-			)} `;
+		const scaleX = getLastBreakpointAttribute(
+			'transform-scale-x',
+			breakpoint,
+			obj
+		);
+		const scaleY = getLastBreakpointAttribute(
+			'transform-scale-y',
+			breakpoint,
+			obj
+		);
+		const translateX = getLastBreakpointAttribute(
+			'transform-translate-x',
+			breakpoint,
+			obj
+		);
+		const translateXUnit = getLastBreakpointAttribute(
+			'transform-translate-x-unit',
+			breakpoint,
+			obj
+		);
+		const translateY = getLastBreakpointAttribute(
+			'transform-translate-y',
+			breakpoint,
+			obj
+		);
+		const translateYUnit = getLastBreakpointAttribute(
+			'transform-translate-y-unit',
+			breakpoint,
+			obj
+		);
+		const rotateX = getLastBreakpointAttribute(
+			'transform-rotate-x',
+			breakpoint,
+			obj
+		);
+		const rotateY = getLastBreakpointAttribute(
+			'transform-rotate-y',
+			breakpoint,
+			obj
+		);
+		const rotateZ = getLastBreakpointAttribute(
+			'transform-rotate-z',
+			breakpoint,
+			obj
+		);
+		const originX = getLastBreakpointAttribute(
+			'transform-origin-x',
+			breakpoint,
+			obj
+		);
+		const originY = getLastBreakpointAttribute(
+			'transform-origin-y',
+			breakpoint,
+			obj
+		);
+
+		if (isNumber(scaleX)) transformString += `scaleX(${scaleX / 100}) `;
+		if (isNumber(scaleY)) transformString += `scaleY(${scaleY / 100}) `;
+		if (isNumber(translateX) && translateX > 0)
+			transformString += `translateX(${translateX}${translateXUnit}) `;
+		if (isNumber(translateY) && translateY > 0)
+			transformString += `translateY(${translateY}${translateYUnit}) `;
+		if (isNumber(rotateX)) transformString += `rotateX(${rotateX}deg) `;
+		if (isNumber(rotateY)) transformString += `rotateY(${rotateY}deg) `;
+		if (isNumber(rotateZ)) transformString += `rotateZ(${rotateZ}deg) `;
+		if (isString(originX)) transformOriginString += `${originX}% `;
+		if (isString(originY)) transformOriginString += `${originY}% `;
 
 		const transformObj = {
 			...(!isEmpty(transformString) && { transform: transformString }),


### PR DESCRIPTION
Never seen this before, and may it helps you in future. HTML elements under `position: fixed` can be affected by parent elements with transform properties. In this case, the blocks were under the TranslateControl statement that were setting `transform: translateX(0%) translateY(0%)` and this was affecting to the position of the element. Hectic, first time I see it in my life, and I don't really understand the documentation:

> For elements whose layout is governed by the CSS box model, any value other than none for the transform property results in the creation of a stacking context. Implementations must paint the layer it creates, within its parent stacking context, at the same stacking order that would be used if it were a positioned element with z-index: 0. If an element with a transform is positioned, the z-index property applies as described in [CSS2], except that auto is treated as 0 since a new stacking context is always created.
> 
> For elements whose layout is governed by the CSS box model, any value other than none for the transform property also causes the element to establish a containing block for all descendants. Its padding box will be used to layout for all of its absolute-position descendants, fixed-position descendants, and descendant fixed background attachments.

[more info](https://www.w3.org/TR/css-transforms-1/#example-02d1d5ba)

So fixed TransformControl also 👍  (may related to #859 )