### PR TITLE
Issue 3025 Text decoration for Twenty Twenty One

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -81,8 +81,8 @@ body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
 	padding: 5px;
 }
 
-/*Removes anchor border for Twenty Twenty One*/
-body.maxi-blocks--active #content .maxi-link-wrapper {
+/*Removes anchor border for Twenty Twenty One and Twenty*/
+body.maxi-blocks--active .maxi-link-wrapper {
 	text-decoration: none;
 	outline: none;
 }

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -79,3 +79,8 @@ body.maxi-blocks--active #wpcontent .is-root-container {
 body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
 	padding: 5px;
 }
+
+/*Removes anchor border for Twenty Twenty One*/
+body.maxi-blocks--active .maxi-link-wrapper {
+	text-decoration: none;
+}

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -57,6 +57,7 @@ body.maxi-blocks--active
 body.maxi-blocks--active #content .maxi-text-block--link:focus,
 body.maxi-blocks--active #content .maxi-link-wrapper:focus {
 	background: unset;
+	text-decoration: none;
 }
 
 /*Removes button focus outline for Twenty Twenty One*/

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -81,6 +81,7 @@ body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
 }
 
 /*Removes anchor border for Twenty Twenty One*/
-body.maxi-blocks--active .maxi-link-wrapper {
+body.maxi-blocks--active #content .maxi-link-wrapper {
 	text-decoration: none;
+	outline: none;
 }


### PR DESCRIPTION
# Description

Twenty Twenty One theme adds text-decoration for all a tags. Overriding it with a custom CSS.

Fixes #3025 

# How to test?

Add a group block and insert a text in it. Add link to the group. The text should not have any decoration.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Insert a group and a text block in it. Link the entire group and make sure the text doesn't have an underline.
-   [ ] Test that you can manually add the underline to the text.

**_ Pre-Code Testing _**

-   [x] Insert a group and a text block in it. Link the entire group and make sure the text doesn't have an underline.
-   [x] Test that you can manually add the underline to the text. Test other text decoration options.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
