### PR TITLE
Shape - shape

### DIFF
--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -128,7 +128,7 @@ const MasonryItem = props => {
 									'bg-shape',
 									'sidebar-block-shape',
 							  ].includes(target) || target.includes('Shape')
-							? serial.replace(' Shape', '')
+							? serial.replace(' shape', '')
 							: serial}
 					</div>
 					<span>{__('Load', 'maxi-block')}</span>


### PR DESCRIPTION
Changed category text from "Shape" to "shape" to remove the "shape" text for all shape icons.

![Screenshot_1](https://user-images.githubusercontent.com/19425503/160824995-cff715df-3c7c-4d28-b205-f36edbe62274.jpg)
