### PR TITLE
Issue 3043 - resizer handles not showing on transform scale

### DIFF
--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -93,6 +93,14 @@ body.maxi-blocks--active .maxi-block__resizer {
 				}
 			}
 		}
+		&__handle-wrapper {
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			z-index: -1;
+			top: 0;
+			left: 0;
+		}
 	}
 	&--overflow {
 		.maxi-resizable__handle {

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -36,6 +36,7 @@ const BlockResizer = forwardRef((props, ref) => {
 	const handleClassName = 'maxi-resizable__handle';
 	const showHandlesClassName = showHandle && 'maxi-resizable__handle--show';
 	const sideHandleClassName = 'maxi-resizable__side-handle';
+	const handlesWrapperClassName = 'maxi-resizable__handle-wrapper';
 
 	const enable = {
 		top: false,
@@ -131,14 +132,7 @@ const BlockResizer = forwardRef((props, ref) => {
 						'maxi-resizable__handle-bottomleft'
 					),
 			}}
-			handleWrapperStyle={{
-				position: 'absolute',
-				height: '100%',
-				width: '100%',
-				zIndex: -1,
-				top: 0,
-				left: 0,
-			}}
+			handleWrapperClass={handlesWrapperClassName}
 		>
 			{children}
 		</Resizable>

--- a/src/components/transform-control/editor.scss
+++ b/src/components/transform-control/editor.scss
@@ -82,6 +82,7 @@
 				}
 			}
 			&__resizer {
+				z-index: 1;
 				border: 1px solid #dddfe1;
 			}
 			&__draggable {


### PR DESCRIPTION
# Description
Moved resizer handles wrapper styles to scss file. Added z-index: 1 to resizer on transfrom control.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3043 

# How Has This Been Tested?
Check handles are visible on transform scale.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check handles are visible
-   [x] Check handles are working

**_ Pre-Code Testing _**

-   [x] Check handles are visible
-   [x] Check handles are working
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes
