### PR TITLE
Issue 2711 - RTL margin on lists

### DIFF
--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -166,7 +166,7 @@ const getTypographyHoverObject = props => {
 };
 
 const getListObject = props => {
-	const { listStyle, listStart, listReversed, content } = props;
+	const { listStyle, listStart, listReversed, content, isRTL } = props;
 
 	let counterReset;
 	if (isNumber(listStart)) {
@@ -206,9 +206,13 @@ const getListObject = props => {
 					});
 
 					if (!isNil(gapNum) && !isNil(gapUnit)) {
-						response.listGap[breakpoint] = {
-							'padding-left': gapNum + gapUnit,
-						};
+						response.listGap[breakpoint] = isRTL
+							? {
+									'padding-right': gapNum + gapUnit,
+							  }
+							: {
+									'padding-left': gapNum + gapUnit,
+							  };
 					}
 
 					// List indent
@@ -291,8 +295,8 @@ const getListParagraphObject = props => {
 };
 
 const getMarkerObject = props => {
-	const { typeOfList, listStyle, listStyleCustom, parentBlockStyle } = props;
-	const { isRTL } = select('core/editor').getEditorSettings();
+	const { typeOfList, listStyle, listStyleCustom, parentBlockStyle, isRTL } =
+		props;
 
 	const { paletteStatus, paletteColor, paletteOpacity, color } =
 		getPaletteAttributes({
@@ -467,6 +471,7 @@ const getMarkerObject = props => {
 const getStyles = props => {
 	const { uniqueID, isList, textLevel, typeOfList } = props;
 	const element = isList ? typeOfList : textLevel;
+	const { isRTL } = select('core/editor').getEditorSettings();
 
 	return {
 		[uniqueID]: stylesCleaner(
@@ -482,8 +487,10 @@ const getStyles = props => {
 						getTypographyHoverObject(props),
 				}),
 				...(isList && {
-					[` ${element}.maxi-text-block__content`]:
-						getListObject(props),
+					[` ${element}.maxi-text-block__content`]: getListObject(
+						props,
+						isRTL
+					),
 					[` ${element}.maxi-text-block__content li`]: {
 						...getTypographyObject(props),
 						...getListItemObject(props),
@@ -493,7 +500,7 @@ const getStyles = props => {
 					[` ${element}.maxi-text-block__content li:hover`]:
 						getTypographyHoverObject(props),
 					[` ${element}.maxi-text-block__content li::before`]:
-						getMarkerObject(props),
+						getMarkerObject(props, isRTL),
 				}),
 				...getBlockBackgroundStyles({
 					...getGroupAttributes(props, [

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { isURL } from '@wordpress/url';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -291,6 +292,7 @@ const getListParagraphObject = props => {
 
 const getMarkerObject = props => {
 	const { typeOfList, listStyle, listStyleCustom, parentBlockStyle } = props;
+	const { isRTL } = select('core/editor').getEditorSettings();
 
 	const { paletteStatus, paletteColor, paletteOpacity, color } =
 		getPaletteAttributes({
@@ -378,6 +380,7 @@ const getMarkerObject = props => {
 							breakpoint,
 							attributes: props,
 						}) || 'px';
+					const indentSum = indentNum + indentUnit;
 
 					// List size
 					const sizeNum =
@@ -414,6 +417,7 @@ const getMarkerObject = props => {
 							breakpoint,
 							attributes: props,
 						}) || 'px';
+					const indentMarkerSum = indentMarkerNum + indentMarkerUnit;
 
 					// Marker line-height
 					const lineHeightMarkerNum =
@@ -443,8 +447,8 @@ const getMarkerObject = props => {
 							(lineHeightMarkerUnit !== '-'
 								? lineHeightMarkerUnit
 								: ''),
-						'margin-right': indentMarkerNum + indentMarkerUnit,
-						'margin-left': indentNum + indentUnit,
+						'margin-right': isRTL ? indentSum : indentMarkerSum,
+						'margin-left': isRTL ? indentMarkerSum : indentSum,
 						...(listStyle === 'none' && {
 							'padding-right': '1em',
 						}),

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -204,7 +204,6 @@ const getListObject = props => {
 						breakpoint,
 						attributes: props,
 					});
-
 					if (!isNil(gapNum) && !isNil(gapUnit)) {
 						response.listGap[breakpoint] = isRTL
 							? {
@@ -487,10 +486,10 @@ const getStyles = props => {
 						getTypographyHoverObject(props),
 				}),
 				...(isList && {
-					[` ${element}.maxi-text-block__content`]: getListObject(
-						props,
-						isRTL
-					),
+					[` ${element}.maxi-text-block__content`]: getListObject({
+						...props,
+						isRTL,
+					}),
 					[` ${element}.maxi-text-block__content li`]: {
 						...getTypographyObject(props),
 						...getListItemObject(props),
@@ -500,7 +499,7 @@ const getStyles = props => {
 					[` ${element}.maxi-text-block__content li:hover`]:
 						getTypographyHoverObject(props),
 					[` ${element}.maxi-text-block__content li::before`]:
-						getMarkerObject(props, isRTL),
+						getMarkerObject({ ...props, isRTL }),
 				}),
 				...getBlockBackgroundStyles({
 					...getGroupAttributes(props, [

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -204,6 +204,7 @@ const getListObject = props => {
 						breakpoint,
 						attributes: props,
 					});
+					
 					if (!isNil(gapNum) && !isNil(gapUnit)) {
 						response.listGap[breakpoint] = isRTL
 							? {


### PR DESCRIPTION
Fixes #2711.

Add margin left-right swap when RTL is on.

Before -> After
![image](https://user-images.githubusercontent.com/46112160/158631222-e8b98aa3-e5c3-4952-8076-f55537d3ec32.png)
