### PR TITLE
Issue: 2966 fixed default padding issue for button maxi

### DIFF
--- a/src/blocks/button-maxi/attributes.js
+++ b/src/blocks/button-maxi/attributes.js
@@ -147,6 +147,25 @@ const attributes = {
 	},
 	...prefixAttributesCreator({ obj: attributesData.boxShadowHover, prefix }),
 
+	...prefixAttributesCreator({ obj: attributesData.size, prefix }),
+	...prefixAttributesCreator({ obj: attributesData.margin, prefix }),
+	...prefixAttributesCreator({
+		obj: attributesData.padding,
+		prefix,
+		diffValAttr: {
+			[`${prefix}padding-top-xxl`]: '23',
+			[`${prefix}padding-right-xxl`]: '55',
+			[`${prefix}padding-bottom-xxl`]: '23',
+			[`${prefix}padding-left-xxl`]: '55',
+			[`${prefix}padding-top-xl`]: '15',
+			[`${prefix}padding-right-xl`]: '36',
+			[`${prefix}padding-bottom-xl`]: '15',
+			[`${prefix}padding-left-xl`]: '36',
+			[`${prefix}padding-sync-xl`]: 'axis',
+			[`${prefix}padding-sync-xxl`]: 'axis',
+		},
+	}),
+
 	/**
 	 * Canvas styles
 	 */
@@ -163,22 +182,6 @@ const attributes = {
 	...attributesData.boxShadow,
 	...attributesData.boxShadowHover,
 	...attributesData.opacity,
-	...prefixAttributesCreator({ obj: attributesData.size, prefix }),
-	...prefixAttributesCreator({ obj: attributesData.margin, prefix }),
-	...prefixAttributesCreator({
-		obj: attributesData.padding,
-		prefix,
-		diffValAttr: {
-			[`${prefix}padding-top-xxl`]: '23',
-			[`${prefix}padding-right-xxl`]: '55',
-			[`${prefix}padding-bottom-xxl`]: '23',
-			[`${prefix}padding-left-xxl`]: '55',
-			[`${prefix}padding-top-xl`]: '15',
-			[`${prefix}padding-right-xl`]: '36',
-			[`${prefix}padding-bottom-xl`]: '15',
-			[`${prefix}padding-left-xl`]: '36',
-		},
-	}),
 
 	/**
 	 * Advanced


### PR DESCRIPTION
# Description
Changed button padding sync to axis instead of all as it fits the default padding values of button maxi
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2966

# How Has This Been Tested?
Create a new button and now the padding sync is axis instead of all.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Add a new button and check padding sync
**_ Pre-Code Testing _**
-   [x] Add a new button and check padding sync
# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
