### PR TITLE
Implement `force aspect ratio`

### DIFF
--- a/e2e-tests/components/full-size-control/index.spec.js
+++ b/e2e-tests/components/full-size-control/index.spec.js
@@ -63,7 +63,7 @@ describe('FullSizeControl', () => {
 
 		await page.$$eval(
 			'.maxi-full-size-control .maxi-toggle-switch input',
-			button => button[0].click()
+			button => button[1].click()
 		);
 
 		const selector = await page.$$(

--- a/src/blocks/column-maxi/attributes.js
+++ b/src/blocks/column-maxi/attributes.js
@@ -37,6 +37,7 @@ const attributes = {
 	...attributesData.boxShadow,
 	...attributesData.boxShadowHover,
 	...attributesData.columnSize,
+	...attributesData.size,
 	...attributesData.margin,
 	...attributesData.padding,
 

--- a/src/blocks/column-maxi/inspector.js
+++ b/src/blocks/column-maxi/inspector.js
@@ -202,6 +202,12 @@ const Inspector = props => {
 										...inspectorTabs.boxShadow({
 											props,
 										}),
+										...inspectorTabs.size({
+											props,
+											block: true,
+											hideWidth: true,
+											hideMaxWidth: true,
+										}),
 										...inspectorTabs.marginPadding({
 											props,
 										}),

--- a/src/blocks/column-maxi/styles.js
+++ b/src/blocks/column-maxi/styles.js
@@ -10,6 +10,7 @@ import {
 	getBorderStyles,
 	getOpacityStyles,
 	getOverflowStyles,
+	getSizeStyles,
 } from '../../extensions/styles/helpers';
 import { selectorsColumn } from './custom-css';
 
@@ -59,6 +60,9 @@ const getNormalObject = props => {
 				...getGroupAttributes(props, 'columnSize'),
 			}),
 		},
+		size: getSizeStyles({
+			...getGroupAttributes(props, 'size'),
+		}),
 		overflow: getOverflowStyles({
 			...getGroupAttributes(props, 'overflow'),
 		}),

--- a/src/blocks/group-maxi/styles.js
+++ b/src/blocks/group-maxi/styles.js
@@ -98,63 +98,64 @@ const getStyles = props => {
 	const { uniqueID } = props;
 
 	const response = {
-		[uniqueID]: stylesCleaner({
-			'': getNormalObject(props),
-			':hover': getHoverObject(props),
-			...getBlockBackgroundStyles({
-				...getGroupAttributes(props, [
-					'blockBackground',
-					'border',
-					'borderWidth',
-					'borderRadius',
-				]),
-				blockStyle: props.parentBlockStyle,
-			}),
-			...getBlockBackgroundStyles({
-				...getGroupAttributes(
-					props,
-					[
+		[uniqueID]: stylesCleaner(
+			{
+				'': getNormalObject(props),
+				':hover': getHoverObject(props),
+				...getBlockBackgroundStyles({
+					...getGroupAttributes(props, [
 						'blockBackground',
 						'border',
 						'borderWidth',
 						'borderRadius',
-					],
-					true
-				),
-				isHover: true,
-				blockStyle: props.parentBlockStyle,
-			}),
-			...getArrowStyles({
-				...getGroupAttributes(props, [
-					'arrow',
-					'border',
-					'borderWidth',
-					'borderRadius',
-					'blockBackground',
-					'boxShadow',
-				]),
-				blockStyle: props.parentBlockStyle,
-			}),
-			...getArrowStyles({
-				...getGroupAttributes(
-					props,
-					[
+					]),
+					blockStyle: props.parentBlockStyle,
+				}),
+				...getBlockBackgroundStyles({
+					...getGroupAttributes(
+						props,
+						[
+							'blockBackground',
+							'border',
+							'borderWidth',
+							'borderRadius',
+						],
+						true
+					),
+					isHover: true,
+					blockStyle: props.parentBlockStyle,
+				}),
+				...getArrowStyles({
+					...getGroupAttributes(props, [
 						'arrow',
 						'border',
 						'borderWidth',
 						'borderRadius',
 						'blockBackground',
 						'boxShadow',
-					],
-					true
-				),
-				...getGroupAttributes(props, ['arrow']),
-				blockStyle: props.parentBlockStyle,
-				isHover: true,
-			}),
-		},
-		selectorsGroup,
-		props
+					]),
+					blockStyle: props.parentBlockStyle,
+				}),
+				...getArrowStyles({
+					...getGroupAttributes(
+						props,
+						[
+							'arrow',
+							'border',
+							'borderWidth',
+							'borderRadius',
+							'blockBackground',
+							'boxShadow',
+						],
+						true
+					),
+					...getGroupAttributes(props, ['arrow']),
+					blockStyle: props.parentBlockStyle,
+					isHover: true,
+				}),
+			},
+			selectorsGroup,
+			props
 		),
 	};
 

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -36,6 +36,7 @@ const FullSizeControl = props => {
 		hideWidth,
 		hideMaxWidth,
 		prefix = '',
+		allowForceAspectRatio = false,
 	} = props;
 
 	const classes = classnames('maxi-full-size-control', className);
@@ -117,38 +118,59 @@ const FullSizeControl = props => {
 					allowedUnits={['px', 'em', 'vw', '%']}
 				/>
 			)}
-			<AdvancedNumberControl
-				label={__('Height', 'maxi-blocks')}
-				enableUnit
-				unit={getLastBreakpointAttribute({
-					target: `${prefix}height-unit`,
-					breakpoint,
-					attributes: props,
-				})}
-				onChangeUnit={val =>
-					onChangeValue([`${prefix}height-unit`], val)
-				}
-				value={getLastBreakpointAttribute({
-					target: `${prefix}height`,
-					breakpoint,
-					attributes: props,
-				})}
-				onChangeValue={val => onChangeValue([`${prefix}height`], val)}
-				onReset={() => {
-					onChangeValue(
-						[`${prefix}height`],
-						getDefaultAttribute(`${prefix}height-${breakpoint}`)
-					);
-					onChangeValue(
-						[`${prefix}height-unit`],
-						getDefaultAttribute(
-							`${prefix}height-unit-${breakpoint}`
-						)
-					);
-				}}
-				minMaxSettings={minMaxSettings}
-				allowedUnits={['px', '%', 'em', 'vw', 'vh']}
-			/>
+			{allowForceAspectRatio && (
+				<ToggleSwitch
+					label={__('Force Aspect Ratio', 'maxi-blocks')}
+					selected={getLastBreakpointAttribute({
+						target: `${prefix}force-aspect-ratio`,
+						breakpoint,
+						attributes: props,
+					})}
+					onChange={val =>
+						onChangeValue(`${prefix}force-aspect-ratio`, val)
+					}
+				/>
+			)}
+			{!getLastBreakpointAttribute({
+				target: `${prefix}force-aspect-ratio`,
+				breakpoint,
+				attributes: props,
+			}) && (
+				<AdvancedNumberControl
+					label={__('Height', 'maxi-blocks')}
+					enableUnit
+					unit={getLastBreakpointAttribute({
+						target: `${prefix}height-unit`,
+						breakpoint,
+						attributes: props,
+					})}
+					onChangeUnit={val =>
+						onChangeValue([`${prefix}height-unit`], val)
+					}
+					value={getLastBreakpointAttribute({
+						target: `${prefix}height`,
+						breakpoint,
+						attributes: props,
+					})}
+					onChangeValue={val =>
+						onChangeValue([`${prefix}height`], val)
+					}
+					onReset={() => {
+						onChangeValue(
+							[`${prefix}height`],
+							getDefaultAttribute(`${prefix}height-${breakpoint}`)
+						);
+						onChangeValue(
+							[`${prefix}height-unit`],
+							getDefaultAttribute(
+								`${prefix}height-unit-${breakpoint}`
+							)
+						);
+					}}
+					minMaxSettings={minMaxSettings}
+					allowedUnits={['px', '%', 'em', 'vw', 'vh']}
+				/>
+			)}
 			<ToggleSwitch
 				label={__('Set custom min/max values', 'maxi-blocks')}
 				selected={props[`${prefix}size-advanced-options`] || 0}

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -66,6 +66,7 @@ const size = ({
 					breakpoint={deviceType}
 					hideWidth={hideWidth || isBlockFullWidth}
 					hideMaxWidth={hideMaxWidth || isBlockFullWidth}
+					allowForceAspectRatio={block}
 				/>
 			</>
 		),

--- a/src/extensions/styles/defaults/size.js
+++ b/src/extensions/styles/defaults/size.js
@@ -55,6 +55,9 @@ export const rawHeight = {
 	height: {
 		type: 'number',
 	},
+	'force-aspect-ratio': {
+		type: 'boolean',
+	},
 };
 
 export const rawMinHeight = {

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -23,6 +23,17 @@ const getSizeStyles = (obj, prefix = '') => {
 
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
+			if (target === 'height') {
+				const forceAspectRatio = getLastBreakpointAttribute({
+					target: `${prefix}force-aspect-ratio`,
+					breakpoint,
+					attributes: obj,
+				});
+
+				if (forceAspectRatio) {
+					return { 'aspect-ratio': 1, height: '100%' };
+				}
+			}
 			if (
 				isNumber(obj[`${prefix}${target}-${breakpoint}`]) ||
 				obj[`${prefix}${target}-unit-${breakpoint}`]

--- a/src/extensions/styles/helpers/test/__snapshots__/getSizeStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getSizeStyles.js.snap
@@ -60,3 +60,64 @@ Object {
   },
 }
 `;
+
+exports[`getSizeStyles Get a correct size styles with force aspect ratio 1`] = `
+Object {
+  "general": Object {
+    "height": "4px",
+    "max-height": "3px",
+    "max-width": "2px",
+    "min-height": "1px",
+    "min-width": "2px",
+    "width": "1px",
+  },
+  "l": Object {
+    "aspect-ratio": 1,
+    "max-height": "2px",
+    "max-width": "2px",
+    "min-height": "1px",
+    "min-width": "3px",
+    "width": "1px",
+  },
+  "m": Object {
+    "aspect-ratio": 1,
+    "max-height": "1px",
+    "max-width": "2px",
+    "min-height": "2px",
+    "min-width": "4px",
+    "width": "3px",
+  },
+  "s": Object {
+    "aspect-ratio": 1,
+    "max-height": "1px",
+    "max-width": "3px",
+    "min-height": "2px",
+    "min-width": "1px",
+    "width": "4px",
+  },
+  "xl": Object {
+    "aspect-ratio": 1,
+    "max-height": "2px",
+    "max-width": "3px",
+    "min-height": "4px",
+    "min-width": "1px",
+    "width": "4px",
+  },
+  "xs": Object {
+    "aspect-ratio": 1,
+    "max-height": "2px",
+    "max-width": "3px",
+    "min-height": "4px",
+    "min-width": "1px",
+    "width": "4px",
+  },
+  "xxl": Object {
+    "height": "2px",
+    "max-height": "1px",
+    "max-width": "2px",
+    "min-height": "2px",
+    "min-width": "4px",
+    "width": "3px",
+  },
+}
+`;

--- a/src/extensions/styles/helpers/test/__snapshots__/getSizeStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getSizeStyles.js.snap
@@ -73,6 +73,7 @@ Object {
   },
   "l": Object {
     "aspect-ratio": 1,
+    "height": "100%",
     "max-height": "2px",
     "max-width": "2px",
     "min-height": "1px",
@@ -81,6 +82,7 @@ Object {
   },
   "m": Object {
     "aspect-ratio": 1,
+    "height": "100%",
     "max-height": "1px",
     "max-width": "2px",
     "min-height": "2px",
@@ -89,6 +91,7 @@ Object {
   },
   "s": Object {
     "aspect-ratio": 1,
+    "height": "100%",
     "max-height": "1px",
     "max-width": "3px",
     "min-height": "2px",
@@ -97,6 +100,7 @@ Object {
   },
   "xl": Object {
     "aspect-ratio": 1,
+    "height": "100%",
     "max-height": "2px",
     "max-width": "3px",
     "min-height": "4px",
@@ -105,6 +109,7 @@ Object {
   },
   "xs": Object {
     "aspect-ratio": 1,
+    "height": "100%",
     "max-height": "2px",
     "max-width": "3px",
     "min-height": "4px",

--- a/src/extensions/styles/helpers/test/getSizeStyles.js
+++ b/src/extensions/styles/helpers/test/getSizeStyles.js
@@ -1,15 +1,5 @@
 import getSizeStyles from '../getSizeStyles';
 
-jest.mock('@wordpress/data', () => {
-	return {
-		select: jest.fn(() => {
-			return {
-				getSelectedBlockCount: jest.fn(() => 1),
-			};
-		}),
-	};
-});
-
 describe('getSizeStyles', () => {
 	it('Get a correct size styles', () => {
 		const object = {
@@ -72,6 +62,94 @@ describe('getSizeStyles', () => {
 			'max-height-m': 1,
 			'height-unit-m': 'px',
 			'height-m': 2,
+			'min-height-unit-m': 'px',
+			'min-height-m': 2,
+			'max-width-unit-s': 'px',
+			'max-width-s': 3,
+			'width-unit-s': 'px',
+			'width-s': 4,
+			'min-width-unit-s': 'px',
+			'min-width-s': 1,
+			'max-height-unit-s': 'px',
+			'max-height-s': 1,
+			'height-unit-s': 'px',
+			'height-s': 1,
+			'min-height-unit-s': 'px',
+			'min-height-s': 2,
+			'max-width-unit-xs': 'px',
+			'max-width-xs': 3,
+			'width-unit-xs': 'px',
+			'width-xs': 4,
+			'min-width-unit-xs': 'px',
+			'min-width-xs': 1,
+			'max-height-unit-xs': 'px',
+			'max-height-xs': 2,
+			'height-unit-xs': 'px',
+			'height-xs': 3,
+			'min-height-unit-xs': 'px',
+			'min-height-xs': 4,
+		};
+
+		const result = getSizeStyles(object);
+		expect(result).toMatchSnapshot();
+	});
+
+	it('Get a correct size styles with force aspect ratio', () => {
+		const object = {
+			'size-advanced-options': true,
+			'max-width-unit-general': 'px',
+			'max-width-general': 2,
+			'width-unit-general': 'px',
+			'width-general': 1,
+			'min-width-unit-general': 'px',
+			'min-width-general': 2,
+			'max-height-unit-general': 'px',
+			'max-height-general': 3,
+			'height-unit-general': 'px',
+			'height-general': 4,
+			'min-height-unit-general': 'px',
+			'min-height-general': 1,
+			'max-width-unit-xxl': 'px',
+			'max-width-xxl': 2,
+			'width-unit-xxl': 'px',
+			'width-xxl': 3,
+			'min-width-unit-xxl': 'px',
+			'min-width-xxl': 4,
+			'max-height-unit-xxl': 'px',
+			'max-height-xxl': 1,
+			'height-unit-xxl': 'px',
+			'height-xxl': 2,
+			'min-height-unit-xxl': 'px',
+			'min-height-xxl': 2,
+			'max-width-unit-xl': 'px',
+			'max-width-xl': 3,
+			'width-unit-xl': 'px',
+			'width-xl': 4,
+			'min-width-unit-xl': 'px',
+			'min-width-xl': 1,
+			'max-height-unit-xl': 'px',
+			'max-height-xl': 2,
+			'force-aspect-ratio-xl': true,
+			'min-height-unit-xl': 'px',
+			'min-height-xl': 4,
+			'max-width-unit-l': 'px',
+			'max-width-l': 2,
+			'width-unit-l': 'px',
+			'width-l': 1,
+			'min-width-unit-l': 'px',
+			'min-width-l': 3,
+			'max-height-unit-l': 'px',
+			'max-height-l': 2,
+			'min-height-unit-l': 'px',
+			'min-height-l': 1,
+			'max-width-unit-m': 'px',
+			'max-width-m': 2,
+			'width-unit-m': 'px',
+			'width-m': 3,
+			'min-width-unit-m': 'px',
+			'min-width-m': 4,
+			'max-height-unit-m': 'px',
+			'max-height-m': 1,
 			'min-height-unit-m': 'px',
 			'min-height-m': 2,
 			'max-width-unit-s': 'px',


### PR DESCRIPTION
@Olekrut was looking for a way to make elements equal on width/height. For it has been implemented on this branch the option `Force aspect ratio`. Here's a video of how it works:


https://user-images.githubusercontent.com/50477222/159490571-5f0f51bf-9dc0-4e9b-ab02-9872753c6624.mp4


Also this branch adds Column Maxi size support, without width and max-width option to don't interfere with Column Size options based on `%` 👍 


The [code editor](https://github.com/yeahcan/maxi-blocks/files/8324550/forceaspectratio.txt) from the video