### PR TITLE
Issue 2852 Replace image/icon button visibility

### DIFF
--- a/src/blocks/image-maxi/editor.scss
+++ b/src/blocks/image-maxi/editor.scss
@@ -31,7 +31,6 @@
 			box-shadow: -3px 3px 6px 0px rgb(0 0 0 / 16%) !important;
 			border-radius: 0;
 			background: #fff;
-			opacity: 0;
 			visibility: visible;
 			transition: 0.3s;
 
@@ -44,14 +43,6 @@
 				svg {
 					fill: #ff4a17;
 				}
-			}
-		}
-	}
-
-	&:hover {
-		.maxi-image-block__settings {
-			.maxi-image-block__settings__upload-button {
-				opacity: 1;
 			}
 		}
 	}

--- a/src/blocks/svg-icon-maxi/editor.scss
+++ b/src/blocks/svg-icon-maxi/editor.scss
@@ -27,7 +27,6 @@
 	&__replace-icon {
 		width: 40px;
 		height: 40px;
-		opacity: 1;
 		visibility: visible;
 		background: #232533;
 		transition: 0.3s;
@@ -36,12 +35,6 @@
 			fill: #fff;
 			width: 20px;
 			height: 20px;
-		}
-	}
-
-	&:hover {
-		.maxi-svg-icon-block__replace-icon {
-			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
Fixes #2852

This fixes the button visibility, but we added 0 opacity to the icons before in order to show them on hover only. See https://github.com/yeahcan/maxi-blocks/pull/2775.

Seems that we changed the DOM and where the replace button is rendered on the page, afterwards. 
It used to be a part of the block, and now it's outside of it. Because of that, the CSS for hover isn't working anymore, so I removed it.

Since the replace button isn't inside the block anymore, we can't make it work easily with CSS. We probably need a function to detect block hover to add a class to the popover settings. Do we want to do that or that's an unnecessary complication?