### PR TITLE
Issue 2420 - Added limits on the range in AdvancedNumberControl

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -55,32 +55,54 @@ const AdvancedNumberControl = props => {
 			px: {
 				min: 0,
 				max: 3999,
-				minRange: 0,
+				minRange: -1999,
 				maxRange: 1999,
 			},
 			em: {
 				min: 0,
 				max: 999,
-				minRange: 0,
+				minRange: -199,
 				maxRange: 199,
 			},
 			vw: {
 				min: 0,
 				max: 999,
-				minRange: 0,
+				minRange: -199,
 				maxRange: 199,
 			},
 			'%': {
 				min: 0,
 				max: 100,
-				minRange: 0,
+				minRange: -100,
 				maxRange: 100,
 			},
 			'-': {
 				min: 0,
 				max: 16,
-				minRange: 0,
+				minRange: -16,
 				maxRange: 16,
+			},
+		},
+		minMaxRangeSettings = {
+			px: {
+				min: -1999,
+				max: 1999,
+			},
+			em: {
+				min: -199,
+				max: 199,
+			},
+			vw: {
+				min: -199,
+				max: 199,
+			},
+			'%': {
+				min: -100,
+				max: 100,
+			},
+			'-': {
+				min: 0,
+				max: 16,
 			},
 		},
 	} = props;
@@ -111,16 +133,16 @@ const AdvancedNumberControl = props => {
 	const maxValue = minMaxSettings[isEmpty(unit) ? '-' : unit]?.max;
 
 	const minValueRange =
-		minMaxSettings[isEmpty(unit) ? '-' : unit]?.minRange < minValue ||
+		minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.min < minValue ||
 		disableInputsLimits
 			? minValue
-			: minMaxSettings[isEmpty(unit) ? '-' : unit]?.minRange;
+			: minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.min;
 
 	const maxValueRange =
-		minMaxSettings[isEmpty(unit) ? '-' : unit]?.maxRange > maxValue ||
+		minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.max > maxValue ||
 		disableInputsLimits
 			? maxValue
-			: minMaxSettings[isEmpty(unit) ? '-' : unit]?.maxRange;
+			: minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.max;
 
 	const getNewValueFromEmpty = e => {
 		const {
@@ -201,9 +223,9 @@ const AdvancedNumberControl = props => {
 							onChange={val => {
 								onChangeUnit(val);
 
-								if (value > minMaxSettings[val]?.maxRange)
+								if (value > minMaxRangeSettings[val]?.max)
 									onChangeValue(
-										minMaxSettings[val]?.maxRange
+										minMaxRangeSettings[val]?.max
 									);
 							}}
 						/>

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -17,7 +17,7 @@ import Button from '../button';
  * External dependencies
  */
 import classnames from 'classnames';
-import { trim, isEmpty, isNumber } from 'lodash';
+import { trim, isEmpty, isNumber, merge } from 'lodash';
 
 /**
  * Styles
@@ -29,6 +29,39 @@ import { getIsValid } from '../../extensions/styles';
 /**
  * Component
  */
+const minMaxSettingsDefault = {
+	px: {
+		min: 0,
+		max: 3999,
+		minRange: -1999,
+		maxRange: 1999,
+	},
+	em: {
+		min: 0,
+		max: 999,
+		minRange: -199,
+		maxRange: 199,
+	},
+	vw: {
+		min: 0,
+		max: 999,
+		minRange: -199,
+		maxRange: 199,
+	},
+	'%': {
+		min: 0,
+		max: 100,
+		minRange: -100,
+		maxRange: 100,
+	},
+	'-': {
+		min: 0,
+		max: 16,
+		minRange: 0,
+		maxRange: 16,
+	},
+};
+
 const AdvancedNumberControl = props => {
 	const {
 		label,
@@ -51,50 +84,7 @@ const AdvancedNumberControl = props => {
 		autoLabel,
 		onReset,
 		allowedUnits = ['px', 'em', 'vw', '%', '-'],
-		minMaxSettings = {
-			px: {
-				min: 0,
-				max: 3999,
-			},
-			em: {
-				min: 0,
-				max: 999,
-			},
-			vw: {
-				min: 0,
-				max: 999,
-			},
-			'%': {
-				min: 0,
-				max: 100,
-			},
-			'-': {
-				min: 0,
-				max: 16,
-			},
-		},
-		minMaxRangeSettings = {
-			px: {
-				min: -1999,
-				max: 1999,
-			},
-			em: {
-				min: -199,
-				max: 199,
-			},
-			vw: {
-				min: -199,
-				max: 199,
-			},
-			'%': {
-				min: -100,
-				max: 100,
-			},
-			'-': {
-				min: 0,
-				max: 16,
-			},
-		},
+		minMaxSettings = minMaxSettingsDefault,
 	} = props;
 
 	const classes = classnames('maxi-advanced-number-control', className);
@@ -119,20 +109,22 @@ const AdvancedNumberControl = props => {
 		return options;
 	};
 
-	const minValue = minMaxSettings[isEmpty(unit) ? '-' : unit]?.min;
-	const maxValue = minMaxSettings[isEmpty(unit) ? '-' : unit]?.max;
+	const minMaxSettingsResult = merge(minMaxSettingsDefault, minMaxSettings);
+
+	const minValue = minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.min;
+	const maxValue = minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.max;
 
 	const minValueRange =
-		minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.min < minValue ||
+		minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.minRange < minValue ||
 		disableInputsLimits
 			? minValue
-			: minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.min;
+			: minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.minRange;
 
 	const maxValueRange =
-		minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.max > maxValue ||
+		minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.maxRange > maxValue ||
 		disableInputsLimits
 			? maxValue
-			: minMaxRangeSettings[isEmpty(unit) ? '-' : unit]?.max;
+			: minMaxSettingsResult[isEmpty(unit) ? '-' : unit]?.maxRange;
 
 	const getNewValueFromEmpty = e => {
 		const {
@@ -213,9 +205,9 @@ const AdvancedNumberControl = props => {
 							onChange={val => {
 								onChangeUnit(val);
 
-								if (value > minMaxRangeSettings[val]?.max)
+								if (value > minMaxSettingsResult[val]?.maxRange)
 									onChangeValue(
-										minMaxRangeSettings[val]?.max
+										minMaxSettingsResult[val]?.maxRange
 									);
 							}}
 						/>

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -55,32 +55,22 @@ const AdvancedNumberControl = props => {
 			px: {
 				min: 0,
 				max: 3999,
-				minRange: -1999,
-				maxRange: 1999,
 			},
 			em: {
 				min: 0,
 				max: 999,
-				minRange: -199,
-				maxRange: 199,
 			},
 			vw: {
 				min: 0,
 				max: 999,
-				minRange: -199,
-				maxRange: 199,
 			},
 			'%': {
 				min: 0,
 				max: 100,
-				minRange: -100,
-				maxRange: 100,
 			},
 			'-': {
 				min: 0,
 				max: 16,
-				minRange: -16,
-				maxRange: 16,
 			},
 		},
 		minMaxRangeSettings = {

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -29,40 +29,40 @@ import { getIsValid } from '../../extensions/styles';
 /**
  * Component
  */
-const minMaxSettingsDefault = {
-	px: {
-		min: 0,
-		max: 3999,
-		minRange: -1999,
-		maxRange: 1999,
-	},
-	em: {
-		min: 0,
-		max: 999,
-		minRange: -199,
-		maxRange: 199,
-	},
-	vw: {
-		min: 0,
-		max: 999,
-		minRange: -199,
-		maxRange: 199,
-	},
-	'%': {
-		min: 0,
-		max: 100,
-		minRange: -100,
-		maxRange: 100,
-	},
-	'-': {
-		min: 0,
-		max: 16,
-		minRange: 0,
-		maxRange: 16,
-	},
-};
-
 const AdvancedNumberControl = props => {
+	const minMaxSettingsDefault = {
+		px: {
+			min: 0,
+			max: 3999,
+			minRange: -1999,
+			maxRange: 1999,
+		},
+		em: {
+			min: 0,
+			max: 999,
+			minRange: -199,
+			maxRange: 199,
+		},
+		vw: {
+			min: 0,
+			max: 999,
+			minRange: -199,
+			maxRange: 199,
+		},
+		'%': {
+			min: 0,
+			max: 100,
+			minRange: -100,
+			maxRange: 100,
+		},
+		'-': {
+			min: 0,
+			max: 16,
+			minRange: 0,
+			maxRange: 16,
+		},
+	};
+
 	const {
 		label,
 		className,

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -38,6 +38,7 @@ const AdvancedNumberControl = props => {
 		placeholder = '',
 		onChangeUnit,
 		enableUnit = false,
+		disableInputsLimits = false,
 		min = 0,
 		max = 999,
 		initial = 0,
@@ -54,22 +55,32 @@ const AdvancedNumberControl = props => {
 			px: {
 				min: 0,
 				max: 3999,
+				minRange: 0,
+				maxRange: 1999,
 			},
 			em: {
 				min: 0,
 				max: 999,
+				minRange: 0,
+				maxRange: 199,
 			},
 			vw: {
 				min: 0,
 				max: 999,
+				minRange: 0,
+				maxRange: 199,
 			},
 			'%': {
 				min: 0,
 				max: 100,
+				minRange: 0,
+				maxRange: 100,
 			},
 			'-': {
 				min: 0,
 				max: 16,
+				minRange: 0,
+				maxRange: 16,
 			},
 		},
 	} = props;
@@ -98,6 +109,18 @@ const AdvancedNumberControl = props => {
 
 	const minValue = minMaxSettings[isEmpty(unit) ? '-' : unit]?.min;
 	const maxValue = minMaxSettings[isEmpty(unit) ? '-' : unit]?.max;
+
+	const minValueRange =
+		minMaxSettings[isEmpty(unit) ? '-' : unit]?.minRange < minValue ||
+		disableInputsLimits
+			? minValue
+			: minMaxSettings[isEmpty(unit) ? '-' : unit]?.minRange;
+
+	const maxValueRange =
+		minMaxSettings[isEmpty(unit) ? '-' : unit]?.maxRange > maxValue ||
+		disableInputsLimits
+			? maxValue
+			: minMaxSettings[isEmpty(unit) ? '-' : unit]?.maxRange;
 
 	const getNewValueFromEmpty = e => {
 		const {
@@ -178,8 +201,10 @@ const AdvancedNumberControl = props => {
 							onChange={val => {
 								onChangeUnit(val);
 
-								if (value > minMaxSettings[val]?.max)
-									onChangeValue(minMaxSettings[val]?.max);
+								if (value > minMaxSettings[val]?.maxRange)
+									onChangeValue(
+										minMaxSettings[val]?.maxRange
+									);
 							}}
 						/>
 					)}
@@ -214,8 +239,8 @@ const AdvancedNumberControl = props => {
 						onChange={val => {
 							onChangeValue(+val);
 						}}
-						min={enableUnit ? minValue : min}
-						max={enableUnit ? maxValue : max}
+						min={enableUnit ? minValueRange : min}
+						max={enableUnit ? maxValueRange : max}
 						step={stepValue}
 						withInputField={false}
 						initialPosition={value || initial}


### PR DESCRIPTION
Fixes #2420 

1. Added new prop: minMaxRangeSettings. It similar to minMaxSettings, but contain min, max on range to every unit with default values which was recommended in the thread of the issue.
2. Added disableInputsLimits parameter, which, if true, disable the range.
3. Added new const variables: minValueRange, maxValueRange and changed into them in min/max RangeControl settings.
4. Changed check in units Select control.

How to test:
1. Check slider min/max values in some parameters like width in different components.
2. Switch between units. For example: from 1999px to em. It should be by default set to 199em.
3. Change default minMaxRangeSettings in some blocks.