### PR TITLE
Issue 3069 - Toolbar cut off

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import { Popover } from '@wordpress/components';
-import { useEffect, useState, memo, forwardRef } from '@wordpress/element';
+import {
+	forwardRef,
+	memo,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { select, useSelect } from '@wordpress/data';
 import { getScrollContainer } from '@wordpress/dom';
 
@@ -138,8 +144,45 @@ const MaxiToolbar = memo(
 
 		const [anchorRef, setAnchorRef] = useState(ref.current);
 
+		const popoverRef = useRef(null);
+
+		const correctPopoverPosition = () => {
+			if (!popoverRef.current) return;
+
+			const popoverContent = popoverRef.current.querySelector(
+				'.components-popover__content'
+			);
+
+			const { x } = popoverContent.getBoundingClientRect();
+			const { offsetWidth } = popoverContent;
+			const { offsetWidth: contentWidth } = document.querySelector(
+				'.interface-interface-skeleton__content'
+			);
+
+			let percentInvisible = null;
+
+			if (x < 0) {
+				percentInvisible = (x / offsetWidth) * 100;
+			}
+
+			if (x + offsetWidth > contentWidth)
+				percentInvisible =
+					((x + offsetWidth - contentWidth) / offsetWidth) * 100;
+
+			if (percentInvisible)
+				popoverContent.style.transform = `translateX(${
+					-50 - percentInvisible
+				}%)`;
+			else popoverContent.style.transform = '';
+		};
+
 		useEffect(() => {
 			setAnchorRef(ref.current);
+			if (isSelected) {
+				setTimeout(() => {
+					correctPopoverPosition();
+				}, 0);
+			}
 		});
 
 		if (!allowedBlocks.includes(name)) return null;
@@ -178,6 +221,7 @@ const MaxiToolbar = memo(
 					animate={false}
 					position='top center right'
 					focusOnMount={false}
+					ref={popoverRef}
 					anchorRef={anchorRef}
 					className={classnames(
 						'maxi-toolbar__popover',

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -142,47 +142,12 @@ const MaxiToolbar = memo(
 			};
 		});
 
-		const [anchorRef, setAnchorRef] = useState(ref.current);
-
 		const popoverRef = useRef(null);
 
-		const correctPopoverPosition = () => {
-			if (!popoverRef.current) return;
-
-			const popoverContent = popoverRef.current.querySelector(
-				'.components-popover__content'
-			);
-
-			const { x } = popoverContent.getBoundingClientRect();
-			const { offsetWidth } = popoverContent;
-			const { offsetWidth: contentWidth } = document.querySelector(
-				'.interface-interface-skeleton__content'
-			);
-
-			let percentInvisible = null;
-
-			if (x < 0) {
-				percentInvisible = (x / offsetWidth) * 100;
-			}
-
-			if (x + offsetWidth > contentWidth)
-				percentInvisible =
-					((x + offsetWidth - contentWidth) / offsetWidth) * 100;
-
-			if (percentInvisible)
-				popoverContent.style.transform = `translateX(${
-					-50 - percentInvisible
-				}%)`;
-			else popoverContent.style.transform = '';
-		};
+		const [anchorRef, setAnchorRef] = useState(ref.current);
 
 		useEffect(() => {
 			setAnchorRef(ref.current);
-			if (isSelected) {
-				setTimeout(() => {
-					correctPopoverPosition();
-				}, 0);
-			}
 		});
 
 		if (!allowedBlocks.includes(name)) return null;
@@ -217,12 +182,48 @@ const MaxiToolbar = memo(
 			isSelected &&
 			anchorRef && (
 				<Popover
+					ref={popoverRef}
 					noArrow
 					animate={false}
 					position='top center right'
 					focusOnMount={false}
-					ref={popoverRef}
-					anchorRef={anchorRef}
+					getAnchorRect={() => {
+						const rect = anchorRef.getBoundingClientRect();
+						const popoverRect = popoverRef.current
+							?.querySelector('.components-popover__content')
+							?.getBoundingClientRect();
+
+						const { width, x } = rect;
+						const { width: popoverWidth } = popoverRect;
+
+						const expectedContentX =
+							x + width / 2 - popoverWidth / 2;
+
+						const container = document
+							.querySelector('.editor-styles-wrapper')
+							?.getBoundingClientRect();
+
+						if (container) {
+							const { x: containerX, width: containerWidth } =
+								container;
+
+							// Left cut off check
+							if (expectedContentX < containerX)
+								rect.x += containerX - expectedContentX;
+
+							// Right cut off check
+							if (
+								expectedContentX + popoverWidth >
+								containerX + containerWidth
+							)
+								rect.x -=
+									expectedContentX +
+									popoverWidth -
+									(containerX + containerWidth);
+						}
+
+						return rect;
+					}}
 					className={classnames(
 						'maxi-toolbar__popover',
 						!!breadcrumbStatus() &&
@@ -270,7 +271,7 @@ const MaxiToolbar = memo(
 								);
 							}}
 							breakpoint={breakpoint}
-							node={anchorRef}
+							node={ref.current}
 							isList={isList}
 							typeOfList={typeOfList}
 							clientId={clientId}
@@ -284,7 +285,7 @@ const MaxiToolbar = memo(
 							])}
 							blockName={name}
 							onChange={obj => maxiSetAttributes(obj)}
-							node={anchorRef}
+							node={ref.current}
 							content={content}
 							breakpoint={breakpoint}
 							isList={isList}

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -271,7 +271,7 @@ const MaxiToolbar = memo(
 								);
 							}}
 							breakpoint={breakpoint}
-							node={ref.current}
+							node={anchorRef}
 							isList={isList}
 							typeOfList={typeOfList}
 							clientId={clientId}
@@ -285,7 +285,7 @@ const MaxiToolbar = memo(
 							])}
 							blockName={name}
 							onChange={obj => maxiSetAttributes(obj)}
-							node={ref.current}
+							node={anchorRef}
 							content={content}
 							breakpoint={breakpoint}
 							isList={isList}


### PR DESCRIPTION
# Description

Checking if `.components-popover__content` in editor container `.editor-styles-wrapper` in `getAnchorRect` popover prop where we return as result correct `DOMRect`

Here is [code editor](https://github.com/yeahcan/maxi-blocks/files/8688337/close_to_borders_icons.txt) with which you can check if the toolbar doesn't cut off now.

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3069 

# How Has This Been Tested?

Checked if the toolbar doesn't cut off on the shared above code editor

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the toolbar doesn't cut off in all possible cases.
-   [x] Test the toolbar which doesn't close to editor container borders(if it looks as always)
-   [x] Same 1-4 points for the responsive

**_ Pre-Code Testing _**

-   [x] Test the toolbar doesn't cut off in all possible cases.
-   [x] Test the toolbar which doesn't close to editor container borders(if it looks as always)
-   [x] Same 1-4 points for the responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
