### PR TITLE
Issue 3080 - Delete min/max attributes reset on switch

### DIFF
--- a/src/blocks/container-maxi/styles.js
+++ b/src/blocks/container-maxi/styles.js
@@ -34,6 +34,7 @@ const getNormalObject = props => {
 		size: getSizeStyles({
 			...getGroupAttributes(props, 'size'),
 			fullWidth: props.blockFullWidth,
+			showMaxWidth: true,
 		}),
 		boxShadow: getBoxShadowStyles({
 			obj: {

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -206,27 +206,6 @@ const FullSizeControl = props => {
 					onChange({
 						[`${prefix}size-advanced-options`]: val,
 					});
-					if (props[`${prefix}size-advanced-options`]) {
-						onChangeValue(
-							[
-								'min-width',
-								'max-width',
-								'min-height',
-								'max-height',
-							],
-							''
-						);
-
-						onChangeValue(
-							[
-								'min-width-unit',
-								'max-width-unit',
-								'min-height-unit',
-								'max-height-unit',
-							],
-							'px'
-						);
-					}
 				}}
 			/>
 			{props[`${prefix}size-advanced-options`] && (

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -104,7 +104,7 @@ const getSizeStyles = (obj, prefix = '') => {
 			...getValue('min-height'),
 		};
 	});
-	console.log(response);
+
 	return response;
 };
 

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -23,6 +23,12 @@ const getSizeStyles = (obj, prefix = '') => {
 
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
+			if (
+				!obj['size-advanced-options'] &&
+				(target.includes('max') || target.includes('min'))
+			)
+				return null;
+
 			if (target === 'height') {
 				const forceAspectRatio = getLastBreakpointAttribute({
 					target: `${prefix}force-aspect-ratio`,

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -23,11 +23,15 @@ const getSizeStyles = (obj, prefix = '') => {
 
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
-			if (
-				!obj['size-advanced-options'] &&
-				(target.includes('max') || target.includes('min'))
-			)
-				return null;
+			if (!obj['size-advanced-options']) {
+				if (!!obj?.showMaxWidth && target === 'max-width') return null;
+
+				if (
+					target !== 'max-width' &&
+					(target.includes('max') || target.includes('min'))
+				)
+					return null;
+			}
 
 			if (target === 'height') {
 				const forceAspectRatio = getLastBreakpointAttribute({
@@ -100,7 +104,7 @@ const getSizeStyles = (obj, prefix = '') => {
 			...getValue('min-height'),
 		};
 	});
-
+	console.log(response);
 	return response;
 };
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3080 

# How Has This Been Tested?

Set min/max values and check if they're not resetting after turning on/off toggle switch

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
