### PR TITLE
Issue 1776

### DIFF
--- a/e2e-tests/blocks/text-maxi/__snapshots__/index.spec.js.snap
+++ b/e2e-tests/blocks/text-maxi/__snapshots__/index.spec.js.snap
@@ -1,8 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextMaxi Test Text Maxi merge 1`] = `
-"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-12\\",\\"content\\":\\"Test Text Maxi......OnMerge\\"} -->
-<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">Test Text Maxi......OnMerge</p></div>
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-3\\",\\"content\\":\\"est Text Maxi...\\"} -->
+<div id=\\"text-maxi-3\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-3 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">est Text Maxi...</p></div>
+<!-- /wp:maxi-blocks/text-maxi -->
+
+<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-4\\",\\"content\\":\\"...OnMerge\\"} -->
+<div id=\\"text-maxi-4\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-4 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">...OnMerge</p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
+
+exports[`TextMaxi Test Text Maxi merge from bottom to top with Custom Formats 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-3\\",\\"content\\":\\"Test Text \\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d0\\\\u0022\\\\u003eMaxi\\\\u003c/span\\\\u003e......\\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d1\\\\u0022\\\\u003eOnMerge\\\\u003c/span\\\\u003e\\",\\"custom-formats\\":{\\"maxi-text-block__custom-format\\\\u002d\\\\u002d0\\":{\\"font-weight-general\\":800},\\"maxi-text-block__custom-format\\\\u002d\\\\u002d1\\":{\\"font-style-general\\":\\"italic\\"}}} -->
+<div id=\\"text-maxi-3\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-3 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">Test Text <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--0\\">Maxi</span>......<span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">OnMerge</span></p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
+
+exports[`TextMaxi Test Text Maxi merge from top to bottom with Custom Formats 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-3\\",\\"content\\":\\"Test Text \\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d0\\\\u0022\\\\u003eMaxi\\\\u003c/span\\\\u003e......\\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d1\\\\u0022\\\\u003eOnMerge\\\\u003c/span\\\\u003e\\",\\"custom-formats\\":{\\"maxi-text-block__custom-format\\\\u002d\\\\u002d0\\":{\\"font-weight-general\\":800},\\"maxi-text-block__custom-format\\\\u002d\\\\u002d1\\":{\\"font-style-general\\":\\"italic\\"}}} -->
+<div id=\\"text-maxi-3\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-3 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">Test Text <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--0\\">Maxi</span>......<span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">OnMerge</span></p></div>
 <!-- /wp:maxi-blocks/text-maxi -->"
 `;
 
@@ -41,6 +57,32 @@ exports[`TextMaxi Test Text Maxi toolbar Link in whole content 1`] = `
 `;
 
 exports[`TextMaxi Test Text Maxi toolbar Link in whole content 2`] = `"<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\">Test Text Maxi</a></p></div>"`;
+
+exports[`TextMaxi Test Text Maxi toolbar Link in whole content, and then keep writing 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-12\\",\\"content\\":\\"\\\\u003ca href=\\\\u0022test.com\\\\u0022 rel=\\\\u0022\\\\u0022 title=\\\\u0022\\\\u0022 class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dlink\\\\u0022\\\\u003eTest Text Maxi and its awesome features\\\\u003c/a\\\\u003e\\",\\"text-decoration-general\\":\\"underline\\"} -->
+<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\">Test Text Maxi and its awesome features</a></p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
+
+exports[`TextMaxi Test Text Maxi toolbar Link in whole content, and then remove it 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-12\\",\\"content\\":\\"Test Text Maxi\\",\\"text-decoration-general\\":\\"\\"} -->
+<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\">Test Text Maxi</p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
+
+exports[`TextMaxi Test Text Maxi toolbar Link in whole content, and then removing a part 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-12\\",\\"content\\":\\"\\\\u003ca href=\\\\u0022test.com\\\\u0022 rel=\\\\u0022\\\\u0022 title=\\\\u0022\\\\u0022 class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dlink\\\\u0022\\\\u003e\\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d1\\\\u0022\\\\u003eTest \\\\u003c/span\\\\u003e\\\\u003c/a\\\\u003eText\\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d1\\\\u0022\\\\u003e \\\\u003ca href=\\\\u0022test.com\\\\u0022 rel=\\\\u0022\\\\u0022 title=\\\\u0022\\\\u0022 class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dlink\\\\u0022\\\\u003eMaxi\\\\u003c/a\\\\u003e\\\\u003c/span\\\\u003e\\",\\"text-decoration-general\\":\\"\\",\\"custom-formats\\":{\\"maxi-text-block__custom-format\\\\u002d\\\\u002d1\\":{\\"text-decoration-general\\":\\"underline\\"}}} -->
+<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\"><span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">Test </span></a>Text<span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\"> <a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\">Maxi</a></span></p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
+
+exports[`TextMaxi Test Text Maxi toolbar Link in whole content, and then removing a part 2`] = `"<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\"><span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">Test </span></a>Text<span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\"> <a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\">Maxi</a></span></p></div>"`;
+
+exports[`TextMaxi Test Text Maxi toolbar Link in whole content, and then removing last part 1`] = `
+"<!-- wp:maxi-blocks/text-maxi {\\"parentBlockStyle\\":\\"light\\",\\"blockStyle\\":\\"maxi-light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"text-maxi-12\\",\\"content\\":\\"\\\\u003ca href=\\\\u0022test.com\\\\u0022 rel=\\\\u0022\\\\u0022 title=\\\\u0022\\\\u0022 class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dlink\\\\u0022\\\\u003e\\\\u003cspan class=\\\\u0022maxi-text-block\\\\u002d\\\\u002dhas-custom-format maxi-text-block__custom-format\\\\u002d\\\\u002d0\\\\u0022\\\\u003eTest Text \\\\u003c/span\\\\u003e\\\\u003c/a\\\\u003eMaxi\\",\\"text-decoration-general\\":\\"\\",\\"custom-formats\\":{\\"maxi-text-block__custom-format\\\\u002d\\\\u002d0\\":{\\"text-decoration-general\\":\\"underline\\"}}} -->
+<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"\\" title=\\"\\" class=\\"maxi-text-block--link\\"><span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--0\\">Test Text </span></a>Maxi</p></div>
+<!-- /wp:maxi-blocks/text-maxi -->"
+`;
 
 exports[`TextMaxi Test Text Maxi toolbar Link with all option on frontend 1`] = `"<div id=\\"text-maxi-12\\" class=\\"maxi-block maxi-text-block maxi-light text-maxi-12 wp-block-maxi-blocks-text-maxi\\" data-align=\\"normal\\"><p class=\\"maxi-text-block__content\\"><a href=\\"test.com\\" rel=\\"noreferrer noopener nofollow sponsored ugc\\" target=\\"_blank\\" title=\\"\\" class=\\"maxi-text-block--link\\">Test Text Maxi</a></p></div>"`;
 

--- a/e2e-tests/blocks/text-maxi/index.spec.js
+++ b/e2e-tests/blocks/text-maxi/index.spec.js
@@ -50,10 +50,64 @@ describe('TextMaxi', () => {
 	it('Test Text Maxi merge', async () => {
 		await insertBlock('Text Maxi');
 		await page.keyboard.type('Test Text Maxi...');
-		await insertBlock('Text Maxi');
+		await page.keyboard.press('Enter');
 		await page.keyboard.type('...OnMerge');
 		await pressKeyTimes('ArrowLeft', '11');
 		await page.keyboard.press('Delete');
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi merge from bottom to top with Custom Formats', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi...');
+		await pressKeyTimes('ArrowLeft', '3');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__bold', button => button.click());
+		await pressKeyTimes('ArrowRight', '4');
+		await page.keyboard.press('Enter');
+
+		await page.keyboard.type('...OnMerge');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__italic', button => button.click());
+		await pressKeyTimes('ArrowLeft', '5');
+		await page.keyboard.press('Delete');
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi merge from top to bottom with Custom Formats', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi...');
+		await pressKeyTimes('ArrowLeft', '3');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__bold', button => button.click());
+		await pressKeyTimes('ArrowRight', '4');
+		await page.keyboard.press('Enter');
+
+		await page.keyboard.type('...OnMerge');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__italic', button => button.click());
+		await pressKeyTimes('ArrowLeft', '4');
+		await page.keyboard.press('Backspace');
 
 		expect(await getEditedPostContent()).toMatchSnapshot();
 	});
@@ -76,6 +130,105 @@ describe('TextMaxi', () => {
 			contentWrapper => contentWrapper.innerHTML.trim()
 		);
 		expect(content).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi toolbar Link in whole content, and then keep writing', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.keyboard.type(linkExample);
+		await page.keyboard.press('Enter');
+
+		const selectMaxiTextDiv = await page.$('.maxi-text-block');
+		const selectMaxiTextP = await selectMaxiTextDiv.$(
+			'.block-editor-rich-text__editable'
+		);
+		await selectMaxiTextP.focus();
+
+		await page.keyboard.type(' and its awesome features');
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi toolbar Link in whole content, and then remove it', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.keyboard.type(linkExample);
+		await page.keyboard.press('Enter');
+
+		const selectMaxiTextDiv = await page.$('.maxi-text-block');
+		const selectMaxiTextP = await selectMaxiTextDiv.$(
+			'.block-editor-rich-text__editable'
+		);
+		await selectMaxiTextP.focus();
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.$eval('.toolbar-popover-link-destroyer', button =>
+			button.click()
+		);
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi toolbar Link in whole content, and then removing a part', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.keyboard.type(linkExample);
+		await page.keyboard.press('Enter');
+
+		const selectMaxiTextDiv = await page.$('.maxi-text-block');
+		const selectMaxiTextP = await selectMaxiTextDiv.$(
+			'.block-editor-rich-text__editable'
+		);
+		await selectMaxiTextP.focus();
+
+		await pressKeyTimes('ArrowLeft', '6');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.$eval('.toolbar-popover-link-destroyer', button =>
+			button.click()
+		);
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
+
+		// Check frontend
+		const editorPage = page;
+		const previewPage = await openPreviewPage(editorPage);
+		await previewPage.waitForSelector('.entry-content');
+		const content = await previewPage.$eval(
+			'.entry-content',
+			contentWrapper => contentWrapper.innerHTML.trim()
+		);
+		expect(content).toMatchSnapshot();
+	});
+
+	it('Test Text Maxi toolbar Link in whole content, and then removing last part', async () => {
+		await insertBlock('Text Maxi');
+		await page.keyboard.type('Test Text Maxi');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.keyboard.type(linkExample);
+		await page.keyboard.press('Enter');
+
+		const selectMaxiTextDiv = await page.$('.maxi-text-block');
+		const selectMaxiTextP = await selectMaxiTextDiv.$(
+			'.block-editor-rich-text__editable'
+		);
+		await selectMaxiTextP.focus();
+
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await pressKeyWithModifier('shift', 'ArrowLeft');
+		await page.$eval('.toolbar-item__text-link', button => button.click());
+		await page.$eval('.toolbar-popover-link-destroyer', button =>
+			button.click()
+		);
+
+		expect(await getEditedPostContent()).toMatchSnapshot();
 	});
 
 	it('Test Text Maxi toolbar Link in part of the content', async () => {

--- a/src/blocks/text-maxi/utils.js
+++ b/src/blocks/text-maxi/utils.js
@@ -7,12 +7,11 @@ import { select, dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { fromListToText, fromTextToList } from '../../extensions/text/formats';
-
-/**
- * External dependencies
- */
-import { isEmpty, merge } from 'lodash';
+import {
+	fromListToText,
+	fromTextToList,
+	getFormatsOnMerge,
+} from '../../extensions/text/formats';
 
 const name = 'maxi-blocks/text-maxi';
 
@@ -48,14 +47,18 @@ export const onMerge = (props, forward) => {
 					: fromTextToList(nextBlockContent)
 				: nextBlockContent;
 
+			const { content: newContent, 'custom-formats': newCustomFormats } =
+				getFormatsOnMerge(
+					{ content, 'custom-formats': customFormats },
+					{
+						content: newNextBlockContent,
+						'custom-formats': nextBlockCustomFormats,
+					}
+				);
+
 			setAttributes({
-				content: content.concat(newNextBlockContent),
-				...(!isEmpty(nextBlockCustomFormats) && {
-					'custom-formats': merge(
-						customFormats,
-						nextBlockCustomFormats
-					),
-				}),
+				content: newContent,
+				'custom-formats': newCustomFormats,
 			});
 
 			removeBlock(nextBlockClientId);
@@ -75,16 +78,23 @@ export const onMerge = (props, forward) => {
 				'custom-formats': previousBlockCustomFormats,
 			} = previousBlockAttributes;
 
+			const { content: newContent, 'custom-formats': newCustomFormats } =
+				getFormatsOnMerge(
+					{
+						content: previousBlockContent,
+						'custom-formats': previousBlockCustomFormats,
+					},
+					{
+						content: attributes.isList
+							? fromListToText(content)
+							: content,
+						'custom-formats': customFormats,
+					}
+				);
+
 			updateBlockAttributes(previousBlockClientId, {
-				content: previousBlockContent.concat(
-					attributes.isList ? fromListToText(content) : content
-				),
-				...(!isEmpty(attributes['custom-formats']) && {
-					'custom-formats': merge(
-						attributes['custom-formats'],
-						previousBlockCustomFormats
-					),
-				}),
+				content: newContent,
+				'custom-formats': newCustomFormats,
 			});
 
 			removeBlock(clientId);

--- a/src/components/toolbar/components/text-link/index.js
+++ b/src/components/toolbar/components/text-link/index.js
@@ -41,12 +41,30 @@ import { toolbarLink } from '../../../../icons';
  * Link
  */
 const LinkContent = withFormatValue(props => {
-	const { onChange, isList, formatValue, textLevel, onClose } = props;
+	const { onChange, isList, formatValue, textLevel, onClose, blockStyle } =
+		props;
 
 	const formatName = 'maxi-blocks/text-link';
 
 	const { formatOptions } = useSelect(() => {
-		const formatOptions = getActiveFormat(formatValue, formatName);
+		const isWholeLink = isEqual(
+			getFormatPosition({
+				formatValue,
+				formatName: 'maxi-blocks/text-link',
+				formatClassName: null,
+				formatAttributes: null,
+			}),
+			[0, formatValue.formats.length - 1]
+		);
+		const end = formatValue.formats.length + 1;
+		const start =
+			isWholeLink && formatValue.start === formatValue.end
+				? 0
+				: formatValue.start;
+		const formatOptions = getActiveFormat(
+			{ ...formatValue, start, end },
+			formatName
+		);
 
 		return {
 			formatOptions,
@@ -133,11 +151,12 @@ const LinkContent = withFormatValue(props => {
 
 	const removeLinkFormatHandle = () => {
 		const obj = removeLinkFormat({
-			formatValue: getUpdatedFormatValue(formatValue, linkValue),
+			formatValue,
 			isList,
 			typography,
 			textLevel,
 			attributes: linkValue,
+			blockStyle,
 		});
 
 		onChange(obj);

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -347,6 +347,7 @@ const MaxiToolbar = memo(
 								linkSettings={linkSettings}
 								breakpoint={breakpoint}
 								textLevel={textLevel}
+								blockStyle={parentBlockStyle}
 							/>
 							<TextListOptions
 								blockName={name}

--- a/src/extensions/text/formats/getFormatsOnMerge.js
+++ b/src/extensions/text/formats/getFormatsOnMerge.js
@@ -6,11 +6,16 @@ const getFormatsOnMerge = (firstBlock, secondBlock) => {
 	const { content: secondContent, 'custom-formats': secondCustomFormats } =
 		secondBlock;
 
-	if (isEmpty(firstCustomFormats) || isEmpty(secondCustomFormats))
+	if (isEmpty(firstCustomFormats) || isEmpty(secondCustomFormats)) {
+		const newCustomFormats = merge(firstCustomFormats, secondCustomFormats);
+
 		return {
 			content: firstContent.concat(secondContent),
-			'custom-formats': merge(firstCustomFormats, secondCustomFormats),
+			...(!isEmpty(newCustomFormats) && {
+				'custom-formats': newCustomFormats,
+			}),
 		};
+	}
 
 	let newSecondContent = secondContent;
 
@@ -37,9 +42,13 @@ const getFormatsOnMerge = (firstBlock, secondBlock) => {
 		if (key !== newKey) delete secondCustomFormats[key];
 	});
 
+	const newCustomFormats = merge(firstCustomFormats, secondCustomFormats);
+
 	return {
 		content: firstContent.concat(newSecondContent),
-		'custom-formats': merge(firstCustomFormats, secondCustomFormats),
+		...(!isEmpty(newCustomFormats) && {
+			'custom-formats': newCustomFormats,
+		}),
 	};
 };
 

--- a/src/extensions/text/formats/getFormatsOnMerge.js
+++ b/src/extensions/text/formats/getFormatsOnMerge.js
@@ -1,0 +1,46 @@
+import { isEmpty, merge } from 'lodash';
+
+const getFormatsOnMerge = (firstBlock, secondBlock) => {
+	const { content: firstContent, 'custom-formats': firstCustomFormats } =
+		firstBlock;
+	const { content: secondContent, 'custom-formats': secondCustomFormats } =
+		secondBlock;
+
+	if (isEmpty(firstCustomFormats) || isEmpty(secondCustomFormats))
+		return {
+			content: firstContent.concat(secondContent),
+			'custom-formats': merge(firstCustomFormats, secondCustomFormats),
+		};
+
+	let newSecondContent = secondContent;
+
+	const getNewCustomFormatEntry = oldKey => {
+		if (!(oldKey in firstCustomFormats)) return oldKey;
+
+		const num = parseInt(
+			oldKey.replace('maxi-text-block__custom-format--', '')
+		);
+		const tempKey = oldKey.replace(num, num + 1);
+		const newKey = getNewCustomFormatEntry(tempKey);
+
+		return newKey;
+	};
+
+	Object.entries(secondCustomFormats).forEach(([key, val]) => {
+		const newKey = getNewCustomFormatEntry(key);
+
+		secondCustomFormats[newKey] = val;
+
+		const replaceRegExp = new RegExp(key, 'g');
+		newSecondContent = newSecondContent.replace(replaceRegExp, newKey);
+
+		if (key !== newKey) delete secondCustomFormats[key];
+	});
+
+	return {
+		content: firstContent.concat(newSecondContent),
+		'custom-formats': merge(firstCustomFormats, secondCustomFormats),
+	};
+};
+
+export default getFormatsOnMerge;

--- a/src/extensions/text/formats/index.js
+++ b/src/extensions/text/formats/index.js
@@ -5,6 +5,7 @@ export { default as formatActive } from './isFormatActive';
 export { default as generateFormatValue } from './generateFormatValue';
 export { default as getCustomFormatValue } from './getCustomFormatValue';
 export { default as getFormatPosition } from './getFormatPosition';
+export { default as getFormatsOnMerge } from './getFormatsOnMerge';
 export { default as getFormattedString } from './getFormattedString';
 export { default as getHasNativeFormat } from './getHasNativeFormat';
 export { default as removeLinkFormat } from './removeLinkFormat';

--- a/src/extensions/text/formats/removeLinkFormat.js
+++ b/src/extensions/text/formats/removeLinkFormat.js
@@ -10,6 +10,13 @@ import getFormatPosition from './getFormatPosition';
 import setFormat from './setFormat';
 
 /**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+import getCustomFormatValue from './getCustomFormatValue';
+import getFormattedString from './getFormattedString';
+
+/**
  * Removes the link and custom formats
  *
  * @param {Object} 	[$0]					Optional named arguments.
@@ -25,18 +32,129 @@ const removeLinkFormat = ({
 	isList,
 	textLevel,
 	attributes,
+	blockStyle,
 }) => {
-	const [newStart, newEnd] = getFormatPosition({
-		formatValue,
-		formatName: 'maxi-blocks/text-link',
-		formatClassName: null,
-		formatAttributes: attributes,
-	}) || [0, formatValue.formats.length];
+	const { start, end } = formatValue;
+	const formatLength = formatValue.formats.length;
+	let newStart = start;
+	let newEnd = end;
+	if (start === end) {
+		[newStart, newEnd] = getFormatPosition({
+			formatValue,
+			formatName: 'maxi-blocks/text-link',
+			formatClassName: null,
+			formatAttributes: attributes,
+		}) || [0, formatLength];
+	}
 
 	const removedLinkFormatValue = removeFormat(
 		{ ...formatValue, start: newStart, end: newEnd + 1 },
 		'maxi-blocks/text-link'
 	);
+
+	// Check if the removing is a partial part of the whole content
+	const isWholeLink = isEqual(
+		getFormatPosition({
+			formatValue,
+			formatName: 'maxi-blocks/text-link',
+			formatClassName: null,
+			formatAttributes: attributes,
+		}),
+		[0, formatLength - 1]
+	);
+	const hasUnderline =
+		getCustomFormatValue({
+			formatValue: { ...formatValue, start: 0, end: formatLength },
+			typography,
+			prop: 'text-decoration',
+			breakpoint: 'general',
+			blockStyle,
+			textLevel,
+		}) === 'underline';
+	const isPartialOfWholeLink =
+		isWholeLink &&
+		hasUnderline &&
+		newStart !== 0 &&
+		newEnd !== formatLength;
+	const isLastPartialOfWholeLink =
+		isWholeLink &&
+		hasUnderline &&
+		newStart !== 0 &&
+		newStart !== formatLength &&
+		newEnd === formatLength;
+
+	if (isPartialOfWholeLink || isLastPartialOfWholeLink) {
+		// Remove whole content underline
+		const cleanTypography = setFormat({
+			disableCustomFormats: true,
+			isList,
+			typography,
+			value: {
+				'text-decoration': '',
+			},
+			textLevel,
+		});
+		// Set first part
+		const { formatValue: firstPartFormatValue, ...firstPartTypography } =
+			start !== 0
+				? setFormat({
+						formatValue: {
+							...removedLinkFormatValue,
+							start: 0,
+							end: start,
+						},
+						isList,
+						typography: cleanTypography,
+						value: {
+							'text-decoration': 'underline',
+						},
+						textLevel,
+						returnFormatValue: true,
+				  })
+				: { formatvalue: removedLinkFormatValue, ...cleanTypography };
+		// Set second part
+		const secondPartTypography =
+			end !== formatLength
+				? setFormat({
+						formatValue: {
+							...firstPartFormatValue,
+							start: end,
+							end: formatLength,
+						},
+						isList,
+						typography: firstPartTypography,
+						value: {
+							'text-decoration': 'underline',
+						},
+						textLevel,
+				  })
+				: { ...firstPartTypography };
+
+		return { ...secondPartTypography };
+	}
+
+	if (
+		isWholeLink &&
+		hasUnderline &&
+		((newStart === 0 && newEnd === formatLength) || start === end)
+	) {
+		const removedLinkContent = getFormattedString({
+			formatValue: removedLinkFormatValue,
+			isList,
+		});
+		return {
+			...setFormat({
+				disableCustomFormats: true,
+				isList,
+				typography,
+				value: {
+					'text-decoration': '',
+				},
+				textLevel,
+			}),
+			content: removedLinkContent,
+		};
+	}
 
 	return setFormat({
 		formatValue: {

--- a/src/extensions/text/formats/test/__snapshots__/getFormatsOnMerge.js.snap
+++ b/src/extensions/text/formats/test/__snapshots__/getFormatsOnMerge.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getFormatsOnMerge Merges from top to bottom 1`] = `
+Object {
+  "content": "Testing <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--0\\">Text</span> MaxiWhen <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">merging</span>",
+  "custom-formats": Object {
+    "maxi-text-block__custom-format--0": Object {
+      "font-weight-general": 800,
+    },
+    "maxi-text-block__custom-format--1": Object {
+      "font-style-general": "italic",
+    },
+  },
+}
+`;

--- a/src/extensions/text/formats/test/__snapshots__/getFormatsOnMerge.js.snap
+++ b/src/extensions/text/formats/test/__snapshots__/getFormatsOnMerge.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getFormatsOnMerge Merges from top to bottom 1`] = `
+exports[`getFormatsOnMerge Merges two Text Maxi 1`] = `
 Object {
   "content": "Testing <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--0\\">Text</span> MaxiWhen <span class=\\"maxi-text-block--has-custom-format maxi-text-block__custom-format--1\\">merging</span>",
   "custom-formats": Object {

--- a/src/extensions/text/formats/test/getFormatsOnMerge.js
+++ b/src/extensions/text/formats/test/getFormatsOnMerge.js
@@ -1,0 +1,28 @@
+import getFormatsOnMerge from '../getFormatsOnMerge';
+
+describe('getFormatsOnMerge', () => {
+	it('Merges two Text Maxi', async () => {
+		const block1 = {
+			content:
+				'Testing <span class="maxi-text-block--has-custom-format maxi-text-block__custom-format--0">Text</span> Maxi',
+			'custom-formats': {
+				'maxi-text-block__custom-format--0': {
+					'font-weight-general': 800,
+				},
+			},
+		};
+		const block2 = {
+			content:
+				'When <span class="maxi-text-block--has-custom-format maxi-text-block__custom-format--0">merging</span>',
+			'custom-formats': {
+				'maxi-text-block__custom-format--0': {
+					'font-style-general': 'italic',
+				},
+			},
+		};
+
+		const result = getFormatsOnMerge(block1, block2);
+
+		expect(result).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
Fixes #1776 

Create some new cases for Text Maxi and its Custom Formats API:
1. When having 2 Text Maxi, each one with its Custom Formats, the classes can coincide, and onces merged creators can lose their styles. That has been fixed on this branch.
2. When having a whole content link on Text Maxi, if creators decide to remove the link from a part of the content, they lose the link and the styles get crazy (underline keeps, etc...). That has been fixed on this branch.

All cases are accompanied by their respective tests 😄 