### PR TITLE
issue-2904 SVG attribute errors

### DIFF
--- a/src/icons/template-icons/2-1-1-2/index.js
+++ b/src/icons/template-icons/2-1-1-2/index.js
@@ -4,7 +4,7 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const twoOneOneTwo = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112.35 37" fill="none" stroke="#323c47" stroke-linejoin="round" stroke-width="2">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 112.35 37" fill="none" stroke="#323c47" strokeLinejoin="round" strokeWidth="2">
 		<Path d="M1 1h110.35v8.08H1zm0 26.92h110.35V36H1zm0-13.39h52.29v6.94H1zm58.06 0h52.29v6.94H59.06z"/>
 	</SVG>
 );


### PR DESCRIPTION
Fixes #2904 
The only place I could it is the "twoOneOnetwo" icon. @Naaaaiix Do we have the warning anywhere else that you noticed?