### PR TITLE
Issue 2960 - responsive bugs fix

### DIFF
--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch, select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { cloneElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import SettingTabsControl from '../setting-tabs-control';
+import { setScreenSize } from '../../extensions/styles';
 
 /**
  * External dependencies
@@ -41,21 +42,7 @@ const ResponsiveTabsControl = props => {
 		};
 	});
 
-	const { setMaxiDeviceType } = useDispatch('maxiBlocks');
-
 	const breakpoints = ['XXL', 'XL', 'L', 'M', 'S', 'XS'];
-
-	const setScreenSize = size => {
-		const xxlSize = select('maxiBlocks').receiveXXLSize();
-		const breakpointsWidth = select('maxiBlocks').receiveMaxiBreakpoints();
-
-		if (winBreakpoint === size) setMaxiDeviceType('general');
-		else
-			setMaxiDeviceType(
-				size,
-				size !== 'xxl' ? breakpointsWidth[size] : xxlSize
-			);
-	};
 
 	const classes = classnames('maxi-responsive-tabs-control', className);
 
@@ -88,7 +75,9 @@ const ResponsiveTabsControl = props => {
 					showNotification: showNotification(breakpoint),
 					callback: () =>
 						!disableCallback
-							? setScreenSize(breakpoint.toLowerCase())
+							? winBreakpoint === breakpoint.toLowerCase()
+								? setScreenSize('general')
+								: setScreenSize(breakpoint.toLowerCase())
 							: null,
 					breakpoint: breakpoint.toLowerCase(),
 				};

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -49,7 +49,7 @@ const ResponsiveTabsControl = props => {
 		const xxlSize = select('maxiBlocks').receiveXXLSize();
 		const breakpointsWidth = select('maxiBlocks').receiveMaxiBreakpoints();
 
-		if (size === 'general') setMaxiDeviceType('general');
+		if (winBreakpoint === size) setMaxiDeviceType('general');
 		else
 			setMaxiDeviceType(
 				size,

--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select } from '@wordpress/data';
 import { cloneElement } from '@wordpress/element';
 
 /**
@@ -32,7 +32,7 @@ const ResponsiveTabsControl = props => {
 	} = props;
 
 	const { winBreakpoint } = useSelect(select => {
-		const { receiveWinBreakpoint } = wp.data.select('maxiBlocks');
+		const { receiveWinBreakpoint } = select('maxiBlocks');
 
 		const winBreakpoint = receiveWinBreakpoint();
 
@@ -44,6 +44,18 @@ const ResponsiveTabsControl = props => {
 	const { setMaxiDeviceType } = useDispatch('maxiBlocks');
 
 	const breakpoints = ['XXL', 'XL', 'L', 'M', 'S', 'XS'];
+
+	const setScreenSize = size => {
+		const xxlSize = select('maxiBlocks').receiveXXLSize();
+		const breakpointsWidth = select('maxiBlocks').receiveMaxiBreakpoints();
+
+		if (size === 'general') setMaxiDeviceType('general');
+		else
+			setMaxiDeviceType(
+				size,
+				size !== 'xxl' ? breakpointsWidth[size] : xxlSize
+			);
+	};
 
 	const classes = classnames('maxi-responsive-tabs-control', className);
 
@@ -76,11 +88,7 @@ const ResponsiveTabsControl = props => {
 					showNotification: showNotification(breakpoint),
 					callback: () =>
 						!disableCallback
-							? setMaxiDeviceType(
-									winBreakpoint === breakpoint.toLowerCase()
-										? 'general'
-										: breakpoint.toLowerCase()
-							  )
+							? setScreenSize(breakpoint.toLowerCase())
 							: null,
 					breakpoint: breakpoint.toLowerCase(),
 				};

--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch, select } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -11,6 +11,7 @@ import { createBlock } from '@wordpress/blocks';
 import Button from '../../components/button';
 import Icon from '../../components/icon';
 import MaxiStyleCardsEditorPopUp from '../style-cards';
+import { setScreenSize } from '../../extensions/styles';
 
 /**
  * External dependencies
@@ -36,32 +37,13 @@ import {
 /**
  * Components
  */
-const ResponsiveButton = ({
-	winBreakpoint,
-	icon,
-	breakpoint,
-	target,
-	breakpoints,
-}) => {
+const ResponsiveButton = ({ winBreakpoint, icon, breakpoint, target }) => {
 	const isWinBreakpoint = winBreakpoint === target;
 
 	const classes = classnames(
 		'maxi-responsive-selector__button-wrapper',
 		isWinBreakpoint && 'maxi-responsive-selector__base'
 	);
-
-	const { setMaxiDeviceType } = useDispatch('maxiBlocks');
-
-	const setScreenSize = size => {
-		const xxlSize = select('maxiBlocks').receiveXXLSize();
-
-		if (size === 'general') setMaxiDeviceType('general');
-		else
-			setMaxiDeviceType(
-				size,
-				size !== 'xxl' ? breakpoints[size] : xxlSize
-			);
-	};
 
 	const getIsPressed = () => {
 		if (breakpoint === 'general') return winBreakpoint === target;

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -23,11 +23,9 @@ const breakpointResizer = (
 		editorWrapper.style.width = '';
 		editorWrapper.style.margin = '';
 	} else {
-		if (size !== 'xxl') editorWrapper.style.width = `${responsiveWidth}px`;
-		else editorWrapper.style.width = `${responsiveWidth}px`;
+		editorWrapper.style.width = `${responsiveWidth}px`;
 
-		if (winHeight > responsiveWidth)
-			editorWrapper.style.margin = '36px auto';
+		if (winHeight > responsiveWidth) editorWrapper.style.margin = '0 auto';
 		else editorWrapper.style.margin = '';
 	}
 };

--- a/src/extensions/styles/index.js
+++ b/src/extensions/styles/index.js
@@ -15,6 +15,7 @@ export { default as hoverAttributesCreator } from './hoverAttributesCreator';
 export { default as paletteAttributesCreator } from './paletteAttributesCreator';
 export { default as prefixAttributesCreator } from './prefixAttributesCreator';
 export { default as setHoverAttributes } from './setHoverAttributes';
+export { default as setScreenSize } from './setScreenSize';
 export { default as styleGenerator } from './styleGenerator';
 export { default as styleResolver } from './styleResolver';
 export { default as stylesCleaner } from './stylesCleaner';

--- a/src/extensions/styles/setScreenSize.js
+++ b/src/extensions/styles/setScreenSize.js
@@ -1,0 +1,15 @@
+import { select, dispatch } from '@wordpress/data';
+
+const setScreenSize = size => {
+	const xxlSize = select('maxiBlocks').receiveXXLSize();
+	const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
+
+	if (size === 'general') dispatch('maxiBlocks').setMaxiDeviceType('general');
+	else
+		dispatch('maxiBlocks').setMaxiDeviceType(
+			size,
+			size !== 'xxl' ? breakpoints[size] : xxlSize
+		);
+};
+
+export default setScreenSize;


### PR DESCRIPTION
# Description
In ResponsiveTabsControl added the same breakpoint change function as in responsive select on top of the screen.
To fix height bug, removed margin top/bottom for editor wrapper on S, XS breakpoints as it was somehow messing with WordPress' height calculations. 
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2960 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test responsive tabs creates iframe
-   [x] Check if height calculates correctly

**_ Pre-Code Testing _**

-   [x] Test responsive tabs creates iframe
-   [x] Check if height calculates correctly
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes
