### PR TITLE
Issue 1946 - Background border over arrow

### DIFF
--- a/src/components/background-displayer/style.scss
+++ b/src/components/background-displayer/style.scss
@@ -8,6 +8,7 @@
 	overflow: hidden;
 	backface-visibility: hidden;
 	box-sizing: content-box;
+	z-index: -1;
 
 	&__layer {
 		position: absolute;


### PR DESCRIPTION
As backgroundDisplayer gets the border also to fix the issues we were facing with bg, it was overlapping the arrow:
<img width="323" alt="Captura de pantalla 2021-08-07 a las 14 11 17" src="https://user-images.githubusercontent.com/50477222/128601530-54ac8a1f-54b9-4149-a4db-665ebd5a39ea.png">

Doesn't fix the totality of #1946, so doesn't close the issue 👍 