### PR TITLE
Fixes gap bug on responsive

### DIFF
--- a/src/extensions/styles/helpers/getColumnSizeStyles.js
+++ b/src/extensions/styles/helpers/getColumnSizeStyles.js
@@ -18,14 +18,17 @@ const getColumnSizeStyles = (obj, rowGapProps) => {
 
 	breakpoints.forEach(breakpoint => {
 		const fitContent = obj[`column-fit-content-${breakpoint}`];
-		const columnSize = obj[`column-size-${breakpoint}`];
+		let columnSize = obj[`column-size-${breakpoint}`];
 
 		if (fitContent) {
 			response[breakpoint] = {
 				width: 'fit-content',
 				'flex-basis': 'fit-content',
 			};
-		} else if (isNumber(columnSize)) {
+		} else if (
+			isNumber(columnSize) ||
+			isNumber(rowGapProps[`column-gap-${breakpoint}`])
+		) {
 			const gap = getLastBreakpointAttribute({
 				target: 'column-gap',
 				breakpoint,
@@ -36,6 +39,13 @@ const getColumnSizeStyles = (obj, rowGapProps) => {
 				breakpoint,
 				attributes: rowGapProps,
 			});
+
+			if (!columnSize)
+				columnSize = getLastBreakpointAttribute({
+					target: 'column-size',
+					breakpoint,
+					attributes: obj,
+				});
 
 			const gapValue = gap ? `${round(gap, 2)}${gapUnit}` : '0px';
 


### PR DESCRIPTION
# Description

Not all the gap values on responsive where working on the column-size, as this video show:


https://user-images.githubusercontent.com/50477222/165952554-5ab6647d-54a6-4d98-bd9d-d3306fce5b21.mp4

The problem was that we need a value for the colum-size to render it, but didn't considere the possibility of a different gap. Now is fixed.

# How Has This Been Tested?

You can use [this code editor](https://github.com/yeahcan/maxi-blocks/files/8591067/boxsize.txt) and in the first column of the top-left you'll see the inner row has 3 different values for column-gap, one for general/xl, other for l and other for m. On the frontend of master branch, the inner columns of the row just receive xl and m, not l. With this branch it works correctly.

# Test checklist

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
