### PR TITLE
Issue 3024 - Prevent breaking attributes of other breakpoint on column template change

### DIFF
--- a/src/blocks/row-maxi/attributes.js
+++ b/src/blocks/row-maxi/attributes.js
@@ -109,26 +109,6 @@ const attributes = {
 			type: 'number',
 			default: 1.5,
 		},
-		'column-gap-xxl': {
-			type: 'number',
-			default: 1.5,
-		},
-		'column-gap-l': {
-			type: 'number',
-			default: 1.5,
-		},
-		'column-gap-m': {
-			type: 'number',
-			default: 1.5,
-		},
-		'column-gap-s': {
-			type: 'number',
-			default: 1.5,
-		},
-		'column-gap-xs': {
-			type: 'number',
-			default: 1.5,
-		},
 		'column-gap-unit-general': {
 			type: 'string',
 			default: '%',

--- a/src/blocks/row-maxi/attributes.js
+++ b/src/blocks/row-maxi/attributes.js
@@ -109,6 +109,26 @@ const attributes = {
 			type: 'number',
 			default: 1.5,
 		},
+		'column-gap-xxl': {
+			type: 'number',
+			default: 1.5,
+		},
+		'column-gap-l': {
+			type: 'number',
+			default: 1.5,
+		},
+		'column-gap-m': {
+			type: 'number',
+			default: 1.5,
+		},
+		'column-gap-s': {
+			type: 'number',
+			default: 1.5,
+		},
+		'column-gap-xs': {
+			type: 'number',
+			default: 1.5,
+		},
 		'column-gap-unit-general': {
 			type: 'string',
 			default: '%',

--- a/src/extensions/column-templates/columnTemplates.js
+++ b/src/extensions/column-templates/columnTemplates.js
@@ -42,19 +42,6 @@ import {
 	twoTwoTwoTwoTwoTwo,
 	twoTwoTwoTwo,
 } from '../../icons';
-import getColumnTemplateContent from './getColumnTemplateContent';
-
-const getColumnContent = (columns, breakpoint = 'general') => {
-	return {
-		sizes: columns,
-		content: getColumnTemplateContent(columns, breakpoint),
-		attributes: {
-			[`flex-wrap-${breakpoint}`]: 'wrap',
-			[`column-gap-${breakpoint}`]: 1.5,
-			[`column-gap-unit-${breakpoint}`]: '%',
-		},
-	};
-};
 
 // Array of all templates
 const columnTemplates = {
@@ -63,7 +50,7 @@ const columnTemplates = {
 			{
 				name: '1',
 				icon: oneColumn,
-				...getColumnContent([1]),
+				sizes: [1],
 			},
 		],
 		responsive: [],
@@ -75,38 +62,38 @@ const columnTemplates = {
 				name: '1-1',
 				icon: twoColumns,
 				responsiveLayout: '2-2',
-				...getColumnContent([1 / 2, 1 / 2]),
+				sizes: [1 / 2, 1 / 2],
 			},
 			{
 				name: '1-3',
 				icon: oneThree,
 				responsiveLayout: '2-2',
-				...getColumnContent([1 / 4, 3 / 4]),
+				sizes: [1 / 4, 3 / 4],
 			},
 			{
 				name: '3-1',
 				icon: threeOne,
 				responsiveLayout: '2-2',
-				...getColumnContent([3 / 4, 1 / 4]),
+				sizes: [3 / 4, 1 / 4],
 			},
 			{
 				name: '1-4',
 				icon: oneFour,
 				responsiveLayout: '2-2',
-				...getColumnContent([1 / 5, 4 / 5]),
+				sizes: [1 / 5, 4 / 5],
 			},
 			{
 				name: '4-1',
 				icon: fourOne,
 				responsiveLayout: '2-2',
-				...getColumnContent([4 / 5, 1 / 5]),
+				sizes: [4 / 5, 1 / 5],
 			},
 		],
 		responsive: [
 			{
 				name: '2-2',
 				icon: twoTwo,
-				...getColumnContent([1, 1], 'm'),
+				sizes: [1, 1],
 			},
 		],
 	},
@@ -117,54 +104,54 @@ const columnTemplates = {
 				name: '3 columns',
 				icon: threeColumns,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([1 / 3, 1 / 3, 1 / 3]),
+				sizes: [1 / 3, 1 / 3, 1 / 3],
 			},
 			{
 				name: '1-1-3',
 				icon: oneOneThree,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([1 / 5, 1 / 5, 3 / 5]),
+				sizes: [1 / 5, 1 / 5, 3 / 5],
 			},
 			{
 				name: '1-1-4',
 				icon: oneOneFour,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([1 / 6, 1 / 6, 4 / 6]),
+				sizes: [1 / 6, 1 / 6, 4 / 6],
 			},
 			{
 				name: '1-4-1',
 				icon: oneFourOne,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([1 / 6, 4 / 6, 1 / 6]),
+				sizes: [1 / 6, 4 / 6, 1 / 6],
 			},
 			{
 				name: '3-1-1',
 				icon: threeOneOne,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([3 / 5, 1 / 5, 1 / 5]),
+				sizes: [3 / 5, 1 / 5, 1 / 5],
 			},
 			{
 				name: '4-1-1',
 				icon: fourOneOne,
 				responsiveLayout: '1-1-1',
-				...getColumnContent([4 / 6, 1 / 6, 1 / 6]),
+				sizes: [4 / 6, 1 / 6, 1 / 6],
 			},
 		],
 		responsive: [
 			{
 				name: '1-1-2',
 				icon: oneOneTwo,
-				...getColumnContent([1 / 2, 1 / 2, 1], 'm'),
+				sizes: [1 / 2, 1 / 2, 1],
 			},
 			{
 				name: '1-2-2',
 				icon: oneTwoTwo,
-				...getColumnContent([1, 1 / 2, 1 / 2], 'm'),
+				sizes: [1, 1 / 2, 1 / 2],
 			},
 			{
 				name: '1-1-1',
 				icon: oneOneOne,
-				...getColumnContent([1, 1, 1], 'm'),
+				sizes: [1, 1, 1],
 			},
 		],
 	},
@@ -175,34 +162,34 @@ const columnTemplates = {
 				name: '4 columns',
 				icon: fourColumns,
 				responsiveLayout: '2-2-2-2',
-				...getColumnContent([1 / 4, 1 / 4, 1 / 4, 1 / 4]),
+				sizes: [1 / 4, 1 / 4, 1 / 4, 1 / 4],
 			},
 		],
 		responsive: [
 			{
 				name: '1-1-1-1',
 				icon: oneOneOneOne,
-				...getColumnContent([1 / 2, 1 / 2, 1 / 2, 1 / 2], 'm'),
+				sizes: [1 / 2, 1 / 2, 1 / 2, 1 / 2],
 			},
 			{
 				name: '2-1-1-2',
 				icon: twoOneOneTwo,
-				...getColumnContent([1, 1 / 2, 1 / 2, 1], 'm'),
+				sizes: [1, 1 / 2, 1 / 2, 1],
 			},
 			{
 				name: '1-1-2-2',
 				icon: oneOneTwoTwo,
-				...getColumnContent([1 / 2, 1 / 2, 1, 1], 'm'),
+				sizes: [1 / 2, 1 / 2, 1, 1],
 			},
 			{
 				name: '2-2-1-1',
 				icon: twoTwoOneOne,
-				...getColumnContent([1, 1, 1 / 2, 1 / 2], 'm'),
+				sizes: [1, 1, 1 / 2, 1 / 2],
 			},
 			{
 				name: '2-2-2-2',
 				icon: twoTwoTwoTwo,
-				...getColumnContent([1, 1, 1, 1], 'm'),
+				sizes: [1, 1, 1, 1],
 			},
 		],
 	},
@@ -213,29 +200,29 @@ const columnTemplates = {
 				name: '5 columns',
 				icon: fiveColumns,
 				responsiveLayout: '1-1-1-1-1',
-				...getColumnContent([1 / 5, 1 / 5, 1 / 5, 1 / 5, 1 / 5]),
+				sizes: [1 / 5, 1 / 5, 1 / 5, 1 / 5, 1 / 5],
 			},
 		],
 		responsive: [
 			{
 				name: '2-1-1-1-1',
 				icon: twoOneOneOneOne,
-				...getColumnContent([1, 1 / 2, 1 / 2, 1 / 2, 1 / 2], 'm'),
+				sizes: [1, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
 			},
 			{
 				name: '1-1-2-1-1',
 				icon: oneOneTwoOneOne,
-				...getColumnContent([1 / 2, 1 / 2, 1, 1 / 2, 1 / 2], 'm'),
+				sizes: [1 / 2, 1 / 2, 1, 1 / 2, 1 / 2],
 			},
 			{
 				name: '1-1-1-1-2',
 				icon: oneOneOneOneTwo,
-				...getColumnContent([1 / 2, 1 / 2, 1 / 2, 1 / 2, 1], 'm'),
+				sizes: [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1],
 			},
 			{
 				name: '1-1-1-1-1',
 				icon: oneOneOneOneOne,
-				...getColumnContent([1, 1, 1, 1, 1], 'm'),
+				sizes: [1, 1, 1, 1, 1],
 			},
 		],
 	},
@@ -246,22 +233,19 @@ const columnTemplates = {
 				name: '6 columns',
 				icon: sixColumns,
 				responsiveLayout: '2-2-2-2-2-2',
-				...getColumnContent([1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6]),
+				sizes: [1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6, 1 / 6],
 			},
 		],
 		responsive: [
 			{
 				name: '1-1-1-1-1-1',
 				icon: oneOneOneOneOneOne,
-				...getColumnContent(
-					[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
-					'm'
-				),
+				sizes: [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
 			},
 			{
 				name: '2-2-2-2-2-2',
 				icon: twoTwoTwoTwoTwoTwo,
-				...getColumnContent([1, 1, 1, 1, 1, 1], 'm'),
+				sizes: [1, 1, 1, 1, 1, 1],
 			},
 		],
 	},
@@ -272,54 +256,34 @@ const columnTemplates = {
 				name: '7 columns',
 				icon: sevenColumns,
 				responsiveLayout: '1-1-1-1-1-1-1',
-				...getColumnContent([
-					1 / 7,
-					1 / 7,
-					1 / 7,
-					1 / 7,
-					1 / 7,
-					1 / 7,
-					1 / 7,
-				]),
+				sizes: [1 / 7, 1 / 7, 1 / 7, 1 / 7, 1 / 7, 1 / 7, 1 / 7],
 			},
 		],
 		responsive: [
 			{
 				name: '2-1-1-1-1-1-1',
 				icon: twoOneOneOneOneOneOne,
-				...getColumnContent(
-					[1, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
-					'm'
-				),
+				sizes: [1, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
 			},
 			{
 				name: '1-1-1-1-1-1-2',
 				icon: oneOneOneOneOneOneTwo,
-				...getColumnContent(
-					[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1],
-					'm'
-				),
+				sizes: [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1],
 			},
 			{
 				name: '1-1-1-1-1-1-1-3',
 				icon: oneOneOneOneOneOneOneThree,
-				...getColumnContent(
-					[1, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3],
-					'm'
-				),
+				sizes: [1, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3],
 			},
 			{
 				name: '3-1-1-1-1-1-1-1',
 				icon: threeOneOneOneOneOneOneOne,
-				...getColumnContent(
-					[1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1],
-					'm'
-				),
+				sizes: [1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1 / 3, 1],
 			},
 			{
 				name: '1-1-1-1-1-1-1',
 				icon: oneOneOneOneOneOneOne,
-				...getColumnContent([1, 1, 1, 1, 1, 1, 1], 'm'),
+				sizes: [1, 1, 1, 1, 1, 1, 1],
 			},
 		],
 	},
@@ -330,31 +294,19 @@ const columnTemplates = {
 				name: '8 columns',
 				icon: eightColumns,
 				responsiveLayout: '2-2-2-2-2-2-2-2',
-				...getColumnContent([
-					1 / 8,
-					1 / 8,
-					1 / 8,
-					1 / 8,
-					1 / 8,
-					1 / 8,
-					1 / 8,
-					1 / 8,
-				]),
+				sizes: [1 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8],
 			},
 		],
 		responsive: [
 			{
 				name: '1-1-1-1-1-1-1-1',
 				icon: oneOneOneOneOneOneOneOne,
-				...getColumnContent(
-					[1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
-					'm'
-				),
+				sizes: [1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2, 1 / 2],
 			},
 			{
 				name: '2-2-2-2-2-2-2-2',
 				icon: twoTwoTwoTwoTwoTwoTwoTwo,
-				...getColumnContent([1, 1, 1, 1, 1, 1, 1, 1], 'm'),
+				sizes: [1, 1, 1, 1, 1, 1, 1, 1],
 			},
 		],
 	},

--- a/src/extensions/column-templates/getColumnTemplate.js
+++ b/src/extensions/column-templates/getColumnTemplate.js
@@ -9,6 +9,17 @@ import getColumnTemplateContent from './getColumnTemplateContent';
  */
 import { find } from 'lodash';
 
+const getColumnContent = (columns, breakpoint) => {
+	return {
+		content: getColumnTemplateContent(columns, breakpoint),
+		attributes: {
+			[`flex-wrap-${breakpoint}`]: 'wrap',
+			[`column-gap-${breakpoint}`]: 1.5,
+			[`column-gap-unit-${breakpoint}`]: '%',
+		},
+	};
+};
+
 const getColumnTemplate = (templateName, breakpoint) => {
 	let template = null;
 
@@ -16,11 +27,9 @@ const getColumnTemplate = (templateName, breakpoint) => {
 		Object.values(colNum).forEach(colRes => {
 			const res = find(colRes, e => e.name === templateName);
 
-			if (res) template = res;
+			if (res) template = getColumnContent(res.sizes, breakpoint);
 		})
 	);
-
-	template.content = getColumnTemplateContent(template.sizes, breakpoint);
 
 	return template;
 };


### PR DESCRIPTION
# Description

Now when you change some breakpoint column template, you won't lose your attributes which was set in another breakpoint

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3024 

# How Has This Been Tested?
Change the column gap at the breakpoint, switch and change column template and check if it does not affect the column gap value and other column template attributes at other breakpoints

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the column gap at each breakpoint does not affect to another
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the column gap at each breakpoint does not affect to another
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
