### PR TITLE
Issue 3011: Style Card editor disappears when opening the Advanced tab

### DIFF
--- a/src/components/accordion-control/Accordion.js
+++ b/src/components/accordion-control/Accordion.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { select, useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
-import { cloneElement } from '@wordpress/element';
+import { useEffect, useState, cloneElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,6 +27,7 @@ const Accordion = props => {
 		disablePadding = false,
 		preExpandedAccordion,
 		blockName,
+		depth = 1,
 	} = props;
 
 	const [itemExpanded, setItemExpanded] = useState(preExpandedAccordion);
@@ -35,14 +35,14 @@ const Accordion = props => {
 	const { updateInspectorPath } = useDispatch('maxiBlocks');
 
 	const updatedItemExpanded = useSelect(
-		() => select('maxiBlocks').receiveInspectorPath()?.[1]?.value
+		() => select('maxiBlocks').receiveInspectorPath()?.[depth]?.value
 	);
 
 	const { getBlockName, getSelectedBlockClientId } =
 		select('core/block-editor');
 
 	const toggleExpanded = uuid => {
-		updateInspectorPath({ depth: 1, value: uuid });
+		updateInspectorPath({ depth, value: uuid });
 		setItemExpanded(uuid);
 	};
 

--- a/src/components/accordion-control/Accordion.js
+++ b/src/components/accordion-control/Accordion.js
@@ -28,6 +28,7 @@ const Accordion = props => {
 		preExpandedAccordion,
 		blockName,
 		depth = 1,
+		isStyleCard = false,
 	} = props;
 
 	const [itemExpanded, setItemExpanded] = useState(preExpandedAccordion);
@@ -42,13 +43,13 @@ const Accordion = props => {
 		select('core/block-editor');
 
 	const toggleExpanded = uuid => {
-		updateInspectorPath({ depth, value: uuid });
+		if (!isStyleCard) updateInspectorPath({ depth, value: uuid });
 		setItemExpanded(uuid);
 	};
 
 	useEffect(() => {
 		if (updatedItemExpanded !== itemExpanded) {
-			setItemExpanded(updatedItemExpanded);
+			if (!isStyleCard) setItemExpanded(updatedItemExpanded);
 		}
 	}, [updatedItemExpanded]);
 

--- a/src/components/accordion-control/index.js
+++ b/src/components/accordion-control/index.js
@@ -18,7 +18,7 @@ import './editor.scss';
  * Component
  */
 const AccordionControl = props => {
-	const { className, isPrimary = false, isSecondary = false } = props;
+	const { className, isPrimary = false, isSecondary = false, depth } = props;
 
 	const classes = classnames(
 		'maxi-accordion-control',
@@ -34,6 +34,7 @@ const AccordionControl = props => {
 			className={classes}
 			preExpanded={preExpandedAccordion}
 			{...props}
+			depth={depth}
 		/>
 	);
 };

--- a/src/components/setting-tabs-control/index.js
+++ b/src/components/setting-tabs-control/index.js
@@ -56,7 +56,7 @@ const SettingTabsControl = props => {
 	const [tab, setTab] = useState(0);
 
 	const updatedTab = useSelect(
-		() => select('maxiBlocks').receiveInspectorPath()?.[0]?.value || 0
+		() => select('maxiBlocks').receiveInspectorPath()?.[depth]?.value || 0
 	);
 
 	const currentForcedTab = getForcedTabFromPath(items, depth);

--- a/src/components/toolbar/components/copy-paste/index.js
+++ b/src/components/toolbar/components/copy-paste/index.js
@@ -404,7 +404,6 @@ const CopyPasteContent = props => {
 							<SettingTabsControl
 								target='sidebar-settings-tabs'
 								disablePadding
-								depth={0}
 								items={getTabItems()}
 							/>
 							<Button

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -402,7 +402,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'
 				isSecondary
-				depth={99}
+				depth='style-card'
 				items={[
 					{
 						label: __('Quick Pick Colour Presets', 'maxi-blocks'),

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -402,7 +402,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'
 				isSecondary
-				depth='style-card'
+				isStyleCard
 				items={[
 					{
 						label: __('Quick Pick Colour Presets', 'maxi-blocks'),

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -402,6 +402,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'
 				isSecondary
+				depth={2}
 				items={[
 					{
 						label: __('Quick Pick Colour Presets', 'maxi-blocks'),

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -402,7 +402,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'
 				isSecondary
-				depth={2}
+				depth={99}
 				items={[
 					{
 						label: __('Quick Pick Colour Presets', 'maxi-blocks'),


### PR DESCRIPTION
# Description
Fixed: Style Card editor disappears when opening the Advanced tab on foundation blocks with Canvas tab and the automatic closing of accordion of the style card when an accordion is opened in the side-bar.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3011 

# How Has This Been Tested?
Check
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the Style card doesn't disappear when opening Advanced Tab
-   [ ] Test the accordion in SC doesn't close when accordion in side bar is opened

**_ Pre-Code Testing _**

-   [x] Test the Style card doesn't disappear when opening Advanced Tab
-   [x] Test the accordion in SC doesn't close when accordion in side bar is opened
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
