### PR TITLE
Issue 2449 - Sidebar overlapping in Firefox by horizontal scrollbar and sidebar horizontal overflow

### DIFF
--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -15,6 +15,7 @@
 ******************/
 .interface-interface-skeleton__sidebar {
 	overflow-x: hidden;
+	scrollbar-gutter: stable;
 }
 h2.gx_error {
 	font-size: 16px;


### PR DESCRIPTION
#2449 was fixed in #2559.
No sidebar x-overflow in different browsers.

Also found error in Firefox where sidebar was overlapped by horizontal scrollbar. Fixed it also.
Before:
![image](https://user-images.githubusercontent.com/46112160/158415377-e89357e0-0c98-4e85-93ff-17073e519bbf.png)

After:
![image](https://user-images.githubusercontent.com/46112160/158415490-38844fb8-117b-4e9b-8f8b-67614de74146.png)
