### PR TITLE
Issue 2636 - Focus bg Twenty Twenty One

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -49,6 +49,11 @@ body.maxi-blocks--active
 	left: auto;
 }
 
+/*Removes focus bacgkround for Twenty Twenty One*/
+#content .maxi-link-wrapper:focus {
+	background: unset;
+}
+
 /*Fixes container alignment for Twenty Twenty Two*/
 body.maxi-blocks--active
 	#wpcontent

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -50,7 +50,8 @@ body.maxi-blocks--active
 }
 
 /*Removes focus bacgkround for Twenty Twenty One*/
-#content .maxi-link-wrapper:focus {
+body.maxi-blocks--active #content .maxi-text-block--link:focus,
+body.maxi-blocks--active #content .maxi-link-wrapper:focus {
 	background: unset;
 }
 


### PR DESCRIPTION
Fixes #2636 

- Updated maxi-themes-banner.css. Made :focus background _unset_ for maxi-link-wrapper elements.