### PR TITLE
Fix #900

### DIFF
--- a/src/blocks/text-maxi/edit.js
+++ b/src/blocks/text-maxi/edit.js
@@ -122,8 +122,6 @@ class edit extends MaxiBlock {
 			className
 		);
 
-		const { getFormatTypes } = select('core/rich-text');
-
 		return [
 			<Inspector
 				key={`block-settings-${uniqueID}`}
@@ -220,9 +218,6 @@ class edit extends MaxiBlock {
 							keepPlaceholderOnFocus
 							__unstableEmbedURLOnPaste
 							__unstableAllowPrefixTransformations
-							allowedFormats={getFormatTypes().filter(format => {
-								return format.name !== 'core/link';
-							})}
 						/>
 					)}
 					{isList && (
@@ -262,9 +257,6 @@ class edit extends MaxiBlock {
 							start={listStart}
 							reversed={!!listReversed}
 							type={typeOfList}
-							allowedFormats={getFormatTypes().filter(format => {
-								return format.name !== 'core/link';
-							})}
 						>
 							{({ value, onChange }) =>
 								isSelected && (

--- a/src/blocks/text-maxi/edit.js
+++ b/src/blocks/text-maxi/edit.js
@@ -25,6 +25,7 @@ import {
 	fromTextToList,
 	getFormatValue,
 	setCustomFormatsWhenPaste,
+	withFormatValue,
 } from '../../extensions/text/formats';
 import {
 	getGroupAttributes,
@@ -45,26 +46,6 @@ class edit extends MaxiBlock {
 	constructor(props) {
 		super(props);
 		this.textRef = createRef();
-	}
-
-	state = {
-		formatValue:
-			this.props.generateFormatValue(
-				this.textRef ? this.textRef.current : null
-			) || {},
-		textSelected: '',
-	};
-
-	componentDidMount() {
-		// const { alignment } = this.props.attributes;
-		// const { isRTL } = select('core/editor').getEditorSettings();
-
-		// if (isEmpty(alignment.general.alignment)) {
-		// 	alignment.general.alignment = isRTL ? 'right' : 'left';
-		// 	this.props.setAttributes({ alignment });
-		// }
-
-		this.displayStyles();
 	}
 
 	get getStylesObject() {
@@ -103,8 +84,7 @@ class edit extends MaxiBlock {
 			onSplit,
 			onReplace,
 			deviceType,
-			selectedText,
-			generateFormatValue,
+			formatValue,
 		} = this.props;
 		const {
 			uniqueID,
@@ -121,17 +101,8 @@ class edit extends MaxiBlock {
 			fullWidth,
 			typography,
 		} = attributes;
-		const { formatValue, textSelected } = this.state;
 
 		const name = 'maxi-blocks/text-maxi';
-
-		if (isEmpty(formatValue) || selectedText !== textSelected)
-			this.setState({
-				formatValue: generateFormatValue(
-					this.textRef ? this.textRef.current : null
-				),
-				textSelected: selectedText,
-			});
 
 		const classes = classnames(
 			'maxi-block',
@@ -172,13 +143,6 @@ class edit extends MaxiBlock {
 					className={classes}
 					data-maxi_initial_block_class={defaultBlockStyle}
 					data-align={fullWidth}
-					onClick={() =>
-						this.setState({
-							formatValue: generateFormatValue(
-								this.textRef ? this.textRef.current : null
-							),
-						})
-					}
 				>
 					<BackgroundDisplayer
 						{...getGroupAttributes(attributes, [
@@ -362,20 +326,17 @@ class edit extends MaxiBlock {
 	}
 }
 
-const editSelect = withSelect(select => {
-	const selectedText = window.getSelection().toString();
+const editSelect = withSelect((select, ownProps) => {
 	const deviceType = select('maxiBlocks').receiveMaxiDeviceType();
 
 	return {
-		// The 'selectedText' attribute is a trigger for generating the formatValue
-		selectedText,
 		deviceType,
 	};
 });
 
 const editDispatch = withDispatch((dispatch, ownProps) => {
 	const { attributes, setAttributes, clientId } = ownProps;
-	const { content, isList, typeOfList } = attributes;
+	const { content } = attributes;
 
 	const name = 'maxi-blocks/text-maxi';
 
@@ -579,23 +540,11 @@ const editDispatch = withDispatch((dispatch, ownProps) => {
 		});
 	};
 
-	const generateFormatValue = node => {
-		const formatElement = {
-			multilineTag: isList ? 'li' : undefined,
-			multilineWrapperTags: isList ? typeOfList : undefined,
-			__unstableIsEditableTree: true,
-		};
-		const formatValue = getFormatValue(formatElement, node);
-
-		return formatValue;
-	};
-
 	return {
 		onReplace,
 		onMerge,
 		onSplit,
-		generateFormatValue,
 	};
 });
 
-export default compose(editSelect, editDispatch)(edit);
+export default compose(editSelect, editDispatch, withFormatValue)(edit);

--- a/src/extensions/attributes/index.js
+++ b/src/extensions/attributes/index.js
@@ -91,11 +91,8 @@ const addAttributes = settings => {
  */
 const withAttributes = createHigherOrderComponent(
 	BlockEdit => props => {
-		const {
-			attributes: { uniqueID },
-			name,
-			clientId,
-		} = props;
+		const { attributes, name, clientId } = props;
+		const { uniqueID } = attributes;
 
 		if (allowedBlocks.includes(name)) {
 			// uniqueID
@@ -106,7 +103,7 @@ const withAttributes = createHigherOrderComponent(
 				const newName = uniqueId(
 					`${name.replace('maxi-blocks/', '')}-`
 				);
-				props.attributes.uniqueID = uniqueIDGenerator(newName);
+				attributes.uniqueID = uniqueIDGenerator(newName);
 			}
 			// isFirstOnHierarchy
 			const parentBlocks = select('core/block-editor')
@@ -117,7 +114,14 @@ const withAttributes = createHigherOrderComponent(
 
 			if (parentBlocks.includes(clientId)) parentBlocks.pop();
 
-			props.attributes.isFirstOnHierarchy = isEmpty(parentBlocks);
+			attributes.isFirstOnHierarchy = isEmpty(parentBlocks);
+
+			// RTL
+			if (attributes['text-alignment-general']) {
+				const { isRTL } = select('core/editor').getEditorSettings();
+
+				attributes['text-alignment-general'] = isRTL ? 'right' : 'left';
+			}
 		}
 
 		return <BlockEdit {...props} />;

--- a/src/extensions/styles/defaults/textAlignment.js
+++ b/src/extensions/styles/defaults/textAlignment.js
@@ -1,7 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+const { select } = wp.data;
+
+const { isRTL } = select('core/editor').getEditorSettings();
+
 const textAlignment = {
 	'text-alignment-general': {
 		type: 'string',
-		default: 'left',
+		default: isRTL ? 'right' : 'left',
 	},
 	'text-alignment-xxl': {
 		type: 'string',

--- a/src/extensions/styles/defaults/textAlignment.js
+++ b/src/extensions/styles/defaults/textAlignment.js
@@ -1,14 +1,7 @@
-/**
- * WordPress dependencies
- */
-const { select } = wp.data;
-
-const { isRTL } = select('core/editor').getEditorSettings();
-
 const textAlignment = {
 	'text-alignment-general': {
 		type: 'string',
-		default: isRTL ? 'right' : 'left',
+		default: 'left',
 	},
 	'text-alignment-xxl': {
 		type: 'string',

--- a/src/extensions/text/formats/index.js
+++ b/src/extensions/text/formats/index.js
@@ -10,3 +10,4 @@ export { default as setFormat } from './setFormat';
 export { default as removeLinkFormat } from './removeLinkFormat';
 export { fromListToText } from './listUtils';
 export { fromTextToList } from './listUtils';
+export { default as withFormatValue } from './withFormatValue';

--- a/src/extensions/text/formats/withFormatValue.js
+++ b/src/extensions/text/formats/withFormatValue.js
@@ -1,0 +1,37 @@
+/**
+ * WordPress dependencies
+ */
+const { createHigherOrderComponent } = wp.compose;
+const { useRef } = wp.element;
+
+/**
+ * Internal dependencies
+ */
+import getFormatValue from './getFormatValue';
+
+/**
+ * Component
+ */
+export default createHigherOrderComponent(
+	TextMaxiComponent => props => {
+		const ref = useRef();
+		const {
+			attributes: { isList, typeOfList },
+		} = props;
+
+		const formatElement = {
+			multilineTag: isList ? 'li' : undefined,
+			multilineWrapperTags: isList ? typeOfList : undefined,
+			__unstableIsEditableTree: true,
+		};
+		const formatValue =
+			(ref.current &&
+				getFormatValue(formatElement, ref.current.textRef.current)) ||
+			{};
+
+		return (
+			<TextMaxiComponent ref={ref} formatValue={formatValue} {...props} />
+		);
+	},
+	'withFormatValue'
+);


### PR DESCRIPTION
This branch has 2 implementations:
- Fixes #900 (not a priority, but took me 2 min)
- Create higher order component for FormatValue blocks: the way we were obtaining the `FormatValue` object was creating errors on console and was rendering much times Text Maxi. First step for fixing other issues of Text Maxi 👍 