### PR TITLE
Issue 2721 - maxiSetAttributes on custom default attributes

### DIFF
--- a/e2e-tests/editor/responsive.spec.js
+++ b/e2e-tests/editor/responsive.spec.js
@@ -481,4 +481,55 @@ describe('Responsive attributes mechanisms', () => {
 
 		expect(resetRadiusOnM).toStrictEqual(expectResetRadiusOnM);
 	});
+
+	it('On change XL default attributes from General responsive, changes on General and XL', async () => {
+		// Base responsive is "M"
+		await setBrowserViewport({ width: 1425, height: 700 });
+
+		await createNewPost();
+		await insertBlock('Button Maxi');
+
+		const accordionPanel = await openSidebarTab(
+			page,
+			'style',
+			'margin padding'
+		);
+
+		const axisControlInstance = await accordionPanel.$(
+			'.maxi-axis-control__padding'
+		);
+		await editAxisControl({
+			page,
+			instance: axisControlInstance,
+			values: '0',
+		});
+
+		const expectPaddingOnM = {
+			'button-padding-top-general': 0,
+			'button-padding-top-xl': 0,
+		};
+
+		const paddingOnM = await getAttributes([
+			'button-padding-top-general',
+			'button-padding-top-xl',
+		]);
+
+		expect(paddingOnM).toStrictEqual(expectPaddingOnM);
+
+		await changeResponsive(page, 'xxl');
+
+		const expectPaddingOnXl = {
+			'button-padding-top-general': 0,
+			'button-padding-top-xl': 0,
+			'button-padding-top-xxl': 23,
+		};
+
+		const paddingOnXl = await getAttributes([
+			'button-padding-top-general',
+			'button-padding-top-xl',
+			'button-padding-top-xxl',
+		]);
+
+		expect(paddingOnXl).toStrictEqual(expectPaddingOnXl);
+	});
 });

--- a/src/extensions/maxi-block/withMaxiProps.js
+++ b/src/extensions/maxi-block/withMaxiProps.js
@@ -43,10 +43,8 @@ export const handleSetAttributes = ({
 			0,
 			key.lastIndexOf('-')
 		)}-${winBreakpoint}`;
-		const attrExistOnWinBreakpoint = !isNil(
-			attributes?.[attrLabelOnWinBreakpoint],
-			true
-		);
+		const attrOnWinBreakpoint = attributes?.[attrLabelOnWinBreakpoint];
+		const attrExistOnWinBreakpoint = !isNil(attrOnWinBreakpoint);
 
 		if (attrExistOnWinBreakpoint && breakpoint !== 'general') return;
 
@@ -89,19 +87,20 @@ export const handleSetAttributes = ({
 					)
 			);
 
+		const defaultOnWinBreakpointAttribute =
+			defaultAttributes?.[attrLabelOnWinBreakpoint] ??
+			getDefaultAttribute(attrLabelOnWinBreakpoint, clientId, true);
+
 		if (
 			!attrExistOnGeneral &&
-			!attrExistOnWinBreakpoint &&
+			existHigherBreakpointAttribute &&
 			breakpoint === 'general' &&
-			existHigherBreakpointAttribute
+			(!attrExistOnWinBreakpoint ||
+				defaultOnWinBreakpointAttribute === attrOnWinBreakpoint)
 		)
 			response[attrLabelOnWinBreakpoint] = value;
 
 		if (!attrExistOnGeneral) return;
-
-		const defaultOnWinBreakpointAttribute =
-			defaultAttributes?.[attrLabelOnWinBreakpoint] ??
-			getDefaultAttribute(attrLabelOnWinBreakpoint, clientId, true);
 
 		if (
 			breakpoint === 'general' &&


### PR DESCRIPTION
On situations like having a Button Maxi on a XL win screen width, when changing trying to remove an attribute like padding which has a default XL value, it was not changing it as #2721 shows. This branch fixes it.

To test: create a Button Maxi and remove the padding or set as 0 or any other value. Should work as expected changing its own padding 👍 

Fixes #2721