### PR TITLE
Issue 3009 - fix resizer positioned incorrectly

### DIFF
--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -136,6 +136,8 @@ const BlockResizer = forwardRef((props, ref) => {
 				height: '100%',
 				width: '100%',
 				zIndex: -1,
+				top: 0,
+				left: 0,
 			}}
 		>
 			{children}


### PR DESCRIPTION
# Description
Made resizer container not get off the blocks
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3009 

# How Has This Been Tested?
Check if resizer looks as it should and works on all blocks to test
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test resizer on all blocks
-   [x] Test resizer on blocks inside the grid (Container + Row + Column)
-   [ ] Test resizer on responsive

**_ Pre-Code Testing _**

-   [x] Test resizer on all blocks
-   [x] Test resizer on blocks inside the grid (Container + Row + Column)
-   [x] Test resizer on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes
