### PR TITLE
issue-2980-width-ui

### DIFF
--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -36,6 +36,7 @@ const FullSizeControl = props => {
 		hideWidth,
 		hideMaxWidth,
 		prefix = '',
+		isBlockFullWidth,
 		allowForceAspectRatio = false,
 	} = props;
 
@@ -80,23 +81,25 @@ const FullSizeControl = props => {
 		},
 	};
 
-	const currentBlockRoot = select('core/block-editor').getBlockRootClientId(
+		const currentBlockRoot = select('core/block-editor').getBlockRootClientId(
 		select('core/block-editor').getSelectedBlockClientId()
 	);
 
 	return (
 		<div className={classes}>
-			<ToggleSwitch
-				label={__('Set width to fit content', 'maxi-blocks')}
-				selected={getLastBreakpointAttribute({
-					target: `${prefix}width-fit-content`,
-					breakpoint,
-					attributes: props,
-				})}
-				onChange={val => {
-					onChangeValue([`${prefix}width-fit-content`], val);
-				}}
-			/>
+			{!isBlockFullWidth && (	
+				<ToggleSwitch
+					label={__('Set width to fit content', 'maxi-blocks')}
+					selected={getLastBreakpointAttribute({
+						target: `${prefix}width-fit-content`,
+						breakpoint,
+						attributes: props,
+					})}
+					onChange={val => {
+						onChangeValue([`${prefix}width-fit-content`], val);
+					}}
+				/>
+			)}
 			{!hideWidth &&
 				!isEmpty(currentBlockRoot) &&
 				!getLastBreakpointAttribute({

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -77,6 +77,7 @@ const size = ({
 						breakpoint={deviceType}
 						hideWidth={hideWidth || isBlockFullWidth}
 						hideMaxWidth={hideMaxWidth || isBlockFullWidth}
+						isBlockFullWidth={isBlockFullWidth}
 						allowForceAspectRatio={block}
 					/>
 				</>


### PR DESCRIPTION
# Description

Enables fit-content option only when full-width is disabled.

Fixes #2980

# How to test it?

Add a block, such as container, and try enabling/disabling the full-width option in the sidebar.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
