### PR TITLE
issue-2947: set static icon colors on maxi modal

### DIFF
--- a/src/editor/library/util.js
+++ b/src/editor/library/util.js
@@ -127,82 +127,17 @@ export const imageUploader = async (imageSrc, usePlaceholderImage) => {
 };
 
 export const svgAttributesReplacer = (blockStyle, svgCode, target = 'svg') => {
-	const { getSelectedBlockClientId, getBlock } = select('core/block-editor');
-	const clientId = getSelectedBlockClientId();
-	const currentAttributes = getBlock(clientId).attributes;
-
-	if (!currentAttributes) return false;
-
-	const fillColor = !currentAttributes[`${target}-fill-palette-status`]
-		? currentAttributes[`${target}-fill-color`]
-		: getColorRGBAString({
-				firstVar: 'icon-fill',
-				secondVar: `color-${
-					currentAttributes[`${target}-fill-palette-color`]
-				}`,
-				opacity: currentAttributes[`${target}-fill-palette-opacity`],
-				blockStyle,
-		  }) || '';
-
-	const lineColor = !currentAttributes[`${target}-line-palette-status`]
-		? currentAttributes[`${target}-line-color`]
-		: getColorRGBAString({
-				firstVar: 'icon-stroke',
-				secondVar: `color-${
-					currentAttributes[`${target}-line-palette-color`]
-				}`,
-				opacity: currentAttributes[`${target}-line-palette-opacity`],
-				blockStyle,
-		  }) || '';
-
-	const shapeFillColor = !currentAttributes[`${target}-fill-palette-status`]
-		? currentAttributes[`${target}-fill-color`]
-		: getColorRGBAString({
-				firstVar: 'shape-fill',
-				secondVar: `color-${
-					currentAttributes[`${target}-fill-palette-color`]
-				}`,
-				opacity: 100,
-				blockStyle,
-		  }) || '';
-
-	const iconNoInheritColor = !currentAttributes[`${target}-palette-status`]
-		? currentAttributes[`${target}-color`]
-		: getColorRGBAString({
-				firstVar: 'color',
-				secondVar: `color-${
-					currentAttributes[`${target}-palette-color`]
-				}`,
-				opacity: 100,
-				blockStyle,
-		  }) || '';
-
-	const iconInheritColor = !currentAttributes['palette-status-general']
-		? currentAttributes['color-general']
-		: getColorRGBAString({
-				firstVar: 'color',
-				secondVar: `color-${currentAttributes['palette-color-general']}`,
-				opacity: 100,
-				blockStyle,
-		  }) || '';
-
-	const iconColor = currentAttributes['icon-inherit']
-		? iconInheritColor
-		: iconNoInheritColor;
-
 	const fillRegExp = new RegExp('fill:[^n]+?(?=})', 'g');
-	const fillStr = `fill:${target === 'shape' ? shapeFillColor : fillColor}`;
+	const fillStr = 'fill:#ff4a17';
 
 	const fillRegExp2 = new RegExp('[^-]fill="[^n]+?(?=")', 'g');
-	const fillStr2 = ` fill="${
-		target === 'shape' ? shapeFillColor : fillColor
-	}`;
+	const fillStr2 = ' fill="#ff4a17';
 
 	const strokeRegExp = new RegExp('stroke:[^n]+?(?=})', 'g');
-	const strokeStr = `stroke:${target === 'icon' ? iconColor : lineColor}`;
+	const strokeStr = 'stroke:#081219';
 
 	const strokeRegExp2 = new RegExp('[^-]stroke="[^n]+?(?=")', 'g');
-	const strokeStr2 = ` stroke="${target === 'icon' ? iconColor : lineColor}`;
+	const strokeStr2 = ' stroke="#081219';
 
 	return target === 'svg'
 		? svgCode


### PR DESCRIPTION
# Description
Maxi modal was built to display icons with icon line and fill colors that are set to the block but when the colors are similar to the modal background ( white) the icons could barely be seen. Therefore, discussing with kyra as a quick implementation I made the icon's colors to be fixed-the default maxi line and fill colors.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2947

# How Has This Been Tested?
changing icon colors in svg icon or button maxi check that the icons in the modal are the same (default colors)
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] check icons colors in the modal for svg and button maxi


**_ Pre-Code Testing _**

-   [x] check icons colors in the modal for svg and button maxi
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
