### PR TITLE
Updated appender z-index

### DIFF
--- a/src/blocks/row-maxi/editor.scss
+++ b/src/blocks/row-maxi/editor.scss
@@ -16,7 +16,7 @@
 		max-width: none;
 		margin: 0;
 		padding: 0;
-		z-index: 1;
+		z-index: 9999;
 	}
 
 	&__template {


### PR DESCRIPTION
Fixes #2473 and #2044 (they are double I think)
- Simply changed from 1 to 9999 currently. That's the max z-index you can choose for a block. Wanted to ensure that the appender stays visible no matter the block's z-index.