### PR TITLE
Font weight on frontend

### DIFF
--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -54,6 +54,8 @@ if (!class_exists('MaxiBlocks_API')):
 			$default_array = [
 				'_maxi_blocks_styles' => '',
 				'_maxi_blocks_styles_preview' => '',
+				'_maxi_blocks_fonts' => '',
+				'_maxi_blocks_fonts_preview' => '',
 			];
 			if (!get_option("mb_post_api_$id")) {
 				add_option("mb_post_api_$id", $default_array);
@@ -109,6 +111,30 @@ if (!class_exists('MaxiBlocks_API')):
 			register_rest_route($this->namespace, '/post', [
 				'methods' => 'POST',
 				'callback' => [$this, 'post_maxi_blocks_post'],
+				'args' => [
+					'id' => [
+						'validate_callback' => function ($param) {
+							return is_numeric($param);
+						},
+					],
+					'meta' => [
+						'validate_callback' => function ($param) {
+							return is_string($param);
+						},
+					],
+					'update' => [
+						'validate_callback' => function ($param) {
+							return is_bool($param);
+						},
+					],
+				],
+				'permission_callback' => function () {
+					return current_user_can('edit_posts');
+				},
+			]);
+			register_rest_route($this->namespace, '/post/fonts', [
+				'methods' => 'POST',
+				'callback' => [$this, 'post_maxi_blocks_fonts'],
 				'args' => [
 					'id' => [
 						'validate_callback' => function ($param) {
@@ -303,9 +329,11 @@ if (!class_exists('MaxiBlocks_API')):
 		 * @return $posts JSON feed of returned objects
 		 */
 		public function get_maxi_blocks_post($data) {
-			$this->mb_register_post_options($data['id']);
+			$id = $data['id'];
 
-			$response = get_option("mb_post_api_{$data['id']}")[
+			$this->mb_register_post_options($id);
+
+			$response = get_option("mb_post_api_{$id}")[
 				'_maxi_blocks_styles_preview'
 			];
 			if (!$response) {
@@ -319,22 +347,48 @@ if (!class_exists('MaxiBlocks_API')):
 		 * Post the posts
 		 */
 		public function post_maxi_blocks_post($data) {
-			$this->mb_register_post_options($data['id']);
+			$id = $data['id'];
+			$meta = json_decode($data['meta'], true);
+			$styles = $meta['styles'];
 
-			$styles = get_option("mb_post_api_{$data['id']}");
+			$this->mb_register_post_options($id);
+
+			$post = get_option("mb_post_api_{$id}");
 
 			if ($data['update']) {
-				$styles = [
-					'_maxi_blocks_styles' => $data['meta'],
-					'_maxi_blocks_styles_preview' => $data['meta'],
-				];
+				$post['_maxi_blocks_styles'] = $styles;
+				$post['_maxi_blocks_styles_preview'] = $styles;
 			} else {
-				$styles['_maxi_blocks_styles_preview'] = $data['meta'];
+				$post['_maxi_blocks_styles_preview'] = $styles;
 			}
 
-			update_option("mb_post_api_{$data['id']}", $styles);
+			update_option("mb_post_api_{$id}", $post);
 
-			return $styles;
+			return $post;
+		}
+
+		/**
+		 * Post the fonts of the post
+		 */
+		public function post_maxi_blocks_fonts($data) {
+			$id = $data['id'];
+			$meta = json_decode($data['meta'], true);
+			$fonts = $meta['fonts'];
+
+			$this->mb_register_post_options($id);
+
+			$post = get_option("mb_post_api_{$id}");
+
+			if ($data['update']) {
+				$post['_maxi_blocks_fonts'] = $fonts;
+				$post['_maxi_blocks_fonts_preview'] = $fonts;
+			} else {
+				$post['_maxi_blocks_fonts_preview'] = $fonts;
+			}
+
+			update_option("mb_post_api_{$id}", $post);
+
+			return $post;
 		}
 
 		/**

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -27,14 +27,18 @@ class MaxiBlocks_Styles {
 	 * Enqueuing styles
 	 */
 	public function enqueue_styles() {
-		$styles = $this->getStyles();
+		$post_content = $this->getPostMeta();
+		$styles = $this->getStyles($post_content);
+		$fonts = $this->getFonts($post_content);
+
 		if ($styles) {
 			// Inline styles
 			wp_register_style('maxi-blocks', false);
 			wp_enqueue_style('maxi-blocks');
 			wp_add_inline_style('maxi-blocks', $styles);
-
-			$this->enqueue_fonts($styles);
+		}
+		if ($fonts) {
+			$this->enqueue_fonts($fonts);
 		}
 
 		wp_localize_script('maxi-front-scripts-js', 'maxi_custom_data', [
@@ -43,30 +47,54 @@ class MaxiBlocks_Styles {
 	}
 
 	/**
-	 * Gets meta content
+	 * Gets post meta content
 	 */
-	public function getStyles() {
+	public function getPostMeta() {
 		global $post;
+
 		if (!$post || !isset($post->ID)) {
 			return false;
 		}
 
-		$styles = get_option("mb_post_api_{$post->ID}");
+		$post_content = get_option("mb_post_api_{$post->ID}");
 
-		if (!$styles) {
+		if (!$post_content) {
 			return false;
 		}
 
+		return $post_content;
+	}
+
+	/**
+	 * Gets post styles content
+	 */
+	public function getStyles($post_content) {
 		$style =
 			is_preview() || is_admin()
-				? $styles['_maxi_blocks_styles_preview']
-				: $styles['_maxi_blocks_styles'];
+				? $post_content['_maxi_blocks_styles_preview']
+				: $post_content['_maxi_blocks_styles'];
 
 		if (!$style || empty($style)) {
 			return false;
 		}
 
 		return $style;
+	}
+
+	/**
+	 * Gets post styles content
+	 */
+	public function getFonts($post_content) {
+		$fonts =
+			is_preview() || is_admin()
+				? $post_content['_maxi_blocks_fonts_preview']
+				: $post_content['_maxi_blocks_fonts'];
+
+		if (!$fonts || empty($fonts)) {
+			return false;
+		}
+
+		return $fonts;
 	}
 
 	/**
@@ -93,18 +121,15 @@ class MaxiBlocks_Styles {
 	 * @return object   Font name with font options
 	 */
 
-	public function enqueue_fonts($styles) {
-		preg_match_all('/font-family:(\w+);/', $styles, $fonts);
-		$fonts = array_unique($fonts[1]);
-
+	public function enqueue_fonts($fonts) {
 		if (empty($fonts)) {
 			return;
 		}
 
 		foreach ($fonts as $font) {
 			wp_enqueue_style(
-				"{$font}",
-				"https://fonts.googleapis.com/css2?family={$font}",
+				$font,
+				"https://fonts.googleapis.com/css2?family=$font:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900",
 			);
 		}
 	}

--- a/src/editor/saver/index.js
+++ b/src/editor/saver/index.js
@@ -8,30 +8,38 @@ import { useDispatch, useSelect } from '@wordpress/data';
  * Component
  */
 const BlockStylesSaver = () => {
-	const { isSaving, isPreviewing } = useSelect(select => {
-		const { isSavingPost, isPreviewingPost } = select('core/editor');
+	const { isSaving, isPreviewing, isDraft } = useSelect(select => {
+		const { isSavingPost, isPreviewingPost, getCurrentPostAttribute } =
+			select('core/editor');
 
 		const isSaving = isSavingPost();
 		const isPreviewing = isPreviewingPost();
+		const isDraft = getCurrentPostAttribute('status') === 'draft';
 
 		return {
 			isSaving,
 			isPreviewing,
+			isDraft,
 		};
 	});
 
 	const { saveStyles } = useDispatch('maxiBlocks/styles');
+	const { saveFonts } = useDispatch('maxiBlocks/text');
 	const { saveCustomData } = useDispatch('maxiBlocks/customData');
 	const { saveSCStyles } = useDispatch('maxiBlocks/style-cards');
 
 	useEffect(() => {
-		if (isSaving && !isPreviewing) {
-			saveStyles(true);
-			saveCustomData(true);
-		} else if (isSaving && isPreviewing) {
-			saveStyles(false);
-			saveCustomData(true);
-			saveSCStyles(false);
+		if (isSaving) {
+			if (!isPreviewing && !isDraft) {
+				saveStyles(true);
+				saveFonts(true);
+				saveCustomData(true);
+			} else if (isPreviewing || isDraft) {
+				saveStyles(false);
+				saveFonts(false);
+				saveCustomData(true);
+				saveSCStyles(false);
+			}
 		}
 	});
 

--- a/src/extensions/text/fonts/loadFonts.js
+++ b/src/extensions/text/fonts/loadFonts.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { select } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 
 /**
  * Prepares the styles to be ready for JS FontFace API
@@ -34,7 +34,8 @@ const getFontStyle = variant => {
  * @param {string} font Name of the selected font
  */
 const loadFonts = font => {
-	// !document.fonts.check(`12px ${font})` with this condition Font Selector have a problem in Firefox(Windows) so we should find a solution for it in future now with removing it the problem will fix temporary :)
+	// !document.fonts.check(`12px ${font})` with this condition Font Selector have a problem in Firefox(Windows)
+	// so we should find a solution for it in future now with removing it the problem will fix temporary :)
 	if (font && document.fonts /* && !document.fonts.check(`12px ${font}`) */) {
 		const { files } = select('maxiBlocks/text').getFont(font);
 
@@ -47,6 +48,8 @@ const loadFonts = font => {
 				console.error(__(`Font hasn't been able to download: ${err}`));
 			});
 		});
+
+		dispatch('maxiBlocks/text').updateFonts(font);
 	}
 };
 

--- a/src/extensions/text/store/actions.js
+++ b/src/extensions/text/store/actions.js
@@ -19,5 +19,17 @@ const actions = {
 			clientId: clientId || getSelectedBlockClientId(),
 		};
 	},
+	updateFonts(fonts) {
+		return {
+			type: 'UPDATE_FONTS',
+			fonts,
+		};
+	},
+	saveFonts(isUpdate) {
+		return {
+			type: 'SAVE_FONTS',
+			isUpdate,
+		};
+	},
 };
 export default actions;

--- a/src/extensions/text/store/controls.js
+++ b/src/extensions/text/store/controls.js
@@ -5,25 +5,19 @@ import apiFetch from '@wordpress/api-fetch';
 import { select } from '@wordpress/data';
 
 /**
- * Internal dependencies
- */
-import frontendStyleGenerator from '../frontendStyleGenerator';
-
-/**
  * Controls
  */
 const controls = {
-	async SAVE_STYLES({ isUpdate, styles }) {
+	async SAVE_FONTS({ isUpdate, fonts }) {
 		const id = select('core/editor').getCurrentPostId();
-		const parsedStyles = frontendStyleGenerator(styles);
 
 		await apiFetch({
-			path: '/maxi-blocks/v1.0/post',
+			path: '/maxi-blocks/v1.0/post/fonts',
 			method: 'POST',
 			data: {
 				id,
 				meta: JSON.stringify({
-					styles: parsedStyles,
+					fonts,
 				}),
 				update: isUpdate,
 			},

--- a/src/extensions/text/store/reducer.js
+++ b/src/extensions/text/store/reducer.js
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
+import controls from './controls';
 import fonts from '../fonts/fonts';
+
+/**
+ * External dependencies
+ */
+import { sortedUniq } from 'lodash';
 
 /**
  * Reducer managing the styles
@@ -11,7 +17,10 @@ import fonts from '../fonts/fonts';
  *
  * @return {Object} Updated state.
  */
-function reducer(state = { fonts: { ...fonts }, formatValues: {} }, action) {
+function reducer(
+	state = { fonts: { ...fonts }, formatValues: {}, postFonts: [] },
+	action
+) {
 	switch (action.type) {
 		case 'RECEIVE_FONTS':
 			return {
@@ -32,6 +41,18 @@ function reducer(state = { fonts: { ...fonts }, formatValues: {} }, action) {
 			};
 		case 'REMOVE_FORMAT_VALUE':
 			delete state.formatValues[action.clientId];
+			return state;
+		case 'UPDATE_FONTS':
+			return {
+				...state,
+				postFonts: sortedUniq([...state.postFonts, ...action.fonts]),
+			};
+		case 'SAVE_FONTS':
+			controls.SAVE_FONTS({
+				isUpdate: action.isUpdate,
+				fonts: state.postFonts,
+			});
+
 			return state;
 		default:
 			return state;


### PR DESCRIPTION
This PR is not linked to any issue as hasn't been create. Fixes the fact that in frontend the `font-weight` wasn't working as expected as the fonts weren't correctly enqueued. That was making, for example, that all the headings didn't show the default `font-weight: 500`. 

This implementation is not optimized. In terms of SEO is horrible as is enqueuing all the font-weight and font-styles, but is working good as for the moment what we need is to prepare the Library. Will be improved when we'll start with the optimization 👍 

How to test?
Test in preview and in published post if the `font-weight` on frontend changes and also with different `font-styles`