### PR TITLE
Alignment icon fix

### DIFF
--- a/src/components/toolbar/components/alignment/index.js
+++ b/src/components/toolbar/components/alignment/index.js
@@ -44,7 +44,15 @@ const Alignment = props => {
 			position='bottom right'
 			renderToggle={({ isOpen, onToggle }) => (
 				<Button onClick={onToggle} text='Copy'>
-					<Icon className='toolbar-item__icon toolbar-item__icon__alignment' icon={alignCenter} />
+					{isText ?
+						<Icon className='toolbar-item__icon toolbar-item__icon__alignment' icon={alignCenter} />
+		
+					:
+						<>
+							{__('Align', 'maxi-blocks')}
+						</>
+					}
+					
 				</Button>
 			)}
 			renderContent={() => (


### PR DESCRIPTION

# Description

I've made a mistake here https://github.com/yeahcan/maxi-blocks/pull/2915/files#diff-eb6f474fe72eb0308cc611eb3dfb2a23a5c3b02fa069cd07c5d46f327b9fc3d8 by changing the alignment text for the icon completely. Should have been conditioned depending on the settings toolbar. Fixed that now, and made the icon show only for the image caption toolbar; and otherwise, it will show the text.

Fixes # (no new issue created, related to the issue posted above)

# How Has This Been Tested?

Add an image block, and compare Alignment in the toolbar more settings with the Alignment in the caption toolbar settings.

# Test checklist


**_ Front/Back Testing _**

-   [ ] Check that the settings work on frontend

**_ Pre-Code Testing _**

-   [ ] Check that the settings work on frontend

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] My changes generate no new warnings/errors
