### PR TITLE
Issue 2517 - Frontend script load error with ScrollEffects

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -78,7 +78,7 @@ class MaxiBlocks_Styles
                         plugins_url($jsScriptPath, dirname(__FILE__)),
                     );
 
-                    wp_localize_script($jsScriptName, $jsVarToPass, $meta);
+                    wp_localize_script($jsScriptName, $jsVarToPass, [$meta]);
                 }
             }
         }


### PR DESCRIPTION
Fixes: #2517 
More about wp_localize_script :  https://developer.wordpress.org/reference/functions/wp_localize_script/
**How to test** 
- Add Maxi block then add scrollEffect to it, in frontend should not produce any php Notice or Error