### PR TITLE
Grid default attributes fix

### DIFF
--- a/src/blocks/container-maxi/attributes.js
+++ b/src/blocks/container-maxi/attributes.js
@@ -71,18 +71,6 @@ const attributes = {
 			type: 'number',
 			default: 90,
 		},
-		'max-width-m': {
-			type: 'number',
-			default: 90,
-		},
-		'max-width-s': {
-			type: 'number',
-			default: 90,
-		},
-		'max-width-xs': {
-			type: 'number',
-			default: 90,
-		},
 		'max-width-unit-xxl': {
 			type: 'string',
 			default: 'px',
@@ -92,18 +80,6 @@ const attributes = {
 			default: 'px',
 		},
 		'max-width-unit-l': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-m': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-s': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-xs': {
 			type: 'string',
 			default: '%',
 		},
@@ -124,18 +100,6 @@ const attributes = {
 			default: 460,
 		},
 		'width-unit-l': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-m': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-s': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-xs': {
 			type: 'string',
 			default: 'px',
 		},

--- a/src/blocks/row-maxi/attributes.js
+++ b/src/blocks/row-maxi/attributes.js
@@ -61,18 +61,6 @@ const attributes = {
 			type: 'number',
 			default: 90,
 		},
-		'max-width-m': {
-			type: 'number',
-			default: 90,
-		},
-		'max-width-s': {
-			type: 'number',
-			default: 90,
-		},
-		'max-width-xs': {
-			type: 'number',
-			default: 90,
-		},
 		'max-width-unit-xxl': {
 			type: 'string',
 			default: 'px',
@@ -82,18 +70,6 @@ const attributes = {
 			default: 'px',
 		},
 		'max-width-unit-l': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-m': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-s': {
-			type: 'string',
-			default: '%',
-		},
-		'max-width-unit-xs': {
 			type: 'string',
 			default: '%',
 		},
@@ -114,18 +90,6 @@ const attributes = {
 			default: 460,
 		},
 		'width-unit-l': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-m': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-s': {
-			type: 'string',
-			default: 'px',
-		},
-		'width-unit-xs': {
 			type: 'string',
 			default: 'px',
 		},


### PR DESCRIPTION
@Olekrut shared he was experiencing problems as changing some values of the grid and then seems they were coming back to its original values. It was before the defaults were repeated with same attributes, as you can see in this video:

https://user-images.githubusercontent.com/50477222/158558886-0fe13551-b016-44ab-bc46-c3cc127f6258.mp4



This PR fixes it. To test it change values on the width and its unit on different Responsive stages and check if the previous Responsive stage attribute prevale 👍 