### PR TITLE
Issue 2222

### DIFF
--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -121,14 +121,19 @@ class edit extends MaxiBlockComponent {
 
 		const isEmptyContent = isEmpty(content);
 
-		const handleOnResizeStart = event => {
+		const handleOnResizeStart = (event, direction, elt) => {
 			event.preventDefault();
+
+			elt.querySelector('svg').style.width = 'auto';
+
 			setAttributes({
 				[`svg-width-unit-${deviceType}`]: 'px',
 			});
 		};
 
 		const handleOnResizeStop = (event, direction, elt) => {
+			elt.querySelector('svg').style.width = null;
+
 			setAttributes({
 				[`svg-width-${deviceType}`]: elt.getBoundingClientRect().width,
 			});

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -84,7 +84,7 @@ class edit extends MaxiBlockComponent {
 				}
 
 				if (!isEmpty(newContent))
-					updateBlockAttributes(this.props.clientId, {
+					this.props.setAttributes({
 						content: newContent,
 					});
 			}
@@ -171,7 +171,15 @@ class edit extends MaxiBlockComponent {
 							className='maxi-svg-icon-block__icon'
 							resizableObject={this.resizableObject}
 							lockAspectRatio
-							maxWidth='100%'
+							maxWidth={
+								getLastBreakpointAttribute(
+									'svg-responsive',
+									deviceType,
+									attributes
+								)
+									? '100%'
+									: null
+							}
 							showHandle={isSelected}
 							enable={{
 								topRight: true,

--- a/src/blocks/svg-icon-maxi/editor.scss
+++ b/src/blocks/svg-icon-maxi/editor.scss
@@ -42,13 +42,13 @@
 		}
 	}
 
-	.maxi-svg-icon-block__icon {
-		height: inherit !important;
-		max-height: 100%;
+	// .maxi-svg-icon-block__icon {
+	// 	// height: inherit !important;
+	// 	// max-height: 100%;
 
-		svg {
-			max-width: none !important;
-			max-height: none !important;
-		}
-	}
+	// 	svg {
+	// 		max-width: none !important;
+	// 		max-height: none !important;
+	// 	}
+	// }
 }

--- a/src/blocks/svg-icon-maxi/inspector.js
+++ b/src/blocks/svg-icon-maxi/inspector.js
@@ -357,6 +357,7 @@ const Inspector = props => {
 													}}
 													breakpoint={deviceType}
 													prefix='svg-'
+													enableResponsive
 												/>
 											),
 										},

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -129,7 +129,6 @@ const IconControl = props => {
 						</>
 					)}
 					<SvgWidthControl
-						prefix='icon-'
 						{...getGroupAttributes(
 							props,
 							`icon${isHover ? 'Hover' : ''}`,
@@ -138,11 +137,11 @@ const IconControl = props => {
 						onChange={obj => {
 							onChange(obj);
 						}}
+						prefix='icon-'
 						breakpoint={breakpoint}
 						isHover={isHover}
 					/>
 					<SvgStrokeWidthControl
-						prefix='icon-'
 						{...getGroupAttributes(
 							props,
 							`icon${isHover ? 'Hover' : ''}`,
@@ -151,6 +150,7 @@ const IconControl = props => {
 						onChange={obj => {
 							onChange(obj);
 						}}
+						prefix='icon-'
 						breakpoint={breakpoint}
 						isHover={isHover}
 					/>

--- a/src/components/svg-width-control/index.js
+++ b/src/components/svg-width-control/index.js
@@ -2,7 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { ToggleSwitch } from '..';
 import {
+	getAttributeKey,
 	getDefaultAttribute,
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
@@ -16,7 +18,13 @@ import AdvancedNumberControl from '../advanced-number-control';
  * Component
  */
 const SvgWidthControl = props => {
-	const { onChange, breakpoint, prefix, isHover } = props;
+	const {
+		onChange,
+		breakpoint,
+		prefix,
+		isHover,
+		enableResponsive = false,
+	} = props;
 
 	const width =
 		props[`${prefix}width-${breakpoint}${isHover ? '-hover' : ''}`];
@@ -47,19 +55,21 @@ const SvgWidthControl = props => {
 				}
 				onChangeValue={val => {
 					onChange({
-						[`${prefix}width-${breakpoint}${
-							isHover ? '-hover' : ''
-						}`]: val !== undefined && val !== '' ? val : '',
+						[getAttributeKey('width', isHover, prefix, breakpoint)]:
+							val !== undefined && val !== '' ? val : '',
 					});
 				}}
 				enableUnit
 				unit={widthUnit}
-				allowedUnits={['px', 'em', 'vw', '%']}
+				allowedUnits={['px', 'vw', '%']}
 				onChangeUnit={val => {
 					onChange({
-						[`${prefix}width-unit-${breakpoint}${
-							isHover ? '-hover' : ''
-						}`]: val,
+						[getAttributeKey(
+							'width-unit',
+							isHover,
+							prefix,
+							breakpoint
+						)]: val,
 					});
 				}}
 				min={10}
@@ -67,17 +77,40 @@ const SvgWidthControl = props => {
 				step={1}
 				onReset={() =>
 					onChange({
-						[`${prefix}width-${breakpoint}${
-							isHover ? '-hover' : ''
-						}`]: defaultWidth,
-						[`${prefix}width-unit-${breakpoint}${
-							isHover ? '-hover' : ''
-						}`]: defaultWidthUnit,
+						[getAttributeKey('width', isHover, prefix, breakpoint)]:
+							defaultWidth,
+						[getAttributeKey(
+							'width-unit',
+							isHover,
+							prefix,
+							breakpoint
+						)]: defaultWidthUnit,
 					})
 				}
 				initialPosition={defaultWidth}
 				isHover={isHover}
 			/>
+			{enableResponsive && (
+				<ToggleSwitch
+					label={__('Force responsive', 'maxi-blocks')}
+					selected={getLastBreakpointAttribute(
+						`${prefix}responsive`,
+						breakpoint,
+						false,
+						props
+					)}
+					onChange={val =>
+						onChange({
+							[getAttributeKey(
+								'responsive',
+								false,
+								prefix,
+								breakpoint
+							)]: val,
+						})
+					}
+				/>
+			)}
 		</>
 	);
 };

--- a/src/extensions/styles/defaults/svg.js
+++ b/src/extensions/styles/defaults/svg.js
@@ -39,6 +39,10 @@ const svg = {
 		type: 'string',
 		default: 'px',
 	},
+	'svg-responsive-general': {
+		type: 'boolean',
+		default: true,
+	},
 	'svg-stroke-xxl': {
 		type: 'number',
 	},
@@ -47,6 +51,9 @@ const svg = {
 	},
 	'svg-width-unit-xxl': {
 		type: 'string',
+	},
+	'svg-responsive-xxl': {
+		type: 'boolean',
 	},
 	'svg-stroke-xl': {
 		type: 'number',
@@ -57,6 +64,9 @@ const svg = {
 	'svg-width-unit-xl': {
 		type: 'string',
 	},
+	'svg-responsive-xl': {
+		type: 'boolean',
+	},
 	'svg-stroke-l': {
 		type: 'number',
 	},
@@ -65,6 +75,9 @@ const svg = {
 	},
 	'svg-width-unit-l': {
 		type: 'string',
+	},
+	'svg-responsive-l': {
+		type: 'boolean',
 	},
 	'svg-stroke-m': {
 		type: 'number',
@@ -75,6 +88,9 @@ const svg = {
 	'svg-width-unit-m': {
 		type: 'string',
 	},
+	'svg-responsive-m': {
+		type: 'boolean',
+	},
 	'svg-stroke-s': {
 		type: 'number',
 	},
@@ -83,6 +99,9 @@ const svg = {
 	},
 	'svg-width-unit-s': {
 		type: 'string',
+	},
+	'svg-responsive-s': {
+		type: 'boolean',
 	},
 	'svg-stroke-xs': {
 		type: 'number',

--- a/src/extensions/styles/helpers/getSvgStyles.js
+++ b/src/extensions/styles/helpers/getSvgStyles.js
@@ -7,7 +7,7 @@ import getLastBreakpointAttribute from '../getLastBreakpointAttribute';
 /**
  * External dependencies
  */
-import { isNil, isEmpty } from 'lodash';
+import { isNil, isEmpty, isBoolean } from 'lodash';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
@@ -20,14 +20,20 @@ const getSVGWidthStyles = obj => {
 	breakpoints.forEach(breakpoint => {
 		response[breakpoint] = {};
 
-		if (!isNil(obj[`svg-width-${breakpoint}`])) {
-			response[breakpoint]['max-width'] = `${
-				obj[`svg-width-${breakpoint}`]
-			}${getLastBreakpointAttribute('svg-width-unit', breakpoint, obj)}`;
-			response[breakpoint]['max-height'] = `${
-				obj[`svg-width-${breakpoint}`]
-			}${getLastBreakpointAttribute('svg-width-unit', breakpoint, obj)}`;
-		}
+		const svgWidth = obj[`svg-width-${breakpoint}`];
+		const svgResponsive = obj[`svg-responsive-${breakpoint}`];
+
+		if (!isNil(svgWidth))
+			response[
+				breakpoint
+			].width = `${svgWidth}${getLastBreakpointAttribute(
+				'svg-width-unit',
+				breakpoint,
+				obj
+			)}`;
+
+		if (isBoolean(svgResponsive))
+			response[breakpoint]['max-width'] = svgResponsive ? '100%' : 'none';
 
 		if (isEmpty(response[breakpoint]) && breakpoint !== 'general')
 			delete response[breakpoint];

--- a/src/extensions/styles/helpers/test/__snapshots__/getSVGStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getSVGStyles.js.snap
@@ -5,10 +5,14 @@ Object {
   "  .maxi-svg-icon-block__icon svg": Object {
     "SVGWidth": Object {
       "general": Object {
-        "max-height": "64px",
-        "max-width": "64px",
+        "max-width": "none",
+        "width": "64px",
       },
       "label": "SVG width",
+      "m": Object {
+        "max-width": "100%",
+        "width": "640vw",
+      },
     },
   },
   "  .maxi-svg-icon-block__icon svg g[data-fill]:not([fill^=\\"none\\"])": Object {
@@ -33,6 +37,9 @@ Object {
         "stroke-width": "2",
       },
       "label": "SVG path",
+      "m": Object {
+        "stroke-width": "20",
+      },
     },
   },
   "  .maxi-svg-icon-block__icon svg path[data-fill]:not([fill^=\\"none\\"])": Object {

--- a/src/extensions/styles/helpers/test/getSVGStyles.js
+++ b/src/extensions/styles/helpers/test/getSVGStyles.js
@@ -20,6 +20,11 @@ describe('getSVGStyles', () => {
 			'svg-stroke-general': 2,
 			'svg-width-general': 64,
 			'svg-width-unit-general': 'px',
+			'svg-responsive-general': false,
+			'svg-stroke-m': 20,
+			'svg-width-m': 640,
+			'svg-width-unit-m': 'vw',
+			'svg-responsive-m': true,
 		};
 		const target = ' .maxi-svg-icon-block__icon';
 		const blockStyle = 'light';


### PR DESCRIPTION
Fixes #2222

Couple of things:
1. VW is working good, what doesn't work correctly is `em` as resizable-box library doesn't allow it, so removed `em` option.
2. As the maximum size the SVG could get was limited to be responsive and to adapt easily to small screens, added a new option labeled `Force responsive` (change if necessary, is just an idea/concept). It forces the SVG to be adaptive in case is enabled, and leaves free size choosing if creators need/want 👍 

Onces this branch will be merged, will generate an issue to let Alejandro do the SVG tests 👍 