### PR TITLE
Issue 2866: Fixed issue with Icon toolbar in button maxi

### DIFF
--- a/src/blocks/button-maxi/edit.js
+++ b/src/blocks/button-maxi/edit.js
@@ -91,8 +91,6 @@ class edit extends MaxiBlockComponent {
 		const { attributes, maxiSetAttributes, changeSVGContent } = this.props;
 		const { uniqueID, blockFullWidth, fullWidth } = attributes;
 
-		const { isIconSelected } = this.state;
-
 		const buttonClasses = classnames(
 			'maxi-button-block__button',
 			attributes['icon-content'] &&
@@ -153,7 +151,6 @@ class edit extends MaxiBlockComponent {
 								ref={this.iconRef}
 								{...this.props}
 								propsToAvoid={['buttonContent', 'formatValue']}
-								isSelected={isIconSelected}
 								changeSVGContent={changeSVGContent}
 							/>
 							<IconWrapper

--- a/src/blocks/button-maxi/edit.js
+++ b/src/blocks/button-maxi/edit.js
@@ -88,7 +88,7 @@ class edit extends MaxiBlockComponent {
 	}
 
 	render() {
-		const { attributes, maxiSetAttributes } = this.props;
+		const { attributes, maxiSetAttributes, changeSVGContent } = this.props;
 		const { uniqueID, blockFullWidth, fullWidth } = attributes;
 
 		const { isIconSelected } = this.state;
@@ -154,6 +154,7 @@ class edit extends MaxiBlockComponent {
 								{...this.props}
 								propsToAvoid={['buttonContent', 'formatValue']}
 								isSelected={isIconSelected}
+								changeSVGContent={changeSVGContent}
 							/>
 							<IconWrapper
 								ref={this.iconRef}

--- a/src/blocks/button-maxi/edit.js
+++ b/src/blocks/button-maxi/edit.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
-import { RawHTML, createRef, forwardRef, useEffect } from '@wordpress/element';
+import { RawHTML, createRef, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,40 +30,10 @@ import classnames from 'classnames';
  * Content
  */
 const IconWrapper = forwardRef((props, ref) => {
-	const { children, className, changeIsSelected, uniqueID } = props;
-
-	useEffect(() => {
-		const handleClickOutside = event => {
-			if (ref.current && !ref.current.contains(event.target)) {
-				changeIsSelected(
-					document
-						.querySelector(`.${uniqueID}`)
-						.classList.contains('is-selected')
-				);
-			}
-		};
-
-		// Bind the event listener
-		ref?.current?.ownerDocument.addEventListener(
-			'mousedown',
-			handleClickOutside
-		);
-
-		return () => {
-			// Unbind the event listener on clean up
-			ref?.current?.ownerDocument.removeEventListener(
-				'mousedown',
-				handleClickOutside
-			);
-		};
-	}, [ref]);
+	const { children, className } = props;
 
 	return (
-		<div
-			onClick={() => changeIsSelected(true)}
-			ref={ref}
-			className={className}
-		>
+		<div ref={ref} className={className}>
 			{children}
 		</div>
 	);
@@ -74,10 +44,6 @@ class edit extends MaxiBlockComponent {
 
 		this.iconRef = createRef(null);
 	}
-
-	state = {
-		isIconSelected: false,
-	};
 
 	typingTimeout = 0;
 
@@ -157,9 +123,6 @@ class edit extends MaxiBlockComponent {
 								ref={this.iconRef}
 								uniqueID={uniqueID}
 								className='maxi-button-block__icon'
-								changeIsSelected={isIconSelected =>
-									this.setState({ isIconSelected })
-								}
 							>
 								<RawHTML>{attributes['icon-content']}</RawHTML>
 							</IconWrapper>

--- a/src/blocks/divider-maxi/divider-maxi.js
+++ b/src/blocks/divider-maxi/divider-maxi.js
@@ -30,7 +30,7 @@ import { dividerIcon } from '../../icons';
 registerBlockType('maxi-blocks/divider-maxi', {
 	title: __('Divider Maxi', 'maxi-blocks'),
 	icon: dividerIcon,
-	description: 'Create a horizontal divider between visual elements',
+	description: 'Create a divider between visual elements',
 	category: 'maxi-blocks',
 	supports: {
 		align: true,

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -298,7 +298,7 @@ const IconControl = props => {
 							{!props['icon-inherit'] ? (
 								svgType !== 'Shape' && (
 									<ColorControl
-										label={__('Icon Line', 'maxi-blocks')}
+										label={__('Icon stroke', 'maxi-blocks')}
 										color={
 											props[
 												`icon-color${

--- a/src/components/toolbar/captionToolbar.js
+++ b/src/components/toolbar/captionToolbar.js
@@ -35,7 +35,7 @@ import { getGroupAttributes } from '../../extensions/styles';
  */
 const CaptionToolbar = memo(
 	forwardRef((props, ref) => {
-		const { attributes, clientId, maxiSetAttributes } = props;
+		const { attributes, clientId, maxiSetAttributes, isSelected } = props;
 		const {
 			captionContent: content,
 			isList = false,
@@ -45,35 +45,28 @@ const CaptionToolbar = memo(
 			parentBlockStyle,
 		} = attributes;
 
-		const { editorVersion, breakpoint, styleCard, isSelected } = useSelect(
-			select => {
-				const { receiveMaxiSettings, receiveMaxiDeviceType } =
-					select('maxiBlocks');
-				const { receiveMaxiSelectedStyleCard } = select(
-					'maxiBlocks/style-cards'
-				);
+		const { editorVersion, breakpoint, styleCard } = useSelect(select => {
+			const { receiveMaxiSettings, receiveMaxiDeviceType } =
+				select('maxiBlocks');
+			const { receiveMaxiSelectedStyleCard } = select(
+				'maxiBlocks/style-cards'
+			);
 
-				const maxiSettings = receiveMaxiSettings();
-				const version = !isEmpty(maxiSettings.editor)
-					? maxiSettings.editor.version
-					: null;
+			const maxiSettings = receiveMaxiSettings();
+			const version = !isEmpty(maxiSettings.editor)
+				? maxiSettings.editor.version
+				: null;
 
-				const breakpoint = receiveMaxiDeviceType();
+			const breakpoint = receiveMaxiDeviceType();
 
-				const styleCard = receiveMaxiSelectedStyleCard()?.value || {};
+			const styleCard = receiveMaxiSelectedStyleCard()?.value || {};
 
-				const isSelected = ref.current?.isSameNode(
-					ref.current.ownerDocument.activeElement
-				);
-
-				return {
-					editorVersion: version,
-					breakpoint,
-					styleCard,
-					isSelected,
-				};
-			}
-		);
+			return {
+				editorVersion: version,
+				breakpoint,
+				styleCard,
+			};
+		});
 
 		const [anchorRef, setAnchorRef] = useState(ref.current);
 

--- a/src/components/toolbar/components/icon-color/index.js
+++ b/src/components/toolbar/components/icon-color/index.js
@@ -15,18 +15,21 @@ import ToggleSwitch from '../../../toggle-switch';
  */
 import './editor.scss';
 import { toolbarShapeColor } from '../../../../icons';
+import { getColorRGBAString } from '../../../../extensions/styles';
 
 /**
  * Component
  */
 const IconColor = props => {
-	const { blockName, onChange } = props;
+	const { blockName, onChange, svgType, changeSVGContent, parentBlockStyle } =
+		props;
 
 	if (blockName !== 'maxi-blocks/button-maxi') return null;
 
 	return (
 		<ToolbarPopover
 			className='toolbar-item__background'
+			position='bottom center'
 			tooltip={__('Icon Colour', 'maxi-blocks')}
 			icon={toolbarShapeColor}
 			advancedOptions='icon'
@@ -52,20 +55,76 @@ const IconColor = props => {
 						)}
 					</p>
 				) : (
-					<ColorControl
-						color={props['icon-color']}
-						prefix='icon-'
-						paletteColor={props['icon-palette-color']}
-						paletteStatus={props['icon-palette-status']}
-						onChange={({ color, paletteColor, paletteStatus }) => {
-							onChange({
-								'icon-color': color,
-								'icon-palette-color': paletteColor,
-								'icon-palette-status': paletteStatus,
-							});
-						}}
-						disableOpacity
-					/>
+					<>
+						{svgType !== 'Shape' && (
+							<ColorControl
+								label={__('Icon stroke', 'maxi-blocks')}
+								color={props['icon-color']}
+								prefix='icon-'
+								paletteColor={props['icon-palette-color']}
+								paletteStatus={props['icon-palette-status']}
+								onChange={({
+									color,
+									paletteColor,
+									paletteStatus,
+								}) => {
+									onChange({
+										'icon-color': color,
+										'icon-palette-color': paletteColor,
+										'icon-palette-status': paletteStatus,
+									});
+									const lineColorStr = getColorRGBAString({
+										firstVar: 'icon-line',
+										secondVar: `color-${paletteColor}`,
+										opacity: props['icon-palette-opacity'],
+										blockStyle: parentBlockStyle,
+									});
+
+									changeSVGContent(
+										paletteStatus ? lineColorStr : color,
+										'stroke'
+									);
+								}}
+								disableOpacity
+							/>
+						)}
+						{svgType !== 'Line' && (
+							<ColorControl
+								label={__('Icon Fill', 'maxi-blocks')}
+								color={props['icon-fill-color']}
+								prefix='icon-fill'
+								paletteColor={props['icon-fill-palette-color']}
+								paletteStatus={
+									props['icon-fill-palette-status']
+								}
+								onChange={({
+									color,
+									paletteColor,
+									paletteStatus,
+								}) => {
+									onChange({
+										'icon-fill-color': color,
+										'icon-fill-palette-color': paletteColor,
+										'icon-fill-palette-status':
+											paletteStatus,
+									});
+									const fillColorStr = getColorRGBAString({
+										firstVar: 'icon-fill',
+										secondVar: `color-${paletteColor}`,
+										opacity:
+											props['icon-fill-palette-opacity'],
+										blockStyle: parentBlockStyle,
+									});
+
+									changeSVGContent(
+										paletteStatus ? fillColorStr : color,
+										'fill'
+									);
+								}}
+								disableOpacity
+							/>
+						)}
+					</>
 				)}
 			</div>
 		</ToolbarPopover>

--- a/src/components/toolbar/components/toolbar-popover/index.js
+++ b/src/components/toolbar/components/toolbar-popover/index.js
@@ -83,6 +83,7 @@ class ToolbarPopover extends Component {
 			children,
 			advancedOptions = false,
 			tab = 0,
+			position = 'top center',
 		} = this.props;
 
 		const { isOpen, onClose } = this.state;
@@ -116,7 +117,7 @@ class ToolbarPopover extends Component {
 								'.toolbar-wrapper'
 							)}
 							onClose={onClose}
-							position='top center'
+							position={position}
 							isAlternate
 							shouldAnchorIncludePadding
 						>

--- a/src/components/toolbar/iconToolbar.js
+++ b/src/components/toolbar/iconToolbar.js
@@ -33,9 +33,15 @@ import { getGroupAttributes } from '../../extensions/styles';
  */
 const IconToolbar = memo(
 	forwardRef((props, ref) => {
-		const { attributes, clientId, maxiSetAttributes, name, isSelected } =
-			props;
-		const { uniqueID } = attributes;
+		const {
+			attributes,
+			clientId,
+			maxiSetAttributes,
+			name,
+			isSelected,
+			changeSVGContent,
+		} = props;
+		const { uniqueID, svgType, parentBlockStyle } = attributes;
 
 		const { editorVersion, breakpoint } = useSelect(select => {
 			const { receiveMaxiSettings, receiveMaxiDeviceType } =
@@ -117,6 +123,9 @@ const IconToolbar = memo(
 							<IconColor
 								blockName={name}
 								{...getGroupAttributes(attributes, 'icon')}
+								svgType={svgType}
+								changeSVGContent={changeSVGContent}
+								parentBlockStyle={parentBlockStyle}
 								onChange={obj => processAttributes(obj)}
 							/>
 							<IconBackground


### PR DESCRIPTION
fixes #2866 

I have changed the description of divider maxi by removing 'horizontal' in the description as Kyra suggested via chat; It's not related with the issue but I thought I don't need to create an issue for it.

I also fixed the Caption Toolbar of Image maxi as the appearance of the Caption Toolbar was also unpredicatable too. 

Now both Icon Toolbar in button maxi and Caption Toolbar in Image maxi appear when the block is selected as @Naaaaiix recommended.