### PR TITLE
Issue 2339 - Bottom resizer handle styles on hover

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -129,10 +129,7 @@ class edit extends MaxiBlockComponent {
 				}}
 				showHandle={isSelected}
 				enable={{
-					bottom: true,
-					top: true,
-					left: true,
-					right: true
+					bottom: true
 				}}
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}

--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -130,6 +130,9 @@ class edit extends MaxiBlockComponent {
 				showHandle={isSelected}
 				enable={{
 					bottom: true,
+					top: true,
+					left: true,
+					right: true
 				}}
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -24,6 +24,8 @@ body.maxi-blocks--active .maxi-block__resizer {
 					top: -10px;
 					left: 0px;
 					border-bottom: 1px solid var(--maxi-primary-color);
+					border-left: 0;
+					border-right: 0;
 				}
 			}
 			&-right {
@@ -32,6 +34,8 @@ body.maxi-blocks--active .maxi-block__resizer {
 					top: 0;
 					right: -10px !important;
 					border-left: 1px solid var(--maxi-primary-color);
+					border-top: 0;
+					border-bottom: 0;
 				}
 			}
 			&-bottom {
@@ -40,6 +44,8 @@ body.maxi-blocks--active .maxi-block__resizer {
 					bottom: -10px;
 					left: 0px;
 					border-top: 1px solid var(--maxi-primary-color);
+					border-left: 0;
+					border-right: 0;
 				}
 			}
 			&-left {
@@ -48,6 +54,8 @@ body.maxi-blocks--active .maxi-block__resizer {
 					top: 0;
 					left: -10px;
 					border-right: 1px solid var(--maxi-primary-color);
+					border-top: 0;
+					border-bottom: 0;
 				}
 			}
 			&-topleft {

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -22,35 +22,68 @@ body.maxi-blocks--active .maxi-block__resizer {
 				top: 0 !important;
 				&:before {
 					top: -10px;
-					left: -10px !important;
-					transform: rotate(45deg) !important;
-					border-right: 10px solid var(--maxi-primary-color);
-					border-bottom: 10px solid transparent !important;
+					left: 0px;
+					border-bottom: 1px solid var(--maxi-primary-color);
 				}
 			}
 			&-right {
 				right: 0 !important;
 				&:before {
-					left: 10px !important;
-					transform: rotate(-225deg) !important;
+					top: 0;
+					right: -10px !important;
+					border-left: 1px solid var(--maxi-primary-color);
 				}
 			}
 			&-bottom {
 				bottom: 0 !important;
 				&:before {
-					bottom: 0px;
+					bottom: -10px;
 					left: 0px;
-					border-bottom: 5px solid var(--maxi-primary-color);
-					border-left: 0;
-					border-right: 0;
+					border-top: 1px solid var(--maxi-primary-color);
 				}
 			}
 			&-left {
 				left: 0 !important;
 				&:before {
+					top: 0;
 					left: -10px;
-					transform: rotate(-135deg);
+					border-right: 1px solid var(--maxi-primary-color);
+				}
+			}
+			&-topleft {
+				left: 0 !important;
+				&:before {
+					left: 0;
+					border-top: 10px solid var(--maxi-primary-color);
+					top: 5px;
+					border-left: 10px solid var(--maxi-primary-color);
+				}
+			}
+			&-topright {
+				right: 0 !important;
+				&:before {
+					right: 0;
+					border-top: 10px solid var(--maxi-primary-color);
+					top: 5px;
+					border-right: 10px solid var(--maxi-primary-color);
+				}
+			}
+			&-bottomleft {
+				left: 0 !important;
+				&:before {
+					left: 0;
 					border-bottom: 10px solid var(--maxi-primary-color);
+					bottom: 5px;
+					border-left: 10px solid var(--maxi-primary-color);
+				}
+			}
+			&-bottomright {
+				right: 0 !important;
+				&:before {
+					right: 0;
+					border-bottom: 10px solid var(--maxi-primary-color);
+					bottom: 5px;
+					border-right: 10px solid var(--maxi-primary-color);
 				}
 			}
 		}
@@ -61,7 +94,6 @@ body.maxi-blocks--active .maxi-block__resizer {
 				&:active,
 				&:hover {
 					&:before {
-						animation: horiz-line-motion 0.1s ease-out 0s;
 						opacity: 1 !important;
 					}
 				}
@@ -76,7 +108,6 @@ body.maxi-blocks--active .maxi-block__resizer {
 				&:active,
 				&:hover {
 					&:before {
-						animation: vert-line-motion 0.1s ease-out 0s;
 						opacity: 1 !important;
 					}
 				}

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -38,10 +38,11 @@ body.maxi-blocks--active .maxi-block__resizer {
 			&-bottom {
 				bottom: 0 !important;
 				&:before {
-					top: 10px;
-					left: 10px;
-					transform: rotate(-225deg);
-					border-bottom: 10px solid var(--maxi-primary-color);
+					bottom: 0px;
+					left: 0px;
+					border-bottom: 5px solid var(--maxi-primary-color);
+					border-left: 0;
+					border-right: 0;
 				}
 			}
 			&-left {

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -99,8 +99,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						handleClassName,
 						showHandlesClassName,
 						cornerHandleClassName,
-						'maxi-resizable__handle-top',
-						'maxi-resizable__handle-left'
+						'maxi-resizable__handle-topleft'
 					),
 				topRight:
 					enable.topRight &&
@@ -108,8 +107,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						handleClassName,
 						showHandlesClassName,
 						cornerHandleClassName,
-						'maxi-resizable__handle-top',
-						'maxi-resizable__handle-right'
+						'maxi-resizable__handle-topright'
 					),
 				bottomRight:
 					enable.bottomRight &&
@@ -117,8 +115,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						handleClassName,
 						showHandlesClassName,
 						cornerHandleClassName,
-						'maxi-resizable__handle-bottom',
-						'maxi-resizable__handle-right'
+						'maxi-resizable__handle-bottomright'
 					),
 				bottomLeft:
 					enable.bottomLeft &&
@@ -126,8 +123,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						handleClassName,
 						showHandlesClassName,
 						cornerHandleClassName,
-						'maxi-resizable__handle-bottom',
-						'maxi-resizable__handle-left'
+						'maxi-resizable__handle-bottomleft'
 					),
 			}}
 		>


### PR DESCRIPTION
Fixes #2339 

Bottom resizer had a weird animation on hover. I've made it a horizontal line instead, that looks better.

I'm aware this change affects all blocks; however, I can't find any other block using the bottom handle, and Divider seems to be the only block.