### PR TITLE
Issue 2454 Button default size value

### DIFF
--- a/src/blocks/button-maxi/attributes.js
+++ b/src/blocks/button-maxi/attributes.js
@@ -63,6 +63,10 @@ const attributes = {
 	...attributesData.textAlignment,
 	...{
 		...attributesData.typography,
+		'font-size-general': {
+			type: 'number',
+			default: '16',
+		},
 		'line-height-unit-general': {
 			type: 'string',
 			default: '%',


### PR DESCRIPTION
Fixes #2454 
- Updated attributes.js and added an attribute for the default button size.