### PR TITLE
Add link options to be copy/pasted

### DIFF
--- a/src/components/toolbar/components/copy-paste/index.js
+++ b/src/components/toolbar/components/copy-paste/index.js
@@ -55,6 +55,7 @@ const ATTRIBUTES = [
 	'columnSize',
 	'display',
 	'divider',
+	'link',
 	'margin',
 	'motion',
 	'opacity',
@@ -64,9 +65,9 @@ const ATTRIBUTES = [
 	'size',
 	'textAlignment',
 	'transform',
+	'transitionDuration',
 	'typography',
 	'typographyHover',
-	'transitionDuration',
 	'zIndex',
 ];
 const WRAPPER_BLOCKS = [


### PR DESCRIPTION
Copy and paste of link options inside `Typography` accordion was not working. Now it should 👍 