### PR TITLE
Issue 2964 - make resizer not affect the grid 

### DIFF
--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -131,7 +131,11 @@ const BlockResizer = forwardRef((props, ref) => {
 						'maxi-resizable__handle-bottomleft'
 					),
 			}}
-			handleWrapperStyle={{ position: 'absolute', height: '100%' }}
+			handleWrapperStyle={{
+				position: 'absolute',
+				height: '100%',
+				width: '100%',
+			}}
 		>
 			{children}
 		</Resizable>

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -131,7 +131,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						'maxi-resizable__handle-bottomleft'
 					),
 			}}
-			handleWrapperStyle={{ position: 'absolute' }}
+			handleWrapperStyle={{ position: 'absolute', height: '100%' }}
 		>
 			{children}
 		</Resizable>

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -131,6 +131,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						'maxi-resizable__handle-bottomleft'
 					),
 			}}
+			handleWrapperStyle={{ position: 'absolute' }}
 		>
 			{children}
 		</Resizable>


### PR DESCRIPTION
# Description
Added position: absolute to the div containing resizers, so it won't affect the grid
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2964 

# How Has This Been Tested?
Insert two blocks in column maxi and set Vertical align to ```space-between``` they should position on top and bottom of the column
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check if positioning works right
-   [x] Same on responsive
-   [x] Check if resizer works
-   [x] Check that the settings work on frontend

**_ Pre-Code Testing _**

-   [ ] Check if positioning works right
-   [ ] Same on responsive
-   [ ] Check if resizer works
-   [ ] Check that the settings work on frontend
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
