### PR TITLE
Issue 3083 - gap default values

### DIFF
--- a/src/components/flex-settings-control/flex-gap-control.js
+++ b/src/components/flex-settings-control/flex-gap-control.js
@@ -68,6 +68,9 @@ const GapAxisControl = props => {
 					[`${target}-${breakpoint}`]: getDefaultAttribute(
 						`${target}-${breakpoint}`
 					),
+					[`${target}-unit-${breakpoint}`]: getDefaultAttribute(
+						`${target}-unit-${breakpoint}`
+					),
 				})
 			}
 		/>


### PR DESCRIPTION
# Description
Fixed gap unit not resetting. And for the padding, the default values should be like that for row maxi.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3083 

# How Has This Been Tested?
Reset row and column gaps to default, check if unit resets to px.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes
