### PR TITLE
Issue 2970 - Toolbar items close after clicking out

### DIFF
--- a/src/components/toolbar/components/toolbar-popover/index.js
+++ b/src/components/toolbar/components/toolbar-popover/index.js
@@ -47,7 +47,10 @@ class ToolbarPopover extends Component {
 		if (
 			this.ref.current?.ownerDocument.querySelectorAll(
 				'.toolbar-item__popover'
-			).length >= 2
+			).length >= 2 ||
+			this.ref.current?.ownerDocument.querySelector(
+				'.components-dropdown__content'
+			)
 		)
 			this.state.onClose();
 	}

--- a/src/components/toolbar/components/toolbar-popover/index.js
+++ b/src/components/toolbar/components/toolbar-popover/index.js
@@ -43,14 +43,18 @@ class ToolbarPopover extends Component {
 	/**
 	 * Ensures the popover closes when clicking outside
 	 */
-	onClickOutside() {
+	onClickOutside(event) {
 		if (
 			this.ref.current?.ownerDocument.querySelectorAll(
 				'.toolbar-item__popover'
 			).length >= 2 ||
-			this.ref.current?.ownerDocument.querySelector(
-				'.components-dropdown__content'
-			)
+			// If the click isn't inside the popover and isn't inside the button
+			(!event.path.includes(
+				this.ref.current?.ownerDocument.querySelector(
+					'.toolbar-item__popover'
+				)
+			) &&
+				!event.path.includes(this.ref.current))
 		)
 			this.state.onClose();
 	}


### PR DESCRIPTION
# Description

Close toolbar popover item if we click to block dropdown list

https://user-images.githubusercontent.com/46112160/167636254-21fe3e25-a9fd-4fc8-b110-765e61db9586.mp4


<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #2970 

# How Has This Been Tested?

Add a row, change the column template, click the block list dropdown, and make sure the toolbar item is closed after

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Toolbar item popover close after clicking out on block dropdown, sidebar, other toolbar item popover, etc (ColumnPicker at first)
-   [x] Toolbar normal behavior doesn't change

**_ Pre-Code Testing _**

-   [ ] Toolbar item popover close after clicking out on block dropdown, sidebar, other toolbar item popover, etc (ColumnPicker at first)
-   [ ] Toolbar normal behavior doesn't change
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
