### PR TITLE
Issue 2604 Twenty Nineteen Backend Container Alignment

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -42,3 +42,8 @@ body.maxi-blocks--active .maxi-button-block__button {
 	border: none;
 	text-decoration: none;
 }
+
+/*Fixes container alignment for Twenty Nineteen*/
+body.maxi-blocks--active .maxi-container-block.wp-block.maxi-block.maxi-block--backend {
+	left: auto;
+}

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -49,12 +49,12 @@ body.maxi-blocks--active .maxi-container-block.wp-block.maxi-block.maxi-block--b
 }
 
 /*Fixes container alignment for Twenty Twenty Two*/
-body.maxi-blocks--active .block-editor-block-list__layout.is-root-container .maxi-block[data-align="full"] {
+body.maxi-blocks--active #wpcontent .block-editor-block-list__layout.is-root-container .maxi-block[data-align="full"] {
 	margin: 0 auto !important;
 }
-body.maxi-blocks--active .is-root-container {
-	padding: 0 !important;
+body.maxi-blocks--active #wpcontent .is-root-container {
+	padding: 0;
 }
-body.maxi-blocks--active .editor-styles-wrapper {
-	padding: 5px !important;
+body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
+	padding: 5px;
 }

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -47,3 +47,14 @@ body.maxi-blocks--active .maxi-button-block__button {
 body.maxi-blocks--active .maxi-container-block.wp-block.maxi-block.maxi-block--backend {
 	left: auto;
 }
+
+/*Fixes container alignment for Twenty Twenty Two*/
+body.maxi-blocks--active .block-editor-block-list__layout.is-root-container .maxi-block[data-align="full"] {
+	margin: 0 auto !important;
+}
+body.maxi-blocks--active .is-root-container {
+	padding: 0 !important;
+}
+body.maxi-blocks--active .editor-styles-wrapper {
+	padding: 5px !important;
+}


### PR DESCRIPTION
Fixes #2604 
- Twenty Nineteen was adding a weird left value for the container. Made it auto.
- Tested if changing container position work from the transform option, and it does. Also, it works on other themes.
- Twenty Twenty Two has a similar issue. Should I also fix it here, or in a new PR?