### PR TITLE
Issue 3016 arrows ff

### DIFF
--- a/src/components/color-control/customColorControl.js
+++ b/src/components/color-control/customColorControl.js
@@ -104,24 +104,6 @@ const CustomColorControl = props => {
 							onReset={onResetOpacity}
 						/>
 					)}
-					{!disableReset && (
-						<Button
-							className='components-maxi-control__reset-button'
-							onClick={e => {
-								e.preventDefault();
-								onReset();
-							}}
-							isSmall
-							aria-label={sprintf(
-								/* translators: %s: a textual label  */
-								__('Reset %s settings', 'maxi-blocks'),
-								label?.toLowerCase()
-							)}
-							type='reset'
-						>
-							{reset}
-						</Button>
-					)}
 				</>
 			)}
 			{isToolbar && (

--- a/src/components/color-control/customColorControl.js
+++ b/src/components/color-control/customColorControl.js
@@ -1,172 +1,173 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import Icon from '../icon';
-import BaseControl from '../base-control';
-import OpacityControl from '../opacity-control';
-import Button from '../button';
-
-/**
- * External dependencies
- */
-import ChromePicker from 'react-color';
-import tinycolor from 'tinycolor2';
-import { isEmpty } from 'lodash';
-
-/**
- * Icons
- */
-import './editor.scss';
-import { colorOpacity, reset } from '../../icons';
-
-/**
- * Component
- */
-const CustomColorControl = props => {
-	const {
-		label,
-		color,
-		onChangeInlineValue,
-		onChangeValue,
-		disableColorDisplay,
-		disableOpacity,
-		isToolbar = false,
-		disableReset,
-		onReset,
-		onResetOpacity,
-	} = props;
-	const [colorPicker, setColorPicker] = useState(color);
-	const [isChanging, setIsChanging] = useState(false);
-
-	useEffect(() => {
-		if (!isChanging) setColorPicker(color);
-	}, [color]);
-
-	return (
-		<>
-			{!isToolbar && (
-				<>
-					{!disableColorDisplay && (
-						<BaseControl
-							className='maxi-color-control__display'
-							label={`${label} ${__('colour', 'maxi-blocks')}`}
-						>
-							<div className='maxi-color-control__display__color'>
-								<span
-									style={{
-										background:
-											tinycolor(
-												colorPicker
-											).toRgbString(),
-									}}
-								/>
-							</div>
-							{!disableReset && (
-								<Button
-									className='components-maxi-control__reset-button'
-									onClick={e => {
-										e.preventDefault();
-										onReset();
-									}}
-									isSmall
-									aria-label={sprintf(
-										/* translators: %s: a textual label  */
-										__('Reset %s settings', 'maxi-blocks'),
-										label?.toLowerCase()
-									)}
-									type='reset'
-								>
-									{reset}
-								</Button>
-							)}
-						</BaseControl>
-					)}
-					{!disableOpacity && (
-						<OpacityControl
-							label={__('Colour opacity', 'maxi-blocks')}
-							opacity={color.a}
-							onChange={val => {
-								if (!isEmpty(color)) {
-									color.a = val;
-
-									onChangeValue({
-										color: tinycolor(color).toRgbString(),
-										paletteOpacity: val,
-									});
-								}
-							}}
-							onReset={onResetOpacity}
-						/>
-					)}
-				</>
-			)}
-			{isToolbar && (
-				<div className='maxi-color-control__wrap'>
-					<BaseControl
-						className='maxi-color-control__display'
-						label={`${label} ${__('colour', 'maxi-blocks')}`}
-					>
-						<div className='maxi-color-control__display__color'>
-							<span
-								style={{
-									background: colorPicker,
-								}}
-							/>
-						</div>
-					</BaseControl>
-					<Icon icon={colorOpacity} />
-					<OpacityControl
-						opacity={color.a}
-						onChange={val => {
-							if (!isEmpty(color)) {
-								color.a = val;
-
-								onChangeValue({
-									color: tinycolor(color).toRgbString(),
-									paletteOpacity: val,
-								});
-							}
-						}}
-						onReset={onResetOpacity}
-						disableLabel
-					/>
-				</div>
-			)}
-			<div className='maxi-color-control__color'>
-				<ChromePicker
-					color={colorPicker}
-					onChange={val => {
-						setIsChanging(true);
-						const tempColor = tinycolor(val.rgb)
-							.toRgbString()
-							.replace(/\s/g, '');
-
-						setColorPicker(tempColor);
-						onChangeInlineValue({
-							color: tempColor,
-						});
-					}}
-					onChangeComplete={val => {
-						const tempColor = tinycolor(val.rgb)
-							.toRgbString()
-							.replace(/\s/g, '');
-
-						onChangeValue({
-							color: tempColor,
-						});
-						setIsChanging(false);
-					}}
-					disableAlpha
-				/>
-			</div>
-		</>
-	);
-};
-
-export default CustomColorControl;
+ import { __, sprintf } from '@wordpress/i18n';
+ import { useEffect, useState } from '@wordpress/element';
+ 
+ /**
+  * Internal dependencies
+  */
+ import Icon from '../icon';
+ import BaseControl from '../base-control';
+ import OpacityControl from '../opacity-control';
+ import Button from '../button';
+ 
+ /**
+  * External dependencies
+  */
+ import ChromePicker from 'react-color';
+ import tinycolor from 'tinycolor2';
+ import { isEmpty } from 'lodash';
+ 
+ /**
+  * Icons
+  */
+ import './editor.scss';
+ import { colorOpacity, reset } from '../../icons';
+ 
+ /**
+  * Component
+  */
+ const CustomColorControl = props => {
+	 const {
+		 label,
+		 color,
+		 onChangeInlineValue,
+		 onChangeValue,
+		 disableColorDisplay,
+		 disableOpacity,
+		 isToolbar = false,
+		 disableReset,
+		 onReset,
+		 onResetOpacity,
+	 } = props;
+	 const [colorPicker, setColorPicker] = useState(color);
+	 const [isChanging, setIsChanging] = useState(false);
+ 
+	 useEffect(() => {
+		 if (!isChanging) setColorPicker(color);
+	 }, [color]);
+ 
+	 return (
+		 <>
+			 {!isToolbar && (
+				 <>
+					 {!disableColorDisplay && (
+						 <BaseControl
+							 className='maxi-color-control__display'
+							 label={`${label} ${__('colour', 'maxi-blocks')}`}
+						 >
+							 <div className='maxi-color-control__display__color'>
+								 <span
+									 style={{
+										 background:
+											 tinycolor(
+												 colorPicker
+											 ).toRgbString(),
+									 }}
+								 />
+							 </div>
+							 {!disableReset && (
+								 <Button
+									 className='components-maxi-control__reset-button'
+									 onClick={e => {
+										 e.preventDefault();
+										 onReset();
+									 }}
+									 isSmall
+									 aria-label={sprintf(
+										 /* translators: %s: a textual label  */
+										 __('Reset %s settings', 'maxi-blocks'),
+										 label?.toLowerCase()
+									 )}
+									 type='reset'
+								 >
+									 {reset}
+								 </Button>
+							 )}
+						 </BaseControl>
+					 )}
+					 {!disableOpacity && (
+						 <OpacityControl
+							 label={__('Colour opacity', 'maxi-blocks')}
+							 opacity={color.a}
+							 onChange={val => {
+								 if (!isEmpty(color)) {
+									 color.a = val;
+ 
+									 onChangeValue({
+										 color: tinycolor(color).toRgbString(),
+										 paletteOpacity: val,
+									 });
+								 }
+							 }}
+							 onReset={onResetOpacity}
+						 />
+					 )}
+				 </>
+			 )}
+			 {isToolbar && (
+				 <div className='maxi-color-control__wrap'>
+					 <BaseControl
+						 className='maxi-color-control__display'
+						 label={`${label} ${__('colour', 'maxi-blocks')}`}
+					 >
+						 <div className='maxi-color-control__display__color'>
+							 <span
+								 style={{
+									 background: colorPicker,
+								 }}
+							 />
+						 </div>
+					 </BaseControl>
+					 <Icon icon={colorOpacity} />
+					 <OpacityControl
+						 opacity={color.a}
+						 onChange={val => {
+							 if (!isEmpty(color)) {
+								 color.a = val;
+ 
+								 onChangeValue({
+									 color: tinycolor(color).toRgbString(),
+									 paletteOpacity: val,
+								 });
+							 }
+						 }}
+						 onReset={onResetOpacity}
+						 disableLabel
+					 />
+				 </div>
+			 )}
+			 <div className='maxi-color-control__color'>
+				 <ChromePicker
+					 color={colorPicker}
+					 onChange={val => {
+						 setIsChanging(true);
+						 const tempColor = tinycolor(val.rgb)
+							 .toRgbString()
+							 .replace(/\s/g, '');
+ 
+						 setColorPicker(tempColor);
+						 onChangeInlineValue({
+							 color: tempColor,
+						 });
+					 }}
+					 onChangeComplete={val => {
+						 const tempColor = tinycolor(val.rgb)
+							 .toRgbString()
+							 .replace(/\s/g, '');
+ 
+						 onChangeValue({
+							 color: tempColor,
+						 });
+						 setIsChanging(false);
+					 }}
+					 disableAlpha
+				 />
+			 </div>
+		 </>
+	 );
+ };
+ 
+ export default CustomColorControl;
+ 

--- a/src/components/color-control/customColorControl.js
+++ b/src/components/color-control/customColorControl.js
@@ -1,173 +1,172 @@
 /**
  * WordPress dependencies
  */
- import { __, sprintf } from '@wordpress/i18n';
- import { useEffect, useState } from '@wordpress/element';
- 
- /**
-  * Internal dependencies
-  */
- import Icon from '../icon';
- import BaseControl from '../base-control';
- import OpacityControl from '../opacity-control';
- import Button from '../button';
- 
- /**
-  * External dependencies
-  */
- import ChromePicker from 'react-color';
- import tinycolor from 'tinycolor2';
- import { isEmpty } from 'lodash';
- 
- /**
-  * Icons
-  */
- import './editor.scss';
- import { colorOpacity, reset } from '../../icons';
- 
- /**
-  * Component
-  */
- const CustomColorControl = props => {
-	 const {
-		 label,
-		 color,
-		 onChangeInlineValue,
-		 onChangeValue,
-		 disableColorDisplay,
-		 disableOpacity,
-		 isToolbar = false,
-		 disableReset,
-		 onReset,
-		 onResetOpacity,
-	 } = props;
-	 const [colorPicker, setColorPicker] = useState(color);
-	 const [isChanging, setIsChanging] = useState(false);
- 
-	 useEffect(() => {
-		 if (!isChanging) setColorPicker(color);
-	 }, [color]);
- 
-	 return (
-		 <>
-			 {!isToolbar && (
-				 <>
-					 {!disableColorDisplay && (
-						 <BaseControl
-							 className='maxi-color-control__display'
-							 label={`${label} ${__('colour', 'maxi-blocks')}`}
-						 >
-							 <div className='maxi-color-control__display__color'>
-								 <span
-									 style={{
-										 background:
-											 tinycolor(
-												 colorPicker
-											 ).toRgbString(),
-									 }}
-								 />
-							 </div>
-							 {!disableReset && (
-								 <Button
-									 className='components-maxi-control__reset-button'
-									 onClick={e => {
-										 e.preventDefault();
-										 onReset();
-									 }}
-									 isSmall
-									 aria-label={sprintf(
-										 /* translators: %s: a textual label  */
-										 __('Reset %s settings', 'maxi-blocks'),
-										 label?.toLowerCase()
-									 )}
-									 type='reset'
-								 >
-									 {reset}
-								 </Button>
-							 )}
-						 </BaseControl>
-					 )}
-					 {!disableOpacity && (
-						 <OpacityControl
-							 label={__('Colour opacity', 'maxi-blocks')}
-							 opacity={color.a}
-							 onChange={val => {
-								 if (!isEmpty(color)) {
-									 color.a = val;
- 
-									 onChangeValue({
-										 color: tinycolor(color).toRgbString(),
-										 paletteOpacity: val,
-									 });
-								 }
-							 }}
-							 onReset={onResetOpacity}
-						 />
-					 )}
-				 </>
-			 )}
-			 {isToolbar && (
-				 <div className='maxi-color-control__wrap'>
-					 <BaseControl
-						 className='maxi-color-control__display'
-						 label={`${label} ${__('colour', 'maxi-blocks')}`}
-					 >
-						 <div className='maxi-color-control__display__color'>
-							 <span
-								 style={{
-									 background: colorPicker,
-								 }}
-							 />
-						 </div>
-					 </BaseControl>
-					 <Icon icon={colorOpacity} />
-					 <OpacityControl
-						 opacity={color.a}
-						 onChange={val => {
-							 if (!isEmpty(color)) {
-								 color.a = val;
- 
-								 onChangeValue({
-									 color: tinycolor(color).toRgbString(),
-									 paletteOpacity: val,
-								 });
-							 }
-						 }}
-						 onReset={onResetOpacity}
-						 disableLabel
-					 />
-				 </div>
-			 )}
-			 <div className='maxi-color-control__color'>
-				 <ChromePicker
-					 color={colorPicker}
-					 onChange={val => {
-						 setIsChanging(true);
-						 const tempColor = tinycolor(val.rgb)
-							 .toRgbString()
-							 .replace(/\s/g, '');
- 
-						 setColorPicker(tempColor);
-						 onChangeInlineValue({
-							 color: tempColor,
-						 });
-					 }}
-					 onChangeComplete={val => {
-						 const tempColor = tinycolor(val.rgb)
-							 .toRgbString()
-							 .replace(/\s/g, '');
- 
-						 onChangeValue({
-							 color: tempColor,
-						 });
-						 setIsChanging(false);
-					 }}
-					 disableAlpha
-				 />
-			 </div>
-		 </>
-	 );
- };
- 
- export default CustomColorControl;
- 
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Icon from '../icon';
+import BaseControl from '../base-control';
+import OpacityControl from '../opacity-control';
+import Button from '../button';
+
+/**
+ * External dependencies
+ */
+import ChromePicker from 'react-color';
+import tinycolor from 'tinycolor2';
+import { isEmpty } from 'lodash';
+
+/**
+ * Icons
+ */
+import './editor.scss';
+import { colorOpacity, reset } from '../../icons';
+
+/**
+ * Component
+ */
+const CustomColorControl = props => {
+	const {
+		label,
+		color,
+		onChangeInlineValue,
+		onChangeValue,
+		disableColorDisplay,
+		disableOpacity,
+		isToolbar = false,
+		disableReset,
+		onReset,
+		onResetOpacity,
+	} = props;
+	const [colorPicker, setColorPicker] = useState(color);
+	const [isChanging, setIsChanging] = useState(false);
+
+	useEffect(() => {
+		if (!isChanging) setColorPicker(color);
+	}, [color]);
+
+	return (
+		<>
+			{!isToolbar && (
+				<>
+					{!disableColorDisplay && (
+						<BaseControl
+							className='maxi-color-control__display'
+							label={`${label} ${__('colour', 'maxi-blocks')}`}
+						>
+							<div className='maxi-color-control__display__color'>
+								<span
+									style={{
+										background:
+											tinycolor(
+												colorPicker
+											).toRgbString(),
+									}}
+								/>
+							</div>
+							{!disableReset && (
+								<Button
+									className='components-maxi-control__reset-button'
+									onClick={e => {
+										e.preventDefault();
+										onReset();
+									}}
+									isSmall
+									aria-label={sprintf(
+										/* translators: %s: a textual label  */
+										__('Reset %s settings', 'maxi-blocks'),
+										label?.toLowerCase()
+									)}
+									type='reset'
+								>
+									{reset}
+								</Button>
+							)}
+						</BaseControl>
+					)}
+					{!disableOpacity && (
+						<OpacityControl
+							label={__('Colour opacity', 'maxi-blocks')}
+							opacity={color.a}
+							onChange={val => {
+								if (!isEmpty(color)) {
+									color.a = val;
+
+									onChangeValue({
+										color: tinycolor(color).toRgbString(),
+										paletteOpacity: val,
+									});
+								}
+							}}
+							onReset={onResetOpacity}
+						/>
+					)}
+				</>
+			)}
+			{isToolbar && (
+				<div className='maxi-color-control__wrap'>
+					<BaseControl
+						className='maxi-color-control__display'
+						label={`${label} ${__('colour', 'maxi-blocks')}`}
+					>
+						<div className='maxi-color-control__display__color'>
+							<span
+								style={{
+									background: colorPicker,
+								}}
+							/>
+						</div>
+					</BaseControl>
+					<Icon icon={colorOpacity} />
+					<OpacityControl
+						opacity={color.a}
+						onChange={val => {
+							if (!isEmpty(color)) {
+								color.a = val;
+
+								onChangeValue({
+									color: tinycolor(color).toRgbString(),
+									paletteOpacity: val,
+								});
+							}
+						}}
+						onReset={onResetOpacity}
+						disableLabel
+					/>
+				</div>
+			)}
+			<div className='maxi-color-control__color'>
+				<ChromePicker
+					color={colorPicker}
+					onChange={val => {
+						setIsChanging(true);
+						const tempColor = tinycolor(val.rgb)
+							.toRgbString()
+							.replace(/\s/g, '');
+
+						setColorPicker(tempColor);
+						onChangeInlineValue({
+							color: tempColor,
+						});
+					}}
+					onChangeComplete={val => {
+						const tempColor = tinycolor(val.rgb)
+							.toRgbString()
+							.replace(/\s/g, '');
+
+						onChangeValue({
+							color: tempColor,
+						});
+						setIsChanging(false);
+					}}
+					disableAlpha
+				/>
+			</div>
+		</>
+	);
+};
+
+export default CustomColorControl;

--- a/src/components/color-control/editor.scss
+++ b/src/components/color-control/editor.scss
@@ -10,7 +10,7 @@
 
 		.maxi-color-control__display {
 			width: 150px;
-			margin-right: 8px;
+			margin-right: 7px;
 		}
 
 		.maxi-advanced-number-control__value {


### PR DESCRIPTION
# Description

Removes an extra reset arrow icon. In Chrome it was rendering an empty div, and in FF there was a huge arrow showing instead.
This one fixes **UI only**. As I commented, the Style Cards reset button isn't working, but I'll make a new issue for that to separate it from UI.

Fixes #3016

# How Has This Been Tested?

Tested sidebar custom colour settings (background, colour).

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Test the component in hover state in sidebar (if hover exists)
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points for the toolbar
-   [x] Same 1-4 points on responsive
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
