### PR TITLE
Issue 2399 - Themes CSS overridding

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -36,3 +36,9 @@ body.maxi-blocks--active .maxi-block {
 body.maxi-blocks--active .maxi-block[data-align="full"] {
 	width: auto;
 }
+
+/*Fixes button hover border and underline for Twenty Twenty One & Twenty Twenty*/
+body.maxi-blocks--active .maxi-button-block__button {
+	border: none;
+	text-decoration: none;
+}

--- a/src/extensions/text/fonts/fonts.js
+++ b/src/extensions/text/fonts/fonts.js
@@ -7751,6 +7751,30 @@ const fontsJSON = {
         "files": {
             "400": "https://fonts.gstatic.com/s/bahianita/v2/yYLr0hTb3vuqqsBUgxWtxTvV2NJPcA.ttf"
         }
+    },
+    "Marcellus": {
+        "value": "Marcellus",
+        "files": {
+            "400": "http://fonts.gstatic.com/s/marcellus/v4/UjiLZzumxWC9whJ86UtaYw.ttf"
+        }
+    },
+    "Karla": {
+        "value": "Karla",
+        "files": {
+            "400": "http://fonts.gstatic.com/s/karla/v5/78UgGRwJFkhqaoFimqoKpQ.ttf"
+        }
+    },
+     "Proza Libre": {
+        "value": "Proza Libre",
+        "files": {
+            "400": "http://fonts.gstatic.com/s/prozalibre/v1/Hg11OrfE1P_U6mKmrZPknKCWcynf_cDxXwCLxiixG1c.ttf"
+        }
+    },
+    "Muli": {
+        "value": "Muli",
+        "files": {
+            "400": "http://fonts.gstatic.com/s/muli/v10/KJiP6KznxbALQgfJcDdPAw.ttf"
+        }
     }
 };
 

--- a/src/extensions/text/fonts/fonts.js
+++ b/src/extensions/text/fonts/fonts.js
@@ -7751,30 +7751,6 @@ const fontsJSON = {
         "files": {
             "400": "https://fonts.gstatic.com/s/bahianita/v2/yYLr0hTb3vuqqsBUgxWtxTvV2NJPcA.ttf"
         }
-    },
-    "Marcellus": {
-        "value": "Marcellus",
-        "files": {
-            "400": "http://fonts.gstatic.com/s/marcellus/v4/UjiLZzumxWC9whJ86UtaYw.ttf"
-        }
-    },
-    "Karla": {
-        "value": "Karla",
-        "files": {
-            "400": "http://fonts.gstatic.com/s/karla/v5/78UgGRwJFkhqaoFimqoKpQ.ttf"
-        }
-    },
-     "Proza Libre": {
-        "value": "Proza Libre",
-        "files": {
-            "400": "http://fonts.gstatic.com/s/prozalibre/v1/Hg11OrfE1P_U6mKmrZPknKCWcynf_cDxXwCLxiixG1c.ttf"
-        }
-    },
-    "Muli": {
-        "value": "Muli",
-        "files": {
-            "400": "http://fonts.gstatic.com/s/muli/v10/KJiP6KznxbALQgfJcDdPAw.ttf"
-        }
     }
 };
 


### PR DESCRIPTION
Fixes #2399

- Added a CSS code to override default hover border in Twenty Twenty One theme, and text underline on hover in Twenty Twenty Theme.