### PR TITLE
Issue 2961 - fix height conflict

### DIFF
--- a/src/blocks/column-maxi/edit.js
+++ b/src/blocks/column-maxi/edit.js
@@ -175,6 +175,15 @@ class edit extends MaxiBlockComponent {
 						)}
 						defaultSize={{
 							width: getColumnWidthDefault(),
+							height: `${getLastBreakpointAttribute({
+								target: 'height',
+								breakpoint: deviceType,
+								attributes,
+							})}${getLastBreakpointAttribute({
+								target: 'height-unit',
+								breakpoint: deviceType,
+								attributes,
+							})}`,
 						}}
 						enable={{
 							right: true,


### PR DESCRIPTION
# Description
Height on column-maxi was controlled by re-resizable library
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2961 

# How Has This Been Tested?
Change height on column maxi and see if it changes to test
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
