### PR TITLE
Issue 2503

### DIFF
--- a/src/extensions/styles/getBlockStyle.js
+++ b/src/extensions/styles/getBlockStyle.js
@@ -20,9 +20,13 @@ const getBlockStyle = clientId => {
 		getBlockHierarchyRootClientId,
 		getBlockAttributes,
 		getSelectedBlockClientId,
+		getFirstMultiSelectedBlockClientId,
 	} = select('core/block-editor');
 
-	const id = clientId || getSelectedBlockClientId();
+	const id =
+		clientId ||
+		getSelectedBlockClientId() ||
+		getFirstMultiSelectedBlockClientId();
 
 	const { blockStyle: currentBlockStyle } = getBlockAttributes(id);
 


### PR DESCRIPTION
Fixes #2503

In case the block style is required in multiple blocks, the first block style is the one that will prevale. 

This PR prevents blocks to don't break when select more than one, but this issue shows we need to fix some situations where more than one block is selected, I'll create a new issue for it 👍 but for the moment consider that testing BackgroundControl is going to be buggy (not going to break, but what shows is not correct)