### PR TITLE
Column inner blocks selection 

### DIFF
--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -135,6 +135,7 @@ const BlockResizer = forwardRef((props, ref) => {
 				position: 'absolute',
 				height: '100%',
 				width: '100%',
+				zIndex: -1,
 			}}
 		>
 			{children}


### PR DESCRIPTION
# Description

Is so small bug: when having blocks inside a column is imposible to select them. The resizer handles are above, so just set a z-index and should work

Fixes # (issue)

# How Has This Been Tested?

Create a column with elements inside and try if you can select them

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Same 1-4 points on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
