### PR TITLE
Issue 1555

### DIFF
--- a/src/blocks/container-maxi/editor.scss
+++ b/src/blocks/container-maxi/editor.scss
@@ -1,5 +1,11 @@
 .maxi-container-block {
 	margin: auto;
+
+	.block-list-appender
+		.block-editor-button-block-appender[aria-label='Add Row Maxi'] {
+		left: calc(50% - 48px);
+		border-radius: 50%;
+	}
 	&__container {
 		border: 1px solid #7fbddc;
 		width: 100%;

--- a/src/blocks/group-maxi/editor.scss
+++ b/src/blocks/group-maxi/editor.scss
@@ -4,6 +4,10 @@
 	&__group {
 		border: 1px solid #7fbddc;
 		width: 100%;
+
+		.maxi-row-block {
+			z-index: 1;
+		}
 	}
 	.block-list-appender {
 		margin: 0;


### PR DESCRIPTION
Show "Add Row Maxi" next to the "Add Block" and change its style to rounded, please check this solution, the problem goes here is when we have not any row the "Add Row Maxi" button is not centered if I have a class when container have Row I can handle this one also

If you like this solution we can find a good way to put it center