### PR TITLE
Issue 2362

### DIFF
--- a/src/blocks/column-maxi/edit.js
+++ b/src/blocks/column-maxi/edit.js
@@ -93,6 +93,12 @@ class edit extends MaxiBlockComponent {
 					].indexOf(blockName) === -1
 			);
 
+		const getIsOverflowHidden = () =>
+			getLastBreakpointAttribute('overflow-y', deviceType, attributes) ===
+				'hidden' &&
+			getLastBreakpointAttribute('overflow-x', deviceType, attributes) ===
+				'hidden';
+
 		return [
 			<RowContext.Consumer key={`column-content-${uniqueID}`}>
 				{context => {
@@ -114,6 +120,7 @@ class edit extends MaxiBlockComponent {
 								key={`maxi-column--${uniqueID}`}
 								ref={this.blockRef}
 								{...getMaxiBlockBlockAttributes(this.props)}
+								isOverflowHidden={getIsOverflowHidden()}
 								disableMotion
 								tagName={BlockResizer}
 								resizableObject={this.resizableObject}

--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -101,6 +101,12 @@ class edit extends MaxiBlockComponent {
 			...(position && { position }),
 		};
 
+		const getIsOverflowHidden = () =>
+			getLastBreakpointAttribute('overflow-y', deviceType, attributes) ===
+				'hidden' &&
+			getLastBreakpointAttribute('overflow-x', deviceType, attributes) ===
+				'hidden';
+
 		return [
 			<Inspector key={`block-settings-${uniqueID}`} {...this.props} />,
 			<Toolbar
@@ -115,6 +121,7 @@ class edit extends MaxiBlockComponent {
 				classes={classes}
 				{...getMaxiBlockBlockAttributes(this.props)}
 				tagName={BlockResizer}
+				isOverflowHidden={getIsOverflowHidden()}
 				size={{
 					width: '100%',
 					height: `${attributes[`height-${deviceType}`]}${
@@ -129,7 +136,7 @@ class edit extends MaxiBlockComponent {
 				}}
 				showHandle={isSelected}
 				enable={{
-					bottom: true
+					bottom: true,
 				}}
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -12,7 +12,10 @@ import { createRef } from '@wordpress/element';
  */
 import getStyles from './styles';
 import Inspector from './inspector';
-import { getGroupAttributes } from '../../extensions/styles';
+import {
+	getGroupAttributes,
+	getLastBreakpointAttribute,
+} from '../../extensions/styles';
 import MaxiBlock, {
 	getMaxiBlockBlockAttributes,
 } from '../../components/maxi-block';
@@ -58,6 +61,7 @@ class edit extends MaxiBlockComponent {
 		};
 
 		this.textRef = createRef(null);
+		this.resizableObject = createRef();
 	}
 
 	propsToAvoidRendering = ['formatValue'];
@@ -89,8 +93,14 @@ class edit extends MaxiBlockComponent {
 	}
 
 	render() {
-		const { attributes, imageData, setAttributes, clientId, isSelected } =
-			this.props;
+		const {
+			attributes,
+			imageData,
+			setAttributes,
+			clientId,
+			isSelected,
+			deviceType,
+		} = this.props;
 		const {
 			'hover-preview': hoverPreview,
 			'hover-type': hoverType,
@@ -196,6 +206,12 @@ class edit extends MaxiBlockComponent {
 			}
 		};
 
+		const getIsOverflowHidden = () =>
+			getLastBreakpointAttribute('overflow-y', deviceType, attributes) ===
+				'hidden' &&
+			getLastBreakpointAttribute('overflow-x', deviceType, attributes) ===
+				'hidden';
+
 		return [
 			<Inspector
 				key={`block-settings-${uniqueID}`}
@@ -262,6 +278,8 @@ class edit extends MaxiBlockComponent {
 									<BlockResizer
 										key={uniqueID}
 										className='maxi-block__resizer maxi-image-block__resizer'
+										resizableObject={this.resizableObject}
+										isOverflowHidden={getIsOverflowHidden()}
 										size={{ width: `${imgWidth}%` }}
 										showHandle={isSelected}
 										maxWidth='100%'

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -333,77 +333,76 @@ const getStyles = props => {
 	const { uniqueID } = props;
 
 	const response = {
-		[uniqueID]: stylesCleaner({
-			'': getWrapperObject(props),
-			':hover': getHoverWrapperObject(props),
-			' .maxi-image-block-wrapper': getImageWrapperObject(props),
-			':hover .maxi-image-block-wrapper':
-				getHoverImageWrapperObject(props),
-			' .maxi-image-block-wrapper > svg:first-child': getImageShapeObject(
-				'svg',
-				props
-			),
-			' .maxi-image-block-wrapper > svg:first-child pattern image':
-				getImageShapeObject('image', props),
-			' .maxi-image-block-wrapper img': getImageObject(props),
-			' figcaption': getFigcaptionObject(props),
-			' .maxi-hover-details .maxi-hover-details__content h4':
-				getHoverEffectTitleTextObject(props),
-			' .maxi-hover-details .maxi-hover-details__content p':
-				getHoverEffectContentTextObject(props),
-			' .maxi-hover-details': getHoverEffectDetailsBoxObject(props),
-			...getBlockBackgroundStyles({
-				...getGroupAttributes(props, [
-					'blockBackground',
-					'border',
-					'borderWidth',
-					'borderRadius',
-				]),
-				blockStyle: props.parentBlockStyle,
-			}),
-			...getBlockBackgroundStyles({
-				...getGroupAttributes(
-					props,
-					[
+		[uniqueID]: stylesCleaner(
+			{
+				'': getWrapperObject(props),
+				':hover': getHoverWrapperObject(props),
+				' .maxi-image-block-wrapper': getImageWrapperObject(props),
+				':hover .maxi-image-block-wrapper':
+					getHoverImageWrapperObject(props),
+				' .maxi-image-block-wrapper > svg:first-child':
+					getImageShapeObject('svg', props),
+				' .maxi-image-block-wrapper > svg:first-child pattern image':
+					getImageShapeObject('image', props),
+				' .maxi-image-block-wrapper img': getImageObject(props),
+				' figcaption': getFigcaptionObject(props),
+				' .maxi-hover-details .maxi-hover-details__content h4':
+					getHoverEffectTitleTextObject(props),
+				' .maxi-hover-details .maxi-hover-details__content p':
+					getHoverEffectContentTextObject(props),
+				' .maxi-hover-details': getHoverEffectDetailsBoxObject(props),
+				...getBlockBackgroundStyles({
+					...getGroupAttributes(props, [
 						'blockBackground',
 						'border',
 						'borderWidth',
 						'borderRadius',
-					],
-					true
+					]),
+					blockStyle: props.parentBlockStyle,
+				}),
+				...getBlockBackgroundStyles({
+					...getGroupAttributes(
+						props,
+						[
+							'blockBackground',
+							'border',
+							'borderWidth',
+							'borderRadius',
+						],
+						true
+					),
+					isHover: true,
+					blockStyle: props.parentBlockStyle,
+				}),
+				...getCustomFormatsStyles(
+					' .maxi-image-block__caption',
+					props['custom-formats'],
+					false,
+					{ ...getGroupAttributes(props, 'typography') },
+					'p',
+					props.parentBlockStyle
 				),
-				isHover: true,
-				blockStyle: props.parentBlockStyle,
-			}),
-			...getCustomFormatsStyles(
-				' .maxi-image-block__caption',
-				props['custom-formats'],
-				false,
-				{ ...getGroupAttributes(props, 'typography') },
-				'p',
-				props.parentBlockStyle
-			),
-			...getCustomFormatsStyles(
-				':hover .maxi-image-block__caption',
-				props['custom-formats-hover'],
-				true,
-				getGroupAttributes(props, 'typographyHover'),
-				'p',
-				props.parentBlockStyle
-			),
-			...getLinkStyles(
-				{ ...getGroupAttributes(props, 'link') },
-				[' a figcaption.maxi-image-block__caption'],
-				props.parentBlockStyle
-			),
-			...getLinkStyles(
-				{ ...getGroupAttributes(props, 'link') },
-				[' figcaption.maxi-image-block__caption a'],
-				props.parentBlockStyle
-			),
-		},
-		selectorsImage,
-		props
+				...getCustomFormatsStyles(
+					':hover .maxi-image-block__caption',
+					props['custom-formats-hover'],
+					true,
+					getGroupAttributes(props, 'typographyHover'),
+					'p',
+					props.parentBlockStyle
+				),
+				...getLinkStyles(
+					{ ...getGroupAttributes(props, 'link') },
+					[' a figcaption.maxi-image-block__caption'],
+					props.parentBlockStyle
+				),
+				...getLinkStyles(
+					{ ...getGroupAttributes(props, 'link') },
+					[' figcaption.maxi-image-block__caption a'],
+					props.parentBlockStyle
+				),
+			},
+			selectorsImage,
+			props
 		),
 	};
 

--- a/src/blocks/number-counter-maxi/edit.js
+++ b/src/blocks/number-counter-maxi/edit.js
@@ -98,6 +98,12 @@ const NumberCounter = attributes => {
 		stroke,
 	]);
 
+	const getIsOverflowHidden = () =>
+		getLastBreakpointAttribute('overflow-y', deviceType, attributes) ===
+			'hidden' &&
+		getLastBreakpointAttribute('overflow-x', deviceType, attributes) ===
+			'hidden';
+
 	return (
 		<>
 			<Button
@@ -111,6 +117,7 @@ const NumberCounter = attributes => {
 			/>
 			<BlockResizer
 				className='maxi-number-counter__box'
+				isOverflowHidden={getIsOverflowHidden()}
 				lockAspectRatio
 				defaultSize={{
 					width: `${getLastBreakpointAttribute(

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -122,6 +122,12 @@ class edit extends MaxiBlockComponent {
 			});
 		};
 
+		const getIsOverflowHidden = () =>
+			getLastBreakpointAttribute('overflow-y', deviceType, attributes) ===
+				'hidden' &&
+			getLastBreakpointAttribute('overflow-x', deviceType, attributes) ===
+				'hidden';
+
 		return [
 			!isEmptyContent && (
 				<Inspector
@@ -159,6 +165,7 @@ class edit extends MaxiBlockComponent {
 						<BlockResizer
 							className='maxi-svg-icon-block__icon'
 							resizableObject={this.resizableObject}
+							isOverflowHidden={getIsOverflowHidden()}
 							lockAspectRatio
 							maxWidth={
 								getLastBreakpointAttribute(

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -8,90 +8,56 @@ body.maxi-blocks--active .maxi-block__resizer {
 			&--show {
 				display: block;
 			}
+			&:after {
+				content: '';
+				display: block;
+				position: absolute;
+				top: calc(50% - #{ceil(15px / 2)});
+				right: calc(50% - #{ceil(15px / 2)});
+				width: 15px;
+				height: 15px;
+				border: 2px solid #fff;
+				border-radius: 50%;
+				background: #ff4a17;
+				cursor: inherit;
+			}
 			&:before {
 				content: '';
 				display: block;
 				cursor: inherit;
 				position: absolute;
-				border-top: 10px solid transparent;
-				border-right: 10px solid transparent;
-				border-bottom: 10px solid transparent;
-				border-left: 10px solid transparent;
-			}
-			&-top {
-				top: 0 !important;
-				&:before {
-					top: -10px;
-					left: 0px;
-					border-bottom: 1px solid var(--maxi-primary-color);
-					border-left: 0;
-					border-right: 0;
-				}
+				background: #ff4a17;
 			}
 			&-right {
-				right: 0 !important;
 				&:before {
-					top: 0;
-					right: -10px !important;
-					border-left: 1px solid var(--maxi-primary-color);
-					border-top: 0;
-					border-bottom: 0;
-				}
-			}
-			&-bottom {
-				bottom: 0 !important;
-				&:before {
-					bottom: -10px;
-					left: 0px;
-					border-top: 1px solid var(--maxi-primary-color);
-					border-left: 0;
-					border-right: 0;
+					top: 50%;
+					right: calc(50% - 2px);
+					transform: translateY(-50%);
+					width: 4px;
 				}
 			}
 			&-left {
-				left: 0 !important;
 				&:before {
-					top: 0;
-					left: -10px;
-					border-right: 1px solid var(--maxi-primary-color);
-					border-top: 0;
-					border-bottom: 0;
+					top: 50%;
+					left: calc(50% - 2px);
+					transform: translateY(-50%);
+					width: 4px;
 				}
 			}
-			&-topleft {
-				left: 0 !important;
+			&-top {
 				&:before {
-					left: 0;
-					border-top: 10px solid var(--maxi-primary-color);
-					top: 5px;
-					border-left: 10px solid var(--maxi-primary-color);
+					top: calc(50% - 2px);
+					left: 50%;
+					transform: translateX(-50%);
+					height: 4px;
 				}
 			}
-			&-topright {
-				right: 0 !important;
+			&-bottom {
 				&:before {
-					right: 0;
-					border-top: 10px solid var(--maxi-primary-color);
-					top: 5px;
-					border-right: 10px solid var(--maxi-primary-color);
-				}
-			}
-			&-bottomleft {
-				left: 0 !important;
-				&:before {
-					left: 0;
-					border-bottom: 10px solid var(--maxi-primary-color);
-					bottom: 5px;
-					border-left: 10px solid var(--maxi-primary-color);
-				}
-			}
-			&-bottomright {
-				right: 0 !important;
-				&:before {
-					right: 0;
-					border-bottom: 10px solid var(--maxi-primary-color);
-					bottom: 5px;
-					border-right: 10px solid var(--maxi-primary-color);
+					bottom: calc(50% - 2px);
+					left: 50%;
+					transform: translateX(-50%);
+					height: 4px;
 				}
 			}
 		}
@@ -102,6 +68,7 @@ body.maxi-blocks--active .maxi-block__resizer {
 				&:active,
 				&:hover {
 					&:before {
+						animation: horiz-line-motion 0.1s ease-out 0s;
 						opacity: 1 !important;
 					}
 				}
@@ -116,12 +83,89 @@ body.maxi-blocks--active .maxi-block__resizer {
 				&:active,
 				&:hover {
 					&:before {
+						animation: vert-line-motion 0.1s ease-out 0s;
 						opacity: 1 !important;
 					}
 				}
 				&:before {
 					height: 100%;
 					opacity: 0;
+				}
+			}
+		}
+	}
+	&--overflow {
+		.maxi-resizable__handle {
+			&:after {
+				top: 0;
+				right: 0;
+				bottom: 0;
+				left: 0;
+				margin: auto;
+			}
+
+			&-top {
+				top: 0 !important;
+
+				&:after {
+					margin-top: 0;
+				}
+			}
+			&-right {
+				right: 0 !important;
+
+				&:after {
+					margin-right: 0;
+				}
+			}
+			&-left {
+				left: 0 !important;
+
+				&:after {
+					margin-left: 0;
+				}
+			}
+			&-bottom {
+				bottom: 0 !important;
+
+				&:after {
+					margin-bottom: 0;
+				}
+			}
+			&-topleft {
+				top: 0 !important;
+				left: 0 !important;
+
+				&:after {
+					margin-top: 0;
+					margin-left: 0;
+				}
+			}
+			&-topright {
+				top: 0 !important;
+				right: 0 !important;
+
+				&:after {
+					margin-top: 0;
+					margin-right: 0;
+				}
+			}
+			&-bottomleft {
+				bottom: 0 !important;
+				left: 0 !important;
+
+				&:after {
+					margin-bottom: 0;
+					margin-left: 0;
+				}
+			}
+			&-bottomright {
+				bottom: 0 !important;
+				right: 0 !important;
+
+				&:after {
+					margin-bottom: 0;
+					margin-right: 0;
 				}
 			}
 		}

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -23,10 +23,15 @@ const BlockResizer = forwardRef((props, ref) => {
 		className,
 		showHandle = false,
 		resizableObject,
+		isOverflowHidden = false,
 		...rest
 	} = props;
 
-	const classes = classnames('maxi-block__resizer', className);
+	const classes = classnames(
+		'maxi-block__resizer',
+		isOverflowHidden && 'maxi-block__resizer--overflow',
+		className
+	);
 	const cornerHandleClassName = 'maxi-resizable__corner-handle';
 	const handleClassName = 'maxi-resizable__handle';
 	const showHandlesClassName = showHandle && 'maxi-resizable__handle--show';


### PR DESCRIPTION
Fixes #3262

Based on @kyrapieterse mock, came back to the circle resizable handles:
![image (15)](https://user-images.githubusercontent.com/50477222/145221648-5c34d2a8-2264-4e93-a818-3a002acfa2a8.png)

So, what finally made is, came back to original circle cicles, and in case the block becomes `overflow: hidden` from creators, the handles came into the element:

https://user-images.githubusercontent.com/50477222/145221841-afe35457-d072-47f7-991d-9a9212c5ed4e.mp4

Affects: Image, SVG, Divider, Number Counter and Column 👍 