### PR TITLE
Issue 2353 - Close sidebar

### DIFF
--- a/src/css/inserter-card.scss
+++ b/src/css/inserter-card.scss
@@ -1,13 +1,6 @@
 /***********
 * Block card
 ***********/
-.interface-interface-skeleton__sidebar {
-	width: 295px;
-	overflow-x: hidden;
-}
-.interface-complementary-area {
-	width: 100%;
-}
 .maxi-sidebar {
 	.block-editor-block-icon {
 		flex: 0;


### PR DESCRIPTION
Fixes #2353

Removed part of CSS I think is not necessary that was affecting the width of the sidebar and affecting not just other plugins, also WP. Checked and didn't find a difference 👍 