### PR TITLE
Issue 2693 - Add vh to height inputs

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -49,6 +49,12 @@ const AdvancedNumberControl = props => {
 			minRange: -199,
 			maxRange: 199,
 		},
+		vh: {
+			min: 0,
+			max: 999,
+			minRange: -199,
+			maxRange: 199,
+		},
 		'%': {
 			min: 0,
 			max: 100,
@@ -83,7 +89,7 @@ const AdvancedNumberControl = props => {
 		enableAuto = false,
 		autoLabel,
 		onReset,
-		allowedUnits = ['px', 'em', 'vw', '%', '-'],
+		allowedUnits = ['px', 'em', 'vw', 'vh', '%', '-'],
 		minMaxSettings = minMaxSettingsDefault,
 	} = props;
 

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -49,7 +49,7 @@ const AdvancedNumberControl = props => {
 		enableAuto = false,
 		autoLabel,
 		onReset,
-		allowedUnits = ['px', 'em', 'vw', '%', '-'],
+		allowedUnits = ['px', 'em', 'vw', 'vh', '%', '-'],
 		minMaxSettings = {
 			px: {
 				min: 0,
@@ -60,6 +60,10 @@ const AdvancedNumberControl = props => {
 				max: 999,
 			},
 			vw: {
+				min: 0,
+				max: 999,
+			},
+			vh: {
 				min: 0,
 				max: 999,
 			},

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -67,6 +67,10 @@ const FullSizeControl = props => {
 			min: 0,
 			max: 999,
 		},
+		vh: {
+			min: 0,
+			max: 999,
+		},
 		'%': {
 			min: 0,
 			max: 100,
@@ -143,7 +147,7 @@ const FullSizeControl = props => {
 					);
 				}}
 				minMaxSettings={minMaxSettings}
-				allowedUnits={['px', '%', 'em', 'vw']}
+				allowedUnits={['px', '%', 'em', 'vw', 'vh']}
 			/>
 			<ToggleSwitch
 				label={__('Set custom min/max values', 'maxi-blocks')}
@@ -285,7 +289,7 @@ const FullSizeControl = props => {
 							);
 						}}
 						minMaxSettings={minMaxSettings}
-						allowedUnits={['px', 'em', 'vw']}
+						allowedUnits={['px', 'em', 'vw', 'vh']}
 					/>
 					<AdvancedNumberControl
 						label={__('Minimum height', 'maxi-blocks')}
@@ -321,7 +325,7 @@ const FullSizeControl = props => {
 							);
 						}}
 						minMaxSettings={minMaxSettings}
-						allowedUnits={['px', 'em', 'vw']}
+						allowedUnits={['px', 'em', 'vw', 'vh']}
 					/>
 				</>
 			)}


### PR DESCRIPTION
Fixes #2693 

1. Added vh to allowedUnits in advanced-number-control and in full-size-control to height inputs
2. Add vh to minMaxSettings in both files.