### PR TITLE
SVG background support and Container multi-row

### DIFF
--- a/src/blocks/container-maxi/edit.js
+++ b/src/blocks/container-maxi/edit.js
@@ -84,7 +84,7 @@ class edit extends MaxiBlockComponent {
 				hasInnerBlocks
 				innerBlocksSettings={{
 					allowedBlocks: ALLOWED_BLOCKS,
-					template: ROW_TEMPLATE,
+					template: !hasInnerBlocks ? ROW_TEMPLATE : false,
 					templateLock: false,
 					orientation: 'horizontal',
 					renderAppender: !hasInnerBlocks

--- a/src/blocks/container-maxi/editor.scss
+++ b/src/blocks/container-maxi/editor.scss
@@ -6,6 +6,12 @@
 		left: 50%;
 		border-radius: 50%;
 	}
+	.block-list-appender--show {
+		.block-editor-button-block-appender {
+			visibility: visible;
+			opacity: 1;
+		}
+	}
 	&__container {
 		width: 100%;
 	}

--- a/src/blocks/svg-icon-maxi/attributes.js
+++ b/src/blocks/svg-icon-maxi/attributes.js
@@ -41,6 +41,28 @@ const attributes = {
 			default: 'center',
 		},
 	},
+	...prefixAttributesCreator({
+		obj: attributesData.background,
+		prefix,
+	}),
+	...prefixAttributesCreator({
+		obj: attributesData.backgroundColor,
+		prefix,
+		diffValAttr: { [`${prefix}background-palette-color-general`]: 4 },
+	}),
+	...prefixAttributesCreator({
+		obj: attributesData.backgroundGradient,
+		prefix,
+	}),
+	...prefixAttributesCreator({ obj: attributesData.backgroundHover, prefix }),
+	...prefixAttributesCreator({
+		obj: attributesData.backgroundColorHover,
+		prefix,
+	}),
+	...prefixAttributesCreator({
+		obj: attributesData.backgroundGradientHover,
+		prefix,
+	}),
 	...prefixAttributesCreator({ obj: attributesData.border, prefix }),
 	...prefixAttributesCreator({ obj: attributesData.borderHover, prefix }),
 	...prefixAttributesCreator({ obj: attributesData.borderRadius, prefix }),

--- a/src/blocks/svg-icon-maxi/inspector.js
+++ b/src/blocks/svg-icon-maxi/inspector.js
@@ -278,6 +278,17 @@ const Inspector = props => {
 													/>
 												),
 											},
+										...inspectorTabs.background({
+											label: 'SVG',
+											props: {
+												...props,
+											},
+											disableImage: true,
+											disableVideo: true,
+											disableClipPath: true,
+											disableSVG: true,
+											prefix: 'svg-',
+										}),
 										...inspectorTabs.border({
 											props,
 											prefix: 'svg-',

--- a/src/blocks/svg-icon-maxi/styles.js
+++ b/src/blocks/svg-icon-maxi/styles.js
@@ -14,6 +14,7 @@ import {
 	getZIndexStyles,
 	getOverflowStyles,
 	getSVGWidthStyles,
+	getBackgroundStyles,
 } from '../../extensions/styles/helpers';
 import { selectorsSvgIcon } from './custom-css';
 
@@ -137,6 +138,16 @@ const getNormalObject = props => {
 			prefix: 'svg-',
 		}),
 		...getSVGWidthStyles(getGroupAttributes(props, 'svg')),
+		...getBackgroundStyles({
+			...getGroupAttributes(
+				props,
+				['background', 'backgroundColor', 'backgroundGradient'],
+				false,
+				'svg-'
+			),
+			blockStyle: props.parentBlockStyle,
+			prefix: 'svg-',
+		}),
 	};
 
 	return response;
@@ -169,6 +180,17 @@ const getHoverObject = props => {
 				parentBlockStyle: props.parentBlockStyle,
 				prefix: 'svg-',
 			}),
+		...getBackgroundStyles({
+			...getGroupAttributes(
+				props,
+				['background', 'backgroundColor', 'backgroundGradient'],
+				true,
+				'svg-'
+			),
+			blockStyle: props.parentBlockStyle,
+			isHover: true,
+			prefix: 'svg-',
+		}),
 	};
 
 	return response;


### PR DESCRIPTION
One of the patterns @Olekrut shared is:

![image (23)](https://user-images.githubusercontent.com/50477222/159530686-2418f689-774d-4ede-98a8-7d9043a9c612.png)

The tools Maxi has for it wasn't enough, so added:
1. SVG background support
2. Fix Container have more than one Row

This helped doing:

https://user-images.githubusercontent.com/50477222/159530903-1b9b6521-e02c-4fec-914c-8ceae7fb82f6.mp4

It needs #2740 for working correctly the responsive, but should be easy 👍 
