### PR TITLE
Issue 2550 - Prevent opening MaxiModal after refreshing

### DIFF
--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -167,7 +167,7 @@ class edit extends MaxiBlockComponent {
 						type='svg'
 						empty={isEmptyContent}
 						style={parentBlockStyle}
-						openFirstTime={openFirstTime}
+						openFirstTime={isSelected ? openFirstTime : false}
 						onOpen={obj => maxiSetAttributes(obj)}
 						onSelect={obj => maxiSetAttributes(obj)}
 						onRemove={obj => maxiSetAttributes(obj)}


### PR DESCRIPTION
Fixes #2550

After refresh you won't have an error if you was in MaxiModal and somehow saved post, because MaxiModal won't open by itself after reload.