### PR TITLE
Issue 1804

### DIFF
--- a/src/blocks/column-maxi/edit.js
+++ b/src/blocks/column-maxi/edit.js
@@ -111,9 +111,14 @@ class edit extends MaxiBlockComponent {
 								propsToAvoid={['resizableObject']}
 								{...this.props}
 							/>
-							<BlockResizer
+							<MaxiBlock
+								key={`maxi-column--${uniqueID}`}
+								ref={this.blockRef}
+								{...getMaxiBlockBlockAttributes(this.props)}
+								disableMotion
+								tagName={BlockResizer}
 								resizableObject={this.resizableObject}
-								className={classnames(
+								classes={classnames(
 									'maxi-block',
 									'maxi-block--backend',
 									'maxi-column-block__resizer',
@@ -150,29 +155,22 @@ class edit extends MaxiBlockComponent {
 									});
 								}}
 							>
-								<MaxiBlock
-									key={`maxi-column--${uniqueID}`}
-									ref={this.blockRef}
-									{...getMaxiBlockBlockAttributes(this.props)}
-									disableMotion
-								>
-									<InnerBlocks
-										allowedBlocks={ALLOWED_BLOCKS}
-										orientation='horizontal'
-										renderAppender={
-											!hasInnerBlocks
-												? () => (
-														<BlockPlaceholder
-															clientId={clientId}
-														/>
-												  )
-												: () => (
-														<InnerBlocks.ButtonBlockAppender />
-												  )
-										}
-									/>
-								</MaxiBlock>
-							</BlockResizer>
+								<InnerBlocks
+									allowedBlocks={ALLOWED_BLOCKS}
+									orientation='horizontal'
+									renderAppender={
+										!hasInnerBlocks
+											? () => (
+													<BlockPlaceholder
+														clientId={clientId}
+													/>
+											  )
+											: () => (
+													<InnerBlocks.ButtonBlockAppender />
+											  )
+									}
+								/>
+							</MaxiBlock>
 						</>
 					);
 				}}

--- a/src/blocks/column-maxi/editor.scss
+++ b/src/blocks/column-maxi/editor.scss
@@ -8,22 +8,15 @@
 	}
 }
 .edit-post-visual-editor {
-	.maxi-column-block__resizer {
-		div.maxi-column-block {
-			width: 100% !important;
-			max-width: 100% !important;
-			flex-basis: 100% !important;
-			margin: 0 !important;
-			height: 100%;
-			outline: 1px solid #81bdda !important;
-			vertical-align: top;
+	.maxi-column-block__resizer.maxi-column-block {
+		outline: 1px solid #81bdda !important;
+		vertical-align: top;
 
-			&.has-child-selected,
-			&.is-selected {
-				outline: 2px solid #ff4a17 !important;
-				&:focus {
-					box-shadow: none !important;
-				}
+		&.has-child-selected,
+		&.is-selected {
+			outline: 2px solid #ff4a17 !important;
+			&:focus {
+				box-shadow: none !important;
 			}
 		}
 	}

--- a/src/blocks/divider-maxi/divider-maxi.js
+++ b/src/blocks/divider-maxi/divider-maxi.js
@@ -9,7 +9,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType  } from '@wordpress/blocks';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Block dependencies
@@ -22,7 +22,6 @@ import save from './save';
  * Styles and icons
  */
 import './style.scss';
-import './editor.scss';
 import { dividerIcon } from '../../icons';
 
 /**

--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -63,7 +63,12 @@ class edit extends MaxiBlockComponent {
 		const classes = classnames(
 			lineOrientation === 'vertical'
 				? 'maxi-divider-block--vertical'
-				: 'maxi-divider-block--horizontal'
+				: 'maxi-divider-block--horizontal',
+			'maxi-divider-block__resizer',
+			`maxi-divider-block__resizer__${uniqueID}`,
+			{
+				'is-selected': isSelected,
+			}
 		);
 
 		const handleOnResizeStart = event => {
@@ -86,16 +91,13 @@ class edit extends MaxiBlockComponent {
 				ref={this.blockRef}
 				{...this.props}
 			/>,
-			<BlockResizer
-				key={uniqueID}
-				className={classnames(
-					'maxi-block__resizer',
-					'maxi-divider-block__resizer',
-					`maxi-divider-block__resizer__${uniqueID}`,
-					{
-						'is-selected': isSelected,
-					}
-				)}
+
+			<MaxiBlock
+				key={`maxi-divider--${uniqueID}`}
+				ref={this.blockRef}
+				classes={classes}
+				{...getMaxiBlockBlockAttributes(this.props)}
+				tagName={BlockResizer}
 				size={{
 					width: '100%',
 					height: `${attributes[`height-${deviceType}`]}${
@@ -115,17 +117,10 @@ class edit extends MaxiBlockComponent {
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}
 			>
-				<MaxiBlock
-					key={`maxi-divider--${uniqueID}`}
-					ref={this.blockRef}
-					classes={classes}
-					{...getMaxiBlockBlockAttributes(this.props)}
-				>
-					{attributes['divider-border-style'] !== 'none' && (
-						<hr className='maxi-divider-block__divider' />
-					)}
-				</MaxiBlock>
-			</BlockResizer>,
+				{attributes['divider-border-style'] !== 'none' && (
+					<hr className='maxi-divider-block__divider' />
+				)}
+			</MaxiBlock>,
 		];
 	}
 }

--- a/src/blocks/divider-maxi/editor.scss
+++ b/src/blocks/divider-maxi/editor.scss
@@ -1,7 +1,0 @@
-body.maxi-blocks--active div.maxi-block.maxi-divider-block {
-	height: 100% !important;
-
-	&__resizer {
-		min-height: 50px;
-	}
-}

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -1,6 +1,4 @@
 body.maxi-blocks--active .maxi-block__resizer {
-	margin: 0;
-
 	.maxi-resizable {
 		&__handle {
 			display: none;

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -8,11 +8,12 @@ import classnames from 'classnames';
  * Styles and icons
  */
 import './editor.scss';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Component
  */
-const BlockResizer = props => {
+const BlockResizer = forwardRef((props, ref) => {
 	const {
 		children,
 		className,
@@ -39,10 +40,17 @@ const BlockResizer = props => {
 		...props.enable,
 	};
 
+	const handleRef = newRef => {
+		if (newRef) {
+			if (resizableObject) resizableObject.current = newRef;
+			if (ref) ref.current = newRef.resizable;
+		}
+	};
+
 	return (
 		<Resizable
 			{...rest}
-			ref={resizableObject}
+			ref={handleRef}
 			className={classes}
 			enable={enable}
 			handleClasses={{
@@ -119,6 +127,6 @@ const BlockResizer = props => {
 			{children}
 		</Resizable>
 	);
-};
+});
 
 export default BlockResizer;


### PR DESCRIPTION
Fixes #1804 

To make Divider Maxi have a better structure and fix positioning problems, BlockResizer has been adapted to be able to fuse with MaxiBlock and eliminate that was creating issues with Style API between frontend and backend. So this fix has been applied to Divider Maxi and Column Maxi 👍 

To test:
1. Divider Maxi and Column Maxi respond as always
2. Divider Maxi and Column Maxi doesn't contain an independent and isolated `resizable` element (`<div class="maxi-block__resizer" [...]>`).