### PR TITLE
Reset SC action

### DIFF
--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -171,6 +171,13 @@ if (!class_exists('MaxiBlocks_API')):
 					return current_user_can('edit_posts');
 				},
 			]);
+			register_rest_route($this->namespace, '/style-cards/reset', [
+				'methods' => 'GET',
+				'callback' => [$this, 'reset_maxi_blocks_style_cards'],
+				'permission_callback' => function () {
+					return current_user_can('edit_posts');
+				},
+			]);
 			register_rest_route($this->namespace, '/style-cards', [
 				'methods' => 'POST',
 				'callback' => [$this, 'set_maxi_blocks_current_style_cards'],
@@ -408,6 +415,33 @@ if (!class_exists('MaxiBlocks_API')):
 				$style_cards = $wpdb->get_var($query);
 				return $style_cards;
 			}
+		}
+
+		public function reset_maxi_blocks_style_cards() {
+			global $wpdb;
+			$table_name = $wpdb->prefix . 'maxi_blocks_general'; // table name
+
+			if (class_exists('MaxiBlocks_StyleCards')) {
+				$defaultStyleCard = MaxiBlocks_StyleCards::getDefaultStyleCard();
+			} else {
+				return false;
+			} // Should return an error
+
+			$response = $wpdb->replace($table_name, [
+				'id' => 'style_cards_current',
+				'object' => $defaultStyleCard,
+			]);
+
+			// Retrieve information
+			$response_code = wp_remote_retrieve_response_code($response);
+			$response_message = wp_remote_retrieve_response_message($response);
+			$response_body = wp_remote_retrieve_body($response);
+
+			return new WP_REST_Response([
+				'status' => $response_code,
+				'response' => $response_message,
+				'body_response' => $response_body,
+			]);
 		}
 
 		public function set_maxi_blocks_current_style_cards($request) {

--- a/src/extensions/style-cards/store/actions.js
+++ b/src/extensions/style-cards/store/actions.js
@@ -46,3 +46,9 @@ export function saveSCStyles(isUpdate) {
 		isUpdate,
 	};
 }
+
+export function resetSC() {
+	return {
+		type: 'RESET_STYLE_CARDS',
+	};
+}

--- a/src/extensions/style-cards/store/controls.js
+++ b/src/extensions/style-cards/store/controls.js
@@ -41,6 +41,16 @@ const controls = {
 			},
 		});
 	},
+	async RESET_STYLE_CARDS() {
+		await apiFetch({
+			path: '/maxi-blocks/v1.0/style-cards/reset',
+		}).then(() =>
+			// eslint-disable-next-line no-console
+			console.log(
+				"IMPORTANT: the changes won't have any effect until the page is refreshed"
+			)
+		);
+	},
 };
 
 export default controls;

--- a/src/extensions/style-cards/store/reducer.js
+++ b/src/extensions/style-cards/store/reducer.js
@@ -80,6 +80,12 @@ function reducer(state = { styleCards: {}, savedStyleCards: {} }, action) {
 			return {
 				...state,
 			};
+		case 'RESET_STYLE_CARDS':
+			controls.RESET_STYLE_CARDS();
+
+			return {
+				...state,
+			};
 		default:
 			return state;
 	}


### PR DESCRIPTION
Creates SC reset action on SC store. To test it:
1. Modify SC, then save/apply
2. Refresh and check the changes are kept
3. On console: `wp.data.dispatch('maxiBlocks/style-cards').resetSC()`
4. Refresh and check if SC are default

This feature is just for developing and will be removed with stable 👍 