### PR TITLE
 Add transition duration control for a button

### DIFF
--- a/src/blocks/button-maxi/attributes.js
+++ b/src/blocks/button-maxi/attributes.js
@@ -120,6 +120,7 @@ const attributes = {
 	...attributesData.entrance,
 	...attributesData.transform,
 	...attributesData.zIndex,
+	...attributesData.transitionDuration,
 };
 
 export default attributes;

--- a/src/blocks/button-maxi/inspector.js
+++ b/src/blocks/button-maxi/inspector.js
@@ -33,6 +33,7 @@ import {
 	TransformControl,
 	TypographyControl,
 	ZIndexControl,
+	TransitionControl,
 } from '../../components';
 import * as defaultPresets from './defaults';
 import {
@@ -1102,6 +1103,24 @@ const Inspector = memo(
 														{...getGroupAttributes(
 															attributes,
 															'zIndex'
+														)}
+														onChange={obj =>
+															setAttributes(obj)
+														}
+														breakpoint={deviceType}
+													/>
+												),
+											},
+											{
+												label: __(
+													'Hover Transition',
+													'maxi-blocks'
+												),
+												content: (
+													<TransitionControl
+														{...getGroupAttributes(
+															attributes,
+															'transitionDuration'
 														)}
 														onChange={obj =>
 															setAttributes(obj)

--- a/src/blocks/button-maxi/styles.js
+++ b/src/blocks/button-maxi/styles.js
@@ -12,6 +12,7 @@ import {
 	getPositionStyles,
 	getSizeStyles,
 	getTransformStyles,
+	getTransitionStyles,
 	getTypographyStyles,
 	getZIndexStyles,
 } from '../../extensions/styles/helpers';
@@ -68,6 +69,9 @@ const getNormalObject = props => {
 		}),
 		zIndex: getZIndexStyles({
 			...getGroupAttributes(props, 'zIndex'),
+		}),
+		transitionDuration: getTransitionStyles({
+			...getGroupAttributes(props, 'transitionDuration'),
 		}),
 		position: getPositionStyles({
 			...getGroupAttributes(props, 'position'),
@@ -158,6 +162,9 @@ const getHoverContentObject = props => {
 			isHover: true,
 			parentBlockStyle: props.parentBlockStyle,
 			textLevel: 'button',
+		}),
+		transitionDuration: getTransitionStyles({
+			...getGroupAttributes(props, 'transitionDuration'),
 		}),
 	};
 

--- a/src/blocks/text-maxi/attributes.js
+++ b/src/blocks/text-maxi/attributes.js
@@ -80,6 +80,7 @@ const attributes = {
 	...attributesData.typography,
 	...attributesData.typographyHover,
 	...attributesData.zIndex,
+	...attributesData.transitionDuration,
 };
 
 export default attributes;

--- a/src/blocks/text-maxi/inspector.js
+++ b/src/blocks/text-maxi/inspector.js
@@ -34,6 +34,7 @@ import {
 	TransformControl,
 	TypographyControl,
 	ZIndexControl,
+	TransitionControl,
 } from '../../components';
 import {
 	getGroupAttributes,
@@ -1089,6 +1090,24 @@ const Inspector = memo(
 																	val,
 															})
 														}
+													/>
+												),
+											},
+											{
+												label: __(
+													'Link Hover Transition',
+													'maxi-blocks'
+												),
+												content: (
+													<TransitionControl
+														{...getGroupAttributes(
+															attributes,
+															'transitionDuration'
+														)}
+														onChange={obj =>
+															setAttributes(obj)
+														}
+														breakpoint={deviceType}
 													/>
 												),
 											},

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -11,6 +11,7 @@ import {
 	getBackgroundStyles,
 	getMarginPaddingStyles,
 	getTypographyStyles,
+	getTransitionStyles,
 	getCustomFormatsStyles,
 	getAlignmentTextStyles,
 	getLinkStyles,
@@ -95,6 +96,16 @@ const getHoverObject = props => {
 	return response;
 };
 
+const getLinkObject = props => {
+	const response = {
+		transitionDuration: getTransitionStyles({
+			...getGroupAttributes(props, 'transitionDuration'),
+		}),
+	};
+
+	return response;
+};
+
 const getTypographyObject = (props, isList = false) => {
 	const response = {
 		typography: getTypographyStyles({
@@ -142,6 +153,8 @@ const getStyles = props => {
 	return {
 		[uniqueID]: stylesCleaner({
 			'': getNormalObject(props),
+			' .maxi-text-block--link, .maxi-text-block--link span':
+				getLinkObject(props),
 			':hover': getHoverObject(props),
 			...(!isList && {
 				[` ${element}.maxi-text-block__content`]: getTypographyObject(

--- a/src/components/background-control/index.js
+++ b/src/components/background-control/index.js
@@ -134,22 +134,24 @@ const BackgroundControl = props => {
 				/>
 			)}
 			{!layersStatus && getOptions().length > 1 && (
-				<FancyRadioControl
-					label={__('Background', 'maxi-blocks')}
-					fullWidthMode
-					selected={backgroundActiveMedia || ''}
-					options={getOptions()}
-					optionType='string'
-					onChange={val =>
-						onChange({
-							[getAttributeKey(
-								'background-active-media',
-								isHover,
-								prefix
-							)]: val,
-						})
-					}
-				/>
+				<>
+					<FancyRadioControl
+						label={__('Background', 'maxi-blocks')}
+						fullWidthMode
+						selected={backgroundActiveMedia || ''}
+						options={getOptions()}
+						optionType='string'
+						onChange={val =>
+							onChange({
+								[getAttributeKey(
+									'background-active-media',
+									isHover,
+									prefix
+								)]: val,
+							})
+						}
+					/>
+				</>
 			)}
 			{!layersStatus && (
 				<>

--- a/src/components/background-control/index.js
+++ b/src/components/background-control/index.js
@@ -134,24 +134,22 @@ const BackgroundControl = props => {
 				/>
 			)}
 			{!layersStatus && getOptions().length > 1 && (
-				<>
-					<FancyRadioControl
-						label={__('Background', 'maxi-blocks')}
-						fullWidthMode
-						selected={backgroundActiveMedia || ''}
-						options={getOptions()}
-						optionType='string'
-						onChange={val =>
-							onChange({
-								[getAttributeKey(
-									'background-active-media',
-									isHover,
-									prefix
-								)]: val,
-							})
-						}
-					/>
-				</>
+				<FancyRadioControl
+					label={__('Background', 'maxi-blocks')}
+					fullWidthMode
+					selected={backgroundActiveMedia || ''}
+					options={getOptions()}
+					optionType='string'
+					onChange={val =>
+						onChange({
+							[getAttributeKey(
+								'background-active-media',
+								isHover,
+								prefix
+							)]: val,
+						})
+					}
+				/>
 			)}
 			{!layersStatus && (
 				<>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -65,6 +65,7 @@ export { default as TextControl } from './text-control';
 export { default as TextShadowControl } from './text-shadow-control';
 export { default as Toolbar } from './toolbar';
 export { default as TransformControl } from './transform-control';
+export { default as TransitionControl } from './transition-control';
 export { default as TypographyControl } from './typography-control';
 export { default as ZIndexControl } from './zindex-control';
 export { default as ImageURL } from './image-url';

--- a/src/components/toolbar/components/copy-paste/index.js
+++ b/src/components/toolbar/components/copy-paste/index.js
@@ -66,6 +66,7 @@ const ATTRIBUTES = [
 	'transform',
 	'typography',
 	'typographyHover',
+	'transitionDuration',
 	'zIndex',
 ];
 const WRAPPER_BLOCKS = [

--- a/src/components/transition-control/index.js
+++ b/src/components/transition-control/index.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AdvancedNumberControl from '../advanced-number-control';
+import {
+	getLastBreakpointAttribute,
+	getDefaultAttribute,
+} from '../../extensions/styles';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Component
+ */
+const TransitionControl = props => {
+	const { onChange, className, breakpoint } = props;
+
+	const classes = classnames('maxi-transition-control', className);
+
+	return (
+		<AdvancedNumberControl
+			label={__('Transition Duration', 'maxi-blocks')}
+			className={classes}
+			defaultValue={getDefaultAttribute(
+				`transition-duration-${breakpoint}`
+			)}
+			value={getLastBreakpointAttribute(
+				'transition-duration',
+				breakpoint,
+				props
+			)}
+			onChangeValue={val => {
+				onChange({
+					[`transition-duration-${breakpoint}`]:
+						val !== undefined && val !== '' ? val : '',
+				});
+			}}
+			min={0}
+			max={5}
+			step={0.1}
+			initial={0.3}
+			onReset={() =>
+				onChange({
+					[`transition-duration-${breakpoint}`]: getDefaultAttribute(
+						`transition-duration-${breakpoint}`
+					),
+				})
+			}
+			initialPosition={getDefaultAttribute(
+				`transition-duration-${breakpoint}`
+			)}
+		/>
+	);
+};
+
+export default TransitionControl;

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -9,22 +9,18 @@
 	margin-right: calc(-100vw / 2 + 500px / 2);
 }
 .maxi-block {
-    position: relative;
-
+	position: relative;
 
 	&[data-align='full'] {
 		width: 100% !important;
 		max-width: 100% !important;
 	}
-	.maxi-text-block--link span {
-		transition: color .3s ease;
-	}
 }
 
 .maxi-link-wrapper {
-    display: block;
+	display: block;
 
-	.maxi-text-block__content{
-		transition: color .3s ease;
+	.maxi-text-block__content {
+		transition: color 0.3s ease;
 	}
 }

--- a/src/extensions/styles/defaults/index.js
+++ b/src/extensions/styles/defaults/index.js
@@ -24,6 +24,7 @@ export { default as textAlignment } from './textAlignment';
 export { default as transform } from './transform';
 export { default as typographyHover } from './typographyHover';
 export { default as zIndex } from './zIndex';
+export { default as transitionDuration } from './transition';
 export * from './background';
 export * from './backgroundHover';
 export * from './border';

--- a/src/extensions/styles/defaults/transition.js
+++ b/src/extensions/styles/defaults/transition.js
@@ -1,0 +1,26 @@
+const transitionDuration = {
+	'transition-duration-general': {
+		type: 'number',
+		default: 0.3,
+	},
+	'transition-duration-xxl': {
+		type: 'number',
+	},
+	'transition-duration-xl': {
+		type: 'number',
+	},
+	'transition-duration-l': {
+		type: 'number',
+	},
+	'transition-duration-m': {
+		type: 'number',
+	},
+	'transition-duration-s': {
+		type: 'number',
+	},
+	'transition-duration-xs': {
+		type: 'number',
+	},
+};
+
+export default transitionDuration;

--- a/src/extensions/styles/helpers/getTransitionStyles.js
+++ b/src/extensions/styles/helpers/getTransitionStyles.js
@@ -1,0 +1,26 @@
+/**
+ * General
+ */
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+/**
+ * Generates size styles object
+ *
+ * @param {Object} obj Block size properties
+ */
+const getTransitionStyles = obj => {
+	const response = {};
+
+	breakpoints.forEach(breakpoint => {
+		if (obj[`transition-duration-${breakpoint}`])
+			response[breakpoint] = {
+				transition: `all ${
+					obj[`transition-duration-${breakpoint}`]
+				}s ease`,
+			};
+	});
+
+	return response;
+};
+
+export default getTransitionStyles;

--- a/src/extensions/styles/helpers/index.js
+++ b/src/extensions/styles/helpers/index.js
@@ -22,6 +22,7 @@ export { default as getShapeStyles } from './getShapeStyles';
 export { default as getSizeStyles } from './getSizeStyles';
 export { default as getSvgStyles } from './getSvgStyles';
 export { default as getTransformStyles } from './getTransformStyles';
+export { default as getTransitionStyles } from './getTransitionStyles';
 export { default as getTypographyStyles } from './getTypographyStyles';
 export { default as getZIndexStyles } from './getZIndexStyles';
 export * from './getBackgroundStyles';


### PR DESCRIPTION
Adds a hover transition duration control for a button, part of the https://github.com/yeahcan/maxi-blocks/issues/2043 

See the Sidebar - Advanced - Hover Transition.

~~Now, an important question before I proceed with adding the same option for the links inside text blocks~~

~~Do we need to add "Advanced - Hover Transition" to all blocks? We have a lot of blocks that use different bg, border, or text color on hover, but this option will collide with any fancy hover animation we add later. So I'm not really sure we need it aside of the button and links, at least for now.~~

From Kyra: "button and links for now is enough"

Note: we will add Speed Curve option in paid Maxi version. Free one has the duration option only.