### PR TITLE
Issue 2881 Switching between 'xs' and 's'

### DIFF
--- a/src/extensions/dom/index.js
+++ b/src/extensions/dom/index.js
@@ -187,6 +187,18 @@ wp.domReady(() => {
 						);
 						const iframeDocument = iframe.contentDocument;
 
+						const editorWrapper = iframeDocument.querySelector(
+							'.editor-styles-wrapper'
+						);
+						editorWrapper.setAttribute(
+							'maxi-blocks-responsive',
+							mutation.target.classList.contains(
+								'is-tablet-preview'
+							)
+								? 's'
+								: 'xs'
+						);
+
 						if (
 							iframe &&
 							!iframeDocument.body.classList.contains(
@@ -196,17 +208,6 @@ wp.domReady(() => {
 							// Iframe needs Maxi classes and attributes
 							iframeDocument.body.classList.add(
 								'maxi-blocks--active'
-							);
-							const editorWrapper = iframeDocument.querySelector(
-								'.editor-styles-wrapper'
-							);
-							editorWrapper.setAttribute(
-								'maxi-blocks-responsive',
-								mutation.target.classList.contains(
-									'is-tablet-preview'
-								)
-									? 's'
-									: 'xs'
 							);
 
 							// Get all Maxi blocks <style> from <head>


### PR DESCRIPTION
Fixes #2881

The problem was in the iframe body attribute 'maxi-blocks-responsive', which didn't change after switching between 'xs' and 's'.