### PR TITLE
Divider Maxi suggestion

### DIFF
--- a/src/blocks/divider-maxi/attributes.js
+++ b/src/blocks/divider-maxi/attributes.js
@@ -38,12 +38,6 @@ const attributes = {
 	},
 	...{
 		...attributesData.size,
-		'width-general': {
-			default: 50,
-		},
-		'width-unit-general': {
-			default: 'px',
-		},
 		'height-general': {
 			default: 100,
 		},

--- a/src/components/divider-control/index.js
+++ b/src/components/divider-control/index.js
@@ -27,11 +27,6 @@ import {
 } from './defaults';
 
 /**
- * External dependencies
- */
-import { isNil } from 'lodash';
-
-/**
  * Icons
  */
 import { styleNone, dashed, dotted, solid } from '../../icons';

--- a/src/extensions/styles/defaults/divider.js
+++ b/src/extensions/styles/defaults/divider.js
@@ -27,11 +27,11 @@ const divider = {
 	},
 	'divider-width': {
 		type: 'number',
-		default: 100,
+		default: 50,
 	},
 	'divider-width-unit': {
 		type: 'string',
-		default: '%',
+		default: 'px',
 	},
 	'divider-height': {
 		type: 'number',


### PR DESCRIPTION
Made some changes on Divider Maxi for suggest some implementations that make it be more coherent with the rest of the blocks. Having a width of '50px' all the block generates situations like:
<img width="635" alt="Captura de pantalla 2021-02-23 a las 17 25 07" src="https://user-images.githubusercontent.com/50477222/108874080-189bbc80-75fc-11eb-8e1b-c611e3e792ef.png">

This branch propose to make it look like:
<img width="635" alt="Captura de pantalla 2021-02-23 a las 17 26 01" src="https://user-images.githubusercontent.com/50477222/108874198-3832e500-75fc-11eb-849c-74e97463f7c9.png">
