### PR TITLE
Add anchor option for blocks - Issue 2232

### DIFF
--- a/e2e-tests/components/custom-label/index.spec.js
+++ b/e2e-tests/components/custom-label/index.spec.js
@@ -16,7 +16,7 @@ describe('CustomLabel', () => {
 		const accordionPanel = await openSidebarTab(
 			page,
 			'advanced',
-			'add css class id'
+			'add css class'
 		);
 
 		await accordionPanel.$eval(

--- a/e2e-tests/components/text-control/index.spec.js
+++ b/e2e-tests/components/text-control/index.spec.js
@@ -16,7 +16,7 @@ describe('TextControl', () => {
 		const accordionPanel = await openSidebarTab(
 			page,
 			'advanced',
-			'add css class id'
+			'add css class'
 		);
 
 		await accordionPanel.$eval(

--- a/src/blocks/button-maxi/inspector.js
+++ b/src/blocks/button-maxi/inspector.js
@@ -413,11 +413,11 @@ const Inspector = memo(
 												props,
 												isAlignment: true,
 												isTextAlignment: true,
-												alignmentLable: __(
+												alignmentLabel: __(
 													'Button',
 													'maxi-blocks'
 												),
-												textAlignmentLable: __(
+												textAlignmentLabel: __(
 													'Text',
 													'maxi-blocks'
 												),
@@ -627,6 +627,11 @@ const Inspector = memo(
 									items={[
 										deviceType === 'general' && {
 											...inspectorTabs.customClasses({
+												props,
+											}),
+										},
+										deviceType === 'general' && {
+											...inspectorTabs.anchor({
 												props,
 											}),
 										},

--- a/src/blocks/column-maxi/inspector.js
+++ b/src/blocks/column-maxi/inspector.js
@@ -180,6 +180,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.transform({
 										props,
 									}),

--- a/src/blocks/container-maxi/inspector.js
+++ b/src/blocks/container-maxi/inspector.js
@@ -92,6 +92,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.motion({
 										props,
 									}),

--- a/src/blocks/divider-maxi/inspector.js
+++ b/src/blocks/divider-maxi/inspector.js
@@ -226,6 +226,11 @@ const Inspector = props => {
 												props,
 											}),
 										},
+										deviceType === 'general' && {
+											...inspectorTabs.anchor({
+												props,
+											}),
+										},
 										...inspectorTabs.motion({
 											props,
 										}),

--- a/src/blocks/group-maxi/inspector.js
+++ b/src/blocks/group-maxi/inspector.js
@@ -69,6 +69,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.motion({
 										props,
 									}),

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -556,6 +556,11 @@ const Inspector = memo(
 													props,
 												}),
 											},
+											deviceType === 'general' && {
+												...inspectorTabs.anchor({
+													props,
+												}),
+											},
 											...inspectorTabs.motion({
 												props,
 											}),

--- a/src/blocks/map-maxi/inspector.js
+++ b/src/blocks/map-maxi/inspector.js
@@ -89,6 +89,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.transform({
 										props,
 									}),

--- a/src/blocks/number-counter-maxi/inspector.js
+++ b/src/blocks/number-counter-maxi/inspector.js
@@ -117,6 +117,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.transform({
 										props,
 									}),

--- a/src/blocks/row-maxi/inspector.js
+++ b/src/blocks/row-maxi/inspector.js
@@ -199,6 +199,11 @@ const Inspector = props => {
 											props,
 										}),
 									},
+									deviceType === 'general' && {
+										...inspectorTabs.anchor({
+											props,
+										}),
+									},
 									...inspectorTabs.transform({
 										props,
 									}),

--- a/src/blocks/svg-icon-maxi/inspector.js
+++ b/src/blocks/svg-icon-maxi/inspector.js
@@ -341,6 +341,11 @@ const Inspector = props => {
 												props,
 											}),
 										},
+										deviceType === 'general' && {
+											...inspectorTabs.anchor({
+												props,
+											}),
+										},
 										...inspectorTabs.motion({
 											props,
 										}),

--- a/src/blocks/text-maxi/inspector.js
+++ b/src/blocks/text-maxi/inspector.js
@@ -232,6 +232,11 @@ const Inspector = memo(
 													props,
 												}),
 											},
+											deviceType === 'general' && {
+												...inspectorTabs.anchor({
+													props,
+												}),
+											},
 											...inspectorTabs.motion({
 												props,
 											}),

--- a/src/components/inspector-tabs/index.js
+++ b/src/components/inspector-tabs/index.js
@@ -1,4 +1,5 @@
 export { default as alignment } from './inspector-alignment';
+export { default as anchor } from './inspector-anchor';
 export { default as background } from './inspector-background';
 export { default as blockSettings } from './inspector-block-settings';
 export { default as border } from './inspector-border';

--- a/src/components/inspector-tabs/inspector-alignment.js
+++ b/src/components/inspector-tabs/inspector-alignment.js
@@ -16,8 +16,8 @@ const alignment = ({
 	props,
 	isAlignment,
 	isTextAlignment,
-	alignmentLable,
-	textAlignmentLable,
+	alignmentLabel,
+	textAlignmentLabel,
 	disableJustify = false,
 }) => {
 	const { attributes, deviceType, setAttributes } = props;
@@ -28,7 +28,7 @@ const alignment = ({
 			<>
 				{isAlignment && (
 					<AlignmentControl
-						label={alignmentLable}
+						label={alignmentLabel}
 						{...getGroupAttributes(attributes, 'alignment')}
 						onChange={obj => setAttributes(obj)}
 						breakpoint={deviceType}
@@ -37,7 +37,7 @@ const alignment = ({
 				)}
 				{isTextAlignment && (
 					<AlignmentControl
-						label={textAlignmentLable}
+						label={textAlignmentLabel}
 						{...getGroupAttributes(attributes, 'textAlignment')}
 						onChange={obj => setAttributes(obj)}
 						breakpoint={deviceType}

--- a/src/components/inspector-tabs/inspector-anchor.js
+++ b/src/components/inspector-tabs/inspector-anchor.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import TextControl from '../text-control';
+
+/**
+ * Component
+ */
+const anchor = ({ props }) => {
+	const { attributes, setAttributes } = props;
+	const { anchorLink } = attributes;
+
+	const validateAnchor = text => {
+		const regex = new RegExp('^[a-zA-Z0-9-_]+$');
+		if (!regex.test(text)) {
+			return text.replace(/[^a-zA-Z0-9-_]/g, '');
+		}
+		return text;
+	};
+
+	return {
+		label: __('Add Anchor Link', 'maxi-blocks'),
+		content: (
+			<TextControl
+				label={__('Add anchor', 'maxi-blocks')}
+				className='maxi-anchor-link'
+				value={anchorLink}
+				onChange={anchorLink => {
+					const link = validateAnchor(anchorLink);
+					setAttributes({
+						anchorLink: link,
+					});
+				}}
+				validationText={
+					__('Add an anchor link to the element. ', 'maxi-blocks') +
+					__('Possible characters: ', 'maxi-blocks') +
+					__('0-9, A-Z, a-z, _ , -', 'maxi-blocks')
+				}
+			/>
+		),
+	};
+};
+
+export default anchor;

--- a/src/components/inspector-tabs/inspector-custom-classes.js
+++ b/src/components/inspector-tabs/inspector-custom-classes.js
@@ -13,34 +13,21 @@ import TextControl from '../text-control';
  */
 const customClasses = ({ props }) => {
 	const { attributes, setAttributes } = props;
-	const { extraClassName, extraID } = attributes;
+	const { extraClassName } = attributes;
 
 	return {
-		label: __('Add CSS class/id', 'maxi-blocks'),
+		label: __('Add CSS class', 'maxi-blocks'),
 		content: (
-			<>
-				<TextControl
-					label={__('Add CSS classes', 'maxi-blocks')}
-					className='maxi-additional__css-classes'
-					value={extraClassName}
-					onChange={extraClassName =>
-						setAttributes({
-							extraClassName,
-						})
-					}
-				/>
-				<TextControl
-					label={__('Add ID', 'maxi-blocks')}
-					className='maxi-additional__css-classes'
-					value={extraID}
-					onChange={extraID => {
-						const id = extraID.trim();
-						setAttributes({
-							extraID: id,
-						});
-					}}
-				/>
-			</>
+			<TextControl
+				label={__('Add CSS classes', 'maxi-blocks')}
+				className='maxi-additional__css-classes'
+				value={extraClassName}
+				onChange={extraClassName =>
+					setAttributes({
+						extraClassName,
+					})
+				}
+			/>
 		),
 	};
 };

--- a/src/components/inspector-tabs/inspector-custom-classes.js
+++ b/src/components/inspector-tabs/inspector-custom-classes.js
@@ -13,21 +13,33 @@ import TextControl from '../text-control';
  */
 const customClasses = ({ props }) => {
 	const { attributes, setAttributes } = props;
-	const { extraClassName } = attributes;
+	const { extraClassName, extraID } = attributes;
 
 	return {
 		label: __('Add CSS class/id', 'maxi-blocks'),
 		content: (
-			<TextControl
-				label={__('Add CSS classes', 'maxi-blocks')}
-				className='maxi-additional__css-classes'
-				value={extraClassName}
-				onChange={extraClassName =>
-					setAttributes({
-						extraClassName,
-					})
-				}
-			/>
+			<>
+				<TextControl
+					label={__('Add CSS classes', 'maxi-blocks')}
+					className='maxi-additional__css-classes'
+					value={extraClassName}
+					onChange={extraClassName =>
+						setAttributes({
+							extraClassName,
+						})
+					}
+				/>
+				<TextControl
+					label={__('Add ID', 'maxi-blocks')}
+					className='maxi-additional__css-classes'
+					value={extraID}
+					onChange={extraID =>
+						setAttributes({
+							extraID,
+						})
+					}
+				/>
+			</>
 		),
 	};
 };

--- a/src/components/inspector-tabs/inspector-custom-classes.js
+++ b/src/components/inspector-tabs/inspector-custom-classes.js
@@ -33,11 +33,12 @@ const customClasses = ({ props }) => {
 					label={__('Add ID', 'maxi-blocks')}
 					className='maxi-additional__css-classes'
 					value={extraID}
-					onChange={extraID =>
+					onChange={extraID => {
+						const id = extraID.trim();
 						setAttributes({
-							extraID,
-						})
-					}
+							extraID: id,
+						});
+					}}
 				/>
 			</>
 		),

--- a/src/components/maxi-block/index.js
+++ b/src/components/maxi-block/index.js
@@ -52,6 +52,7 @@ const MainBlock = forwardRef(
 			disableBackground,
 			uniqueID,
 			isSave,
+			extraID,
 			...props
 		},
 		ref
@@ -59,6 +60,7 @@ const MainBlock = forwardRef(
 		if (isSave)
 			return (
 				<TagName ref={ref} {...useBlockProps.save(props)}>
+					{!isEmpty(extraID) && <span id={extraID} />}
 					{disableBackground && (
 						<BackgroundDisplayer isSave {...background} />
 					)}
@@ -68,6 +70,7 @@ const MainBlock = forwardRef(
 
 		return (
 			<TagName {...useBlockProps({ ...props, ref })}>
+				{!isEmpty(extraID) && <span id={extraID} />}
 				{disableBackground && <BackgroundDisplayer {...background} />}
 				{children}
 			</TagName>
@@ -83,6 +86,7 @@ const MaxiBlock = forwardRef((props, ref) => {
 		children,
 		blockStyle,
 		extraClassName,
+		extraID,
 		uniqueID,
 		className,
 		displayValue,
@@ -191,6 +195,7 @@ const MaxiBlock = forwardRef((props, ref) => {
 		id: uniqueID,
 		key: `maxi-block-${uniqueID}`,
 		uniqueID,
+		extraID,
 		background,
 		disableBackground: !disableBackground,
 		isSave,
@@ -245,6 +250,7 @@ export const getMaxiBlockBlockAttributes = props => {
 	const {
 		blockStyle,
 		extraClassName,
+		extraID,
 		uniqueID,
 		blockFullWidth,
 		linkSettings,
@@ -277,6 +283,7 @@ export const getMaxiBlockBlockAttributes = props => {
 		blockName: name,
 		blockStyle,
 		extraClassName,
+		extraID,
 		uniqueID,
 		blockFullWidth,
 		displayValue,

--- a/src/components/maxi-block/index.js
+++ b/src/components/maxi-block/index.js
@@ -52,7 +52,7 @@ const MainBlock = forwardRef(
 			disableBackground,
 			uniqueID,
 			isSave,
-			extraID,
+			anchorLink,
 			...props
 		},
 		ref
@@ -60,7 +60,9 @@ const MainBlock = forwardRef(
 		if (isSave)
 			return (
 				<TagName ref={ref} {...useBlockProps.save(props)}>
-					{!isEmpty(extraID) && <span id={extraID} />}
+					{!isEmpty(anchorLink) && (
+						<span id={anchorLink} className='maxi-block-anchor' />
+					)}
 					{disableBackground && (
 						<BackgroundDisplayer isSave {...background} />
 					)}
@@ -70,7 +72,7 @@ const MainBlock = forwardRef(
 
 		return (
 			<TagName {...useBlockProps({ ...props, ref })}>
-				{!isEmpty(extraID) && <span id={extraID} />}
+				{!isEmpty(anchorLink) && <span id={anchorLink} />}
 				{disableBackground && <BackgroundDisplayer {...background} />}
 				{children}
 			</TagName>
@@ -86,7 +88,7 @@ const MaxiBlock = forwardRef((props, ref) => {
 		children,
 		blockStyle,
 		extraClassName,
-		extraID,
+		anchorLink,
 		uniqueID,
 		className,
 		displayValue,
@@ -195,7 +197,7 @@ const MaxiBlock = forwardRef((props, ref) => {
 		id: uniqueID,
 		key: `maxi-block-${uniqueID}`,
 		uniqueID,
-		extraID,
+		anchorLink,
 		background,
 		disableBackground: !disableBackground,
 		isSave,
@@ -250,7 +252,7 @@ export const getMaxiBlockBlockAttributes = props => {
 	const {
 		blockStyle,
 		extraClassName,
-		extraID,
+		anchorLink,
 		uniqueID,
 		blockFullWidth,
 		linkSettings,
@@ -283,7 +285,7 @@ export const getMaxiBlockBlockAttributes = props => {
 		blockName: name,
 		blockStyle,
 		extraClassName,
-		extraID,
+		anchorLink,
 		uniqueID,
 		blockFullWidth,
 		displayValue,

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -15,6 +15,11 @@
 		width: 100% !important;
 		max-width: 100% !important;
 	}
+
+	span.maxi-block-anchor {
+		position: absolute;
+		top: 0;
+	}
 }
 
 .maxi-link-wrapper {

--- a/src/extensions/styles/defaults/global.js
+++ b/src/extensions/styles/defaults/global.js
@@ -22,6 +22,7 @@ const global = {
 	},
 	extraID: {
 		type: 'string',
+		default: '',
 	},
 	isFirstOnHierarchy: {
 		type: 'boolean',

--- a/src/extensions/styles/defaults/global.js
+++ b/src/extensions/styles/defaults/global.js
@@ -20,6 +20,9 @@ const global = {
 		type: 'string',
 		default: '',
 	},
+	extraID: {
+		type: 'string',
+	},
 	isFirstOnHierarchy: {
 		type: 'boolean',
 	},

--- a/src/extensions/styles/defaults/global.js
+++ b/src/extensions/styles/defaults/global.js
@@ -20,7 +20,7 @@ const global = {
 		type: 'string',
 		default: '',
 	},
-	extraID: {
+	anchorLink: {
 		type: 'string',
 		default: '',
 	},

--- a/src/extensions/styles/test/getGroupAttributes.js
+++ b/src/extensions/styles/test/getGroupAttributes.js
@@ -4,6 +4,7 @@ const attributes = {
 	blockStyleBackground: 1,
 	defaultBlockStyle: 'maxi-def-light',
 	extraClassName: '',
+	extraID: '',
 	customLabel: 'Button',
 	fullWidth: 'normal',
 	buttonContent: '',

--- a/src/extensions/styles/test/getGroupAttributes.js
+++ b/src/extensions/styles/test/getGroupAttributes.js
@@ -4,7 +4,7 @@ const attributes = {
 	blockStyleBackground: 1,
 	defaultBlockStyle: 'maxi-def-light',
 	extraClassName: '',
-	extraID: '',
+	anchorLink: '',
 	customLabel: 'Button',
 	fullWidth: 'normal',
 	buttonContent: '',


### PR DESCRIPTION
I'm not a fan of changing the actual id of the block to something custom, because we use that uniqueID a lot (style generation, etc.).

Since we need the extra id setting mostly for anchors, here is a test implementation that adds an empty span with the extra id. 