### PR TITLE
Fix svg alignment

### DIFF
--- a/src/blocks/svg-icon-maxi/style.scss
+++ b/src/blocks/svg-icon-maxi/style.scss
@@ -8,7 +8,6 @@ body.maxi-blocks--active .maxi-svg-icon-block {
 	}
 
 	.maxi-svg-icon-block__icon {
-		width: 100%;
 		height: 100%;
 	}
 


### PR DESCRIPTION
fixes #2104 

(can anybody remember why did we add width 100% to the .maxi-svg-icon-block__icon? )