### PR TITLE
Issue 2965: Button Maxi icon margin 

### DIFF
--- a/src/blocks/button-maxi/styles.js
+++ b/src/blocks/button-maxi/styles.js
@@ -400,20 +400,24 @@ const getIconObject = (props, target) => {
 			!isNil(props['icon-position'])
 		) {
 			props['icon-position'] === 'left'
-				? (responsive[breakpoint][
-						'margin-right'
-				  ] = `${getLastBreakpointAttribute({
-						target: 'icon-spacing',
-						breakpoint,
-						attributes: props,
-				  })}px`)
-				: (responsive[breakpoint][
-						'margin-left'
-				  ] = `${getLastBreakpointAttribute({
-						target: 'icon-spacing',
-						breakpoint,
-						attributes: props,
-				  })}px`);
+				? (responsive[breakpoint]['margin-right'] = `${
+						props['icon-only']
+							? '0'
+							: getLastBreakpointAttribute({
+									target: 'icon-spacing',
+									breakpoint,
+									attributes: props,
+							  })
+				  }px`)
+				: (responsive[breakpoint]['margin-left'] = `${
+						props['icon-only']
+							? '0'
+							: getLastBreakpointAttribute({
+									target: 'icon-spacing',
+									breakpoint,
+									attributes: props,
+							  })
+				  }px`);
 		}
 	});
 


### PR DESCRIPTION
# Description
Got rid of the unnecessary margin of the icons on icon-only button maxi.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2965

# How Has This Been Tested?
Making the button icon only check there is no margin on `.maxi-button-block__icon` div.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
