### PR TITLE
Issue 2382 - Fixed clip-path styling

### DIFF
--- a/src/components/clip-path-control/editor.scss
+++ b/src/components/clip-path-control/editor.scss
@@ -118,6 +118,7 @@
 	.maxi-clip-path-visual-editor {
 		position: relative;
 		width: 100%;
+		margin: 5px 0px;
 		min-height: 291px;
 
 		&__preview {


### PR DESCRIPTION
 Fixes #2382 
Added simple margin to create spacing. This seems to be working well,