### PR TITLE
Fixes box-sizing on different themes

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -24,6 +24,10 @@ body.maxi-blocks--active .maxi-block {
 	transition: none;
 	line-height: 1;
 
+	* {
+		box-sizing: border-box;
+	}
+
 	&.maxi-container-block .maxi-block:not(.maxi-row-block) {
 		max-width: none;
 	}


### PR DESCRIPTION
# Description

Checking this pattern on my local:
<img width="1423" alt="Captura de pantalla 2022-04-29 a las 13 31 46" src="https://user-images.githubusercontent.com/50477222/165936551-2b455e74-8664-42df-acde-05e010cdbd85.png">

received:
<img width="1423" alt="Captura de pantalla 2022-04-29 a las 13 32 22" src="https://user-images.githubusercontent.com/50477222/165936617-66c66fb1-6de4-4e2d-b33c-7c7a487dfa36.png">


and this has been my face: 💩

Luckily I found it was a line of CSS that wasn't on Twenty Twenty Two theme. Now is done 😝  

# How Has This Been Tested?

Take [this code editor](https://github.com/yeahcan/maxi-blocks/files/8590436/boxsize.txt) and check it from master in frontend in a theme like Twenty Twenty Two; is it broken? It should! Now, change to this branch and... voilá! 

# Test checklist

**_ Front/Back Testing _**

-   [x] Test is broken in `master`
-   [x] Test is fixed in this branch
-   [x] Check other patterns to see this doesn't affect other styles

**_ Pre-Code Testing _**

-   [x] Test is broken in `master`
-   [x] Test is fixed in this branch
-   [ ] Check other patterns to see this doesn't affect other styles

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
