### PR TITLE
Refactor MaxiModal

### DIFF
--- a/src/blocks/cloud-maxi/edit.js
+++ b/src/blocks/cloud-maxi/edit.js
@@ -48,6 +48,7 @@ export default class Edit extends Component {
 							type='patterns'
 							openFirstTime={openFirstTime}
 							onOpen={obj => setAttributes(obj)}
+							onSelect={obj => setAttributes(obj)}
 							{...this.props}
 						/>
 					</Placeholder>

--- a/src/blocks/cloud-maxi/edit.js
+++ b/src/blocks/cloud-maxi/edit.js
@@ -49,6 +49,7 @@ export default class Edit extends Component {
 							openFirstTime={openFirstTime}
 							onOpen={obj => setAttributes(obj)}
 							onSelect={obj => setAttributes(obj)}
+							onRemove={obj => setAttributes(obj)}
 							{...this.props}
 						/>
 					</Placeholder>

--- a/src/blocks/cloud-maxi/edit.js
+++ b/src/blocks/cloud-maxi/edit.js
@@ -22,7 +22,7 @@ import { isEmpty } from 'lodash';
 
 export default class Edit extends Component {
 	render() {
-		const { attributes, clientId } = this.props;
+		const { attributes, clientId, setAttributes } = this.props;
 
 		const { content, openFirstTime } = attributes;
 
@@ -47,6 +47,8 @@ export default class Edit extends Component {
 							clientId={clientId}
 							type='patterns'
 							openFirstTime={openFirstTime}
+							onOpen={obj => setAttributes(obj)}
+							{...this.props}
 						/>
 					</Placeholder>
 				)}

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -80,6 +80,7 @@ const Inspector = memo(
 			imageRatio,
 			isImageUrl,
 			parentBlockStyle,
+			SVGElement,
 		} = attributes;
 		const { wpAlt, titleAlt } = altOptions || {};
 
@@ -1097,7 +1098,7 @@ const Inspector = memo(
 														onRemove={obj => {
 															setAttributes(obj);
 														}}
-														{...attributes}
+														icon={SVGElement}
 													/>
 												),
 											},

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -1089,7 +1089,13 @@ const Inspector = memo(
 													'maxi-blocks'
 												),
 												content: (
-													<MaxiModal type='image-shape' />
+													<MaxiModal
+														type='image-shape'
+														onSelect={obj => {
+															setAttributes(obj);
+														}}
+														{...attributes}
+													/>
 												),
 											},
 											{

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -1094,6 +1094,9 @@ const Inspector = memo(
 														onSelect={obj => {
 															setAttributes(obj);
 														}}
+														onRemove={obj => {
+															setAttributes(obj);
+														}}
 														{...attributes}
 													/>
 												),

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -165,7 +165,6 @@ class edit extends MaxiBlockComponent {
 						onOpen={obj => setAttributes(obj)}
 						onSelect={obj => setAttributes(obj)}
 						onRemove={obj => setAttributes(obj)}
-						{...this.props}
 					/>
 					{!isEmptyContent && (
 						<BlockResizer

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -162,6 +162,9 @@ class edit extends MaxiBlockComponent {
 						empty={isEmptyContent}
 						style={parentBlockStyle}
 						openFirstTime={openFirstTime}
+						onOpen={obj => setAttributes(obj)}
+						onSelect={obj => setAttributes(obj)}
+						{...this.props}
 					/>
 					{!isEmptyContent && (
 						<BlockResizer

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -164,6 +164,7 @@ class edit extends MaxiBlockComponent {
 						openFirstTime={openFirstTime}
 						onOpen={obj => setAttributes(obj)}
 						onSelect={obj => setAttributes(obj)}
+						onRemove={obj => setAttributes(obj)}
 						{...this.props}
 					/>
 					{!isEmptyContent && (

--- a/src/components/background-control/svgLayer.js
+++ b/src/components/background-control/svgLayer.js
@@ -59,6 +59,7 @@ const SVGLayer = props => {
 								layerId={layerId}
 								style={getBlockStyle(clientId)}
 								onSelect={obj => onChange(obj)}
+								onRemove={obj => onChange(obj)}
 								{...SVGOptions}
 							/>
 						),

--- a/src/components/background-control/svgLayer.js
+++ b/src/components/background-control/svgLayer.js
@@ -58,6 +58,8 @@ const SVGLayer = props => {
 								type='bg-shape'
 								layerId={layerId}
 								style={getBlockStyle(clientId)}
+								onSelect={obj => onChange(obj)}
+								{...SVGOptions}
 							/>
 						),
 					},

--- a/src/components/background-control/svgLayer.js
+++ b/src/components/background-control/svgLayer.js
@@ -56,11 +56,26 @@ const SVGLayer = props => {
 						content: (
 							<MaxiModal
 								type='bg-shape'
-								layerId={layerId}
 								style={getBlockStyle(clientId)}
 								onSelect={obj => onChange(obj)}
-								onRemove={obj => onChange(obj)}
-								{...SVGOptions}
+								onRemove={obj => {
+									if (layerId) {
+										delete SVGOptions[
+											'background-svg-SVGElement'
+										];
+										delete SVGOptions[
+											'background-svg-SVGMediaID'
+										];
+										delete SVGOptions[
+											'background-svg-SVGMediaURL'
+										];
+										delete SVGOptions[
+											'background-svg-SVGData'
+										];
+									}
+									onChange({ ...SVGOptions, ...obj });
+								}}
+								icon={SVGOptions['background-svg-SVGElement']}
 							/>
 						),
 					},

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -89,6 +89,7 @@ const IconControl = props => {
 					type='button-icon'
 					style={parentBlockStyle}
 					onSelect={obj => onChange(obj)}
+					onRemove={obj => onChange(obj)}
 					{...props}
 				/>
 			)}

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -85,7 +85,12 @@ const IconControl = props => {
 	return (
 		<div className={classes}>
 			{!isHover && deviceType === 'general' && (
-				<MaxiModal type='button-icon' style={parentBlockStyle} />
+				<MaxiModal
+					type='button-icon'
+					style={parentBlockStyle}
+					onSelect={obj => onChange(obj)}
+					{...props}
+				/>
 			)}
 			{isHover && (
 				<FancyRadioControl

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -90,7 +90,7 @@ const IconControl = props => {
 					style={parentBlockStyle}
 					onSelect={obj => onChange(obj)}
 					onRemove={obj => onChange(obj)}
-					{...props}
+					icon={props['icon-content']}
 				/>
 			)}
 			{isHover && (

--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -141,7 +141,7 @@ const MasonryItem = props => {
  * Component
  */
 const LibraryContainer = props => {
-	const { type, onRequestClose, blockStyle, layerId } = props;
+	const { type, onRequestClose, blockStyle, layerId, onSelect } = props;
 
 	const {
 		styleCards,
@@ -170,8 +170,7 @@ const LibraryContainer = props => {
 		};
 	});
 
-	const { replaceBlock, updateBlockAttributes } =
-		useDispatch('core/block-editor');
+	const { replaceBlock } = useDispatch('core/block-editor');
 	const { saveMaxiStyleCards, setSelectedStyleCard } = useDispatch(
 		'maxiBlocks/style-cards'
 	);
@@ -220,7 +219,7 @@ const LibraryContainer = props => {
 				'maxi-blocks'
 			)}<span class="maxi-spinner"></span></h3>`;
 
-			updateBlockAttributes(clientId, { content: loadingMessage });
+			onSelect({ content: loadingMessage });
 
 			onRequestClose();
 
@@ -359,8 +358,8 @@ const LibraryContainer = props => {
 		).replaceAll(replaceIt, newSvgClass);
 
 		if (isValidTemplate(finalSvgCode)) {
-			updateBlockAttributes(clientId, { content: finalSvgCode });
-			updateBlockAttributes(clientId, { svgType });
+			onSelect({ content: finalSvgCode });
+			onSelect({ svgType });
 			onRequestClose();
 		}
 	};
@@ -409,7 +408,7 @@ const LibraryContainer = props => {
 					},
 				};
 
-				updateBlockAttributes(clientId, {
+				onSelect({
 					shapeSVGElement: svgCode,
 					shapeSVGData: SVGData,
 				});
@@ -445,7 +444,7 @@ const LibraryContainer = props => {
 				const resEl = injectImgSVG(svg, resData);
 
 				if (!bgLayersStatus) {
-					updateBlockAttributes(clientId, {
+					onSelect({
 						'background-svg-SVGElement': resEl.outerHTML,
 						'background-svg-SVGMediaID': null,
 						'background-svg-SVGMediaURL': null,
@@ -460,7 +459,7 @@ const LibraryContainer = props => {
 					newBgLayers[layerId]['background-svg-SVGMediaURL'] = '';
 					newBgLayers[layerId]['background-svg-SVGData'] = resData;
 
-					updateBlockAttributes(clientId, {
+					onSelect({
 						'background-layers': [...newBgLayers],
 					});
 				}
@@ -489,7 +488,7 @@ const LibraryContainer = props => {
 				const resData = generateDataObject(SVGOptions[SVGData], svg);
 				const resEl = injectImgSVG(svg, resData);
 
-				updateBlockAttributes(clientId, {
+				onSelect({
 					SVGElement: injectImgSVG(resEl, SVGData).outerHTML,
 					SVGData,
 				});
@@ -500,7 +499,7 @@ const LibraryContainer = props => {
 			if (type === 'button-icon') {
 				const cleanedContent = DOMPurify.sanitize(svgCode);
 
-				updateBlockAttributes(clientId, {
+				onSelect({
 					'icon-content': cleanedContent,
 				});
 

--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -141,7 +141,7 @@ const MasonryItem = props => {
  * Component
  */
 const LibraryContainer = props => {
-	const { type, onRequestClose, blockStyle, layerId, onSelect } = props;
+	const { type, onRequestClose, blockStyle, onSelect } = props;
 
 	const {
 		styleCards,
@@ -393,8 +393,6 @@ const LibraryContainer = props => {
 			uniqueID,
 			mediaID,
 			mediaURL,
-			'background-layers': bgLayers,
-			'background-layers-status': bgLayersStatus,
 			'background-svg-SVGData': svgData,
 		} = select('core/block-editor').getBlockAttributes(clientId);
 
@@ -443,26 +441,12 @@ const LibraryContainer = props => {
 
 				const resEl = injectImgSVG(svg, resData);
 
-				if (!bgLayersStatus) {
-					onSelect({
-						'background-svg-SVGElement': resEl.outerHTML,
-						'background-svg-SVGMediaID': null,
-						'background-svg-SVGMediaURL': null,
-						'background-svg-SVGData': resData,
-					});
-				} else {
-					const newBgLayers = cloneDeep(bgLayers);
-
-					newBgLayers[layerId]['background-svg-SVGElement'] =
-						resEl.outerHTML;
-					newBgLayers[layerId]['background-svg-SVGMediaID'] = '';
-					newBgLayers[layerId]['background-svg-SVGMediaURL'] = '';
-					newBgLayers[layerId]['background-svg-SVGData'] = resData;
-
-					onSelect({
-						'background-layers': [...newBgLayers],
-					});
-				}
+				onSelect({
+					'background-svg-SVGElement': resEl.outerHTML,
+					'background-svg-SVGMediaID': null,
+					'background-svg-SVGMediaURL': null,
+					'background-svg-SVGData': resData,
+				});
 
 				onRequestClose();
 			}

--- a/src/editor/library/index.js
+++ b/src/editor/library/index.js
@@ -26,7 +26,8 @@ import './editor.scss';
  * @param {string} cloudType Type of the data to get from the Cloud, values: patterns, svg, sc
  */
 const CloudLibrary = props => {
-	const { onClose, className, cloudType, blockStyle, layerId } = props;
+	const { onClose, className, cloudType, blockStyle, layerId, onSelect } =
+		props;
 
 	const [type, setType] = useState(cloudType);
 
@@ -47,6 +48,7 @@ const CloudLibrary = props => {
 					type={type}
 					onRequestClose={onClose}
 					blockStyle={blockStyle}
+					onSelect={onSelect}
 				/>
 			</>
 		</Modal>

--- a/src/editor/library/index.js
+++ b/src/editor/library/index.js
@@ -26,8 +26,7 @@ import './editor.scss';
  * @param {string} cloudType Type of the data to get from the Cloud, values: patterns, svg, sc
  */
 const CloudLibrary = props => {
-	const { onClose, className, cloudType, blockStyle, layerId, onSelect } =
-		props;
+	const { onClose, className, cloudType, blockStyle, onSelect } = props;
 
 	const [type, setType] = useState(cloudType);
 
@@ -44,7 +43,6 @@ const CloudLibrary = props => {
 			<>
 				<LibraryToolbar type={type} onChange={type => setType(type)} />
 				<LibraryContainer
-					layerId={layerId}
 					type={type}
 					onRequestClose={onClose}
 					blockStyle={blockStyle}

--- a/src/editor/library/modal.js
+++ b/src/editor/library/modal.js
@@ -1,20 +1,15 @@
 /**
- * Layout modal window with tab panel.
- */
-
-import CloudLibrary from '.';
-
-/**
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { Component, RawHTML } from '@wordpress/element';
+import { RawHTML, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { select, dispatch } from '@wordpress/data';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import CloudLibrary from '.';
 import { Icon } from '../../components';
 
 /**
@@ -27,232 +22,215 @@ import { isEmpty, cloneDeep } from 'lodash';
  */
 import { SCaddMore, toolbarReplaceImage, remove } from '../../icons';
 
-class MaxiModal extends Component {
-	state = {
-		isOpen: this.props.openFirstTime,
+/**
+ * Layout modal window with tab panel.
+ */
+const MaxiModal = props => {
+	const {
+		type,
+		clientId,
+		empty,
+		style,
+		layerId,
+		openFirstTime,
+		onOpen = null,
+		onRemove,
+		onSelect,
+		...rest
+	} = props;
+
+	const [isOpen, changeIsOpen] = useState(openFirstTime);
+
+	const { getBlockAttributes } = select('core/block-editor');
+
+	const attributes = rest || getBlockAttributes(clientId);
+
+	const onClick = () => {
+		changeIsOpen(!isOpen);
+
+		if (onOpen) onOpen({ openFirstTime: !isOpen });
 	};
 
-	render() {
-		const { isOpen } = this.state;
-
-		const { type, clientId, empty, style, layerId } = this.props;
-
-		const { getBlockAttributes, getSelectedBlockClientId } =
-			select('core/block-editor');
-
-		const attributes = getBlockAttributes(getSelectedBlockClientId());
-
-		const onClick = () => {
-			this.setState({
-				isOpen: !isOpen,
-			});
-
-			dispatch('core/block-editor').updateBlockAttributes(clientId, {
-				openFirstTime: !isOpen,
-			});
-		};
-
-		return (
-			<div className='maxi-library-modal__action-section'>
-				<div className='maxi-library-modal__action-section__buttons'>
-					{type === 'patterns' && (
+	return (
+		<div className='maxi-library-modal__action-section'>
+			<div className='maxi-library-modal__action-section__buttons'>
+				{type === 'patterns' && (
+					<Button
+						key={`maxi-block-library__modal-button--${clientId}`}
+						isPrimary
+						className='maxi-block-library__modal-button'
+						onClick={onClick}
+					>
+						{__('Launch the Library', 'maxi-blocks')}
+					</Button>
+				)}
+				{type === 'sc' && (
+					<Button
+						className='maxi-style-cards__sc__more-sc--add-more'
+						onClick={onClick}
+					>
+						<Icon icon={SCaddMore} />
+					</Button>
+				)}
+				{type === 'svg' && empty && (
+					<div className='maxi-svg-icon-block__placeholder'>
 						<Button
-							key={`maxi-block-library__modal-button--${clientId}`}
 							isPrimary
+							key={`maxi-block-library__modal-button--${clientId}`}
 							className='maxi-block-library__modal-button'
 							onClick={onClick}
 						>
-							{__('Launch the Library', 'maxi-blocks')}
+							{__('Select SVG Icon', 'maxi-blocks')}
 						</Button>
-					)}
-					{type === 'sc' && (
-						<Button
-							className='maxi-style-cards__sc__more-sc--add-more'
-							onClick={onClick}
-						>
-							<Icon icon={SCaddMore} />
-						</Button>
-					)}
-					{type === 'svg' && empty && (
-						<div className='maxi-svg-icon-block__placeholder'>
-							<Button
-								isPrimary
-								key={`maxi-block-library__modal-button--${clientId}`}
-								className='maxi-block-library__modal-button'
-								onClick={onClick}
-							>
-								{__('Select SVG Icon', 'maxi-blocks')}
-							</Button>
-						</div>
-					)}
-					{type === 'svg' && !empty && (
-						<Button
-							className='maxi-svg-icon-block__replace-icon'
-							onClick={onClick}
-							icon={toolbarReplaceImage}
-						/>
-					)}
-					{(type === 'bg-shape' ||
-						type === 'image-shape' ||
-						type === 'sidebar-block-shape') && (
-						<Button
-							className='maxi-library-modal__action-section__buttons__load-library'
-							onClick={onClick}
-						>
-							{__('Load Shape Library', 'maxi-blocks')}
-						</Button>
-					)}
-					{type === 'button-icon' && (
-						<Button
-							className='maxi-library-modal__action-section__buttons__load-library'
-							onClick={onClick}
-						>
-							{isEmpty(attributes['icon-content'])
-								? __('Add Icon', 'maxi-blocks')
-								: __('Replace Icon', 'maxi-blocks')}
-						</Button>
-					)}
-					{isOpen && (
-						<CloudLibrary
-							layerId={layerId}
-							cloudType={type}
-							onClose={onClick}
-							blockStyle={style}
-						/>
-					)}
-				</div>
-				{attributes &&
-					type === 'button-icon' &&
-					attributes['icon-content'] && (
-						<div className='maxi-library-modal__action-section__preview'>
-							<Icon
-								className='maxi-library-modal__action-section__preview--remove'
-								icon={remove}
-								onClick={() =>
-									dispatch(
-										'core/block-editor'
-									).updateBlockAttributes(
-										getSelectedBlockClientId(),
-										{
-											'icon-content': '',
-											'icon-only': false,
-										}
-									)
-								}
-							/>
-							<RawHTML className='maxi-library-modal__action-section__preview__icon'>
-								{attributes['icon-content']}
-							</RawHTML>
-						</div>
-					)}
-				{attributes &&
-					type === 'sidebar-block-shape' &&
-					attributes.shapeSVGElement && (
-						<div className='maxi-library-modal__action-section__preview'>
-							<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-								{attributes.shapeSVGElement}
-							</RawHTML>
-						</div>
-					)}
-				{attributes &&
-					type === 'bg-shape' &&
-					attributes['background-layers-status'] &&
-					!isEmpty(
-						attributes['background-layers'][layerId][
-							'background-svg-SVGElement'
-						]
-					) && (
-						<div className='maxi-library-modal__action-section__preview'>
-							<Icon
-								className='maxi-library-modal__action-section__preview--remove'
-								icon={remove}
-								onClick={() => {
-									const newBgLayers = cloneDeep(
-										attributes['background-layers']
-									);
-
-									delete newBgLayers[layerId][
-										'background-svg-SVGElement'
-									];
-									delete newBgLayers[layerId][
-										'background-svg-SVGMediaID'
-									];
-									delete newBgLayers[layerId][
-										'background-svg-SVGMediaURL'
-									];
-									delete newBgLayers[layerId][
-										'background-svg-SVGData'
-									];
-
-									dispatch(
-										'core/block-editor'
-									).updateBlockAttributes(
-										getSelectedBlockClientId(),
-										{
-											'background-layers': [
-												...newBgLayers,
-											],
-										}
-									);
-								}}
-							/>
-							<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-								{
-									attributes['background-layers'][layerId][
-										'background-svg-SVGElement'
-									]
-								}
-							</RawHTML>
-						</div>
-					)}
-				{attributes &&
-					type === 'bg-shape' &&
-					!attributes['background-layers-status'] &&
-					!isEmpty(attributes['background-svg-SVGElement']) && (
-						<div className='maxi-library-modal__action-section__preview'>
-							<Icon
-								className='maxi-library-modal__action-section__preview--remove'
-								icon={remove}
-								onClick={() =>
-									dispatch(
-										'core/block-editor'
-									).updateBlockAttributes(
-										getSelectedBlockClientId(),
-										{
-											'background-svg-SVGElement': '',
-										}
-									)
-								}
-							/>
-							<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-								{attributes['background-svg-SVGElement']}
-							</RawHTML>
-						</div>
-					)}
-				{attributes && type === 'image-shape' && attributes.SVGElement && (
+					</div>
+				)}
+				{type === 'svg' && !empty && (
+					<Button
+						className='maxi-svg-icon-block__replace-icon'
+						onClick={onClick}
+						icon={toolbarReplaceImage}
+					/>
+				)}
+				{(type === 'bg-shape' ||
+					type === 'image-shape' ||
+					type === 'sidebar-block-shape') && (
+					<Button
+						className='maxi-library-modal__action-section__buttons__load-library'
+						onClick={onClick}
+					>
+						{__('Load Shape Library', 'maxi-blocks')}
+					</Button>
+				)}
+				{type === 'button-icon' && (
+					<Button
+						className='maxi-library-modal__action-section__buttons__load-library'
+						onClick={onClick}
+					>
+						{isEmpty(attributes['icon-content'])
+							? __('Add Icon', 'maxi-blocks')
+							: __('Replace Icon', 'maxi-blocks')}
+					</Button>
+				)}
+				{isOpen && (
+					<CloudLibrary
+						layerId={layerId}
+						cloudType={type}
+						onClose={onClick}
+						blockStyle={style}
+						onSelect={onSelect}
+					/>
+				)}
+			</div>
+			{attributes &&
+				type === 'button-icon' &&
+				attributes['icon-content'] && (
 					<div className='maxi-library-modal__action-section__preview'>
 						<Icon
 							className='maxi-library-modal__action-section__preview--remove'
 							icon={remove}
 							onClick={() =>
-								dispatch(
-									'core/block-editor'
-								).updateBlockAttributes(
-									getSelectedBlockClientId(),
-									{
-										SVGElement: '',
-										SVGData: {},
-									}
-								)
+								onRemove({
+									'icon-content': '',
+									'icon-only': false,
+								})
 							}
 						/>
-						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-							{attributes.SVGElement}
+						<RawHTML className='maxi-library-modal__action-section__preview__icon'>
+							{attributes['icon-content']}
 						</RawHTML>
 					</div>
 				)}
-			</div>
-		);
-	}
-}
+			{attributes &&
+				type === 'sidebar-block-shape' &&
+				attributes.shapeSVGElement && (
+					<div className='maxi-library-modal__action-section__preview'>
+						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
+							{attributes.shapeSVGElement}
+						</RawHTML>
+					</div>
+				)}
+			{attributes &&
+				type === 'bg-shape' &&
+				attributes['background-layers-status'] &&
+				!isEmpty(
+					attributes['background-layers'][layerId][
+						'background-svg-SVGElement'
+					]
+				) && (
+					<div className='maxi-library-modal__action-section__preview'>
+						<Icon
+							className='maxi-library-modal__action-section__preview--remove'
+							icon={remove}
+							onClick={() => {
+								const newBgLayers = cloneDeep(
+									attributes['background-layers']
+								);
+
+								delete newBgLayers[layerId][
+									'background-svg-SVGElement'
+								];
+								delete newBgLayers[layerId][
+									'background-svg-SVGMediaID'
+								];
+								delete newBgLayers[layerId][
+									'background-svg-SVGMediaURL'
+								];
+								delete newBgLayers[layerId][
+									'background-svg-SVGData'
+								];
+
+								onRemove({
+									'background-layers': [...newBgLayers],
+								});
+							}}
+						/>
+						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
+							{
+								attributes['background-layers'][layerId][
+									'background-svg-SVGElement'
+								]
+							}
+						</RawHTML>
+					</div>
+				)}
+			{attributes &&
+				type === 'bg-shape' &&
+				!attributes['background-layers-status'] &&
+				!isEmpty(attributes['background-svg-SVGElement']) && (
+					<div className='maxi-library-modal__action-section__preview'>
+						<Icon
+							className='maxi-library-modal__action-section__preview--remove'
+							icon={remove}
+							onClick={() =>
+								onRemove({
+									'background-svg-SVGElement': '',
+								})
+							}
+						/>
+						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
+							{attributes['background-svg-SVGElement']}
+						</RawHTML>
+					</div>
+				)}
+			{attributes && type === 'image-shape' && attributes.SVGElement && (
+				<div className='maxi-library-modal__action-section__preview'>
+					<Icon
+						className='maxi-library-modal__action-section__preview--remove'
+						icon={remove}
+						onClick={() =>
+							onRemove({
+								SVGElement: '',
+								SVGData: {},
+							})
+						}
+					/>
+					<RawHTML className='maxi-library-modal__action-section__preview__shape'>
+						{attributes.SVGElement}
+					</RawHTML>
+				</div>
+			)}
+		</div>
+	);
+};
+
 export default MaxiModal;

--- a/src/editor/library/modal.js
+++ b/src/editor/library/modal.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { RawHTML, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import { Icon } from '../../components';
 /**
  * External dependencies
  */
-import { isEmpty, cloneDeep } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Icons
@@ -31,19 +30,14 @@ const MaxiModal = props => {
 		clientId,
 		empty,
 		style,
-		layerId,
 		openFirstTime,
 		onOpen = null,
 		onRemove,
 		onSelect,
-		...rest
+		icon,
 	} = props;
 
 	const [isOpen, changeIsOpen] = useState(openFirstTime);
-
-	const { getBlockAttributes } = select('core/block-editor');
-
-	const attributes = rest || getBlockAttributes(clientId);
 
 	const onClick = () => {
 		changeIsOpen(!isOpen);
@@ -106,14 +100,13 @@ const MaxiModal = props => {
 						className='maxi-library-modal__action-section__buttons__load-library'
 						onClick={onClick}
 					>
-						{isEmpty(attributes['icon-content'])
+						{isEmpty(icon)
 							? __('Add Icon', 'maxi-blocks')
 							: __('Replace Icon', 'maxi-blocks')}
 					</Button>
 				)}
 				{isOpen && (
 					<CloudLibrary
-						layerId={layerId}
 						cloudType={type}
 						onClose={onClick}
 						blockStyle={style}
@@ -121,98 +114,40 @@ const MaxiModal = props => {
 					/>
 				)}
 			</div>
-			{attributes &&
-				type === 'button-icon' &&
-				attributes['icon-content'] && (
-					<div className='maxi-library-modal__action-section__preview'>
-						<Icon
-							className='maxi-library-modal__action-section__preview--remove'
-							icon={remove}
-							onClick={() =>
-								onRemove({
-									'icon-content': '',
-									'icon-only': false,
-								})
-							}
-						/>
-						<RawHTML className='maxi-library-modal__action-section__preview__icon'>
-							{attributes['icon-content']}
-						</RawHTML>
-					</div>
-				)}
-			{attributes &&
-				type === 'sidebar-block-shape' &&
-				attributes.shapeSVGElement && (
-					<div className='maxi-library-modal__action-section__preview'>
-						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-							{attributes.shapeSVGElement}
-						</RawHTML>
-					</div>
-				)}
-			{attributes &&
-				type === 'bg-shape' &&
-				attributes['background-layers-status'] &&
-				!isEmpty(
-					attributes['background-layers'][layerId][
-						'background-svg-SVGElement'
-					]
-				) && (
-					<div className='maxi-library-modal__action-section__preview'>
-						<Icon
-							className='maxi-library-modal__action-section__preview--remove'
-							icon={remove}
-							onClick={() => {
-								const newBgLayers = cloneDeep(
-									attributes['background-layers']
-								);
-
-								delete newBgLayers[layerId][
-									'background-svg-SVGElement'
-								];
-								delete newBgLayers[layerId][
-									'background-svg-SVGMediaID'
-								];
-								delete newBgLayers[layerId][
-									'background-svg-SVGMediaURL'
-								];
-								delete newBgLayers[layerId][
-									'background-svg-SVGData'
-								];
-
-								onRemove({
-									'background-layers': [...newBgLayers],
-								});
-							}}
-						/>
-						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-							{
-								attributes['background-layers'][layerId][
-									'background-svg-SVGElement'
-								]
-							}
-						</RawHTML>
-					</div>
-				)}
-			{attributes &&
-				type === 'bg-shape' &&
-				!attributes['background-layers-status'] &&
-				!isEmpty(attributes['background-svg-SVGElement']) && (
-					<div className='maxi-library-modal__action-section__preview'>
-						<Icon
-							className='maxi-library-modal__action-section__preview--remove'
-							icon={remove}
-							onClick={() =>
-								onRemove({
-									'background-svg-SVGElement': '',
-								})
-							}
-						/>
-						<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-							{attributes['background-svg-SVGElement']}
-						</RawHTML>
-					</div>
-				)}
-			{attributes && type === 'image-shape' && attributes.SVGElement && (
+			{type === 'button-icon' && !isEmpty(icon) && (
+				<div className='maxi-library-modal__action-section__preview'>
+					<Icon
+						className='maxi-library-modal__action-section__preview--remove'
+						icon={remove}
+						onClick={() =>
+							onRemove({
+								'icon-content': '',
+								'icon-only': false,
+							})
+						}
+					/>
+					<RawHTML className='maxi-library-modal__action-section__preview__icon'>
+						{icon}
+					</RawHTML>
+				</div>
+			)}
+			{type === 'bg-shape' && !isEmpty(icon) && (
+				<div className='maxi-library-modal__action-section__preview'>
+					<Icon
+						className='maxi-library-modal__action-section__preview--remove'
+						icon={remove}
+						onClick={() => {
+							onRemove({
+								'background-svg-SVGElement': '',
+							});
+						}}
+					/>
+					<RawHTML className='maxi-library-modal__action-section__preview__shape'>
+						{icon}
+					</RawHTML>
+				</div>
+			)}
+			{type === 'image-shape' && !isEmpty(icon) && (
 				<div className='maxi-library-modal__action-section__preview'>
 					<Icon
 						className='maxi-library-modal__action-section__preview--remove'
@@ -225,7 +160,7 @@ const MaxiModal = props => {
 						}
 					/>
 					<RawHTML className='maxi-library-modal__action-section__preview__shape'>
-						{attributes.SVGElement}
+						{icon}
 					</RawHTML>
 				</div>
 			)}


### PR DESCRIPTION
Replaced dispatch action `updateBlockAttributes` for `onSelect` method which relays the responsibility of the attributes changed from the Modal on the block and not on the Modal itself.
Rewrite MaxiModal to be a functional component instead of class component.

What to test:
- All modal instances do the same they were doing before