### PR TITLE
Issue 3077 - StyleCards custom color reset button bug

### DIFF
--- a/src/components/color-control/index.js
+++ b/src/components/color-control/index.js
@@ -151,7 +151,6 @@ const ColorControl = props => {
 				blockStyle,
 			})},${paletteOpacity || 1})`;
 
-			onChangeInline && onChangeInline({ color: defaultColor });
 			onChange({
 				paletteStatus,
 				paletteColor,

--- a/src/components/color-control/index.js
+++ b/src/components/color-control/index.js
@@ -40,7 +40,6 @@ const ColorControl = props => {
 		color,
 		defaultColorAttributes,
 		globalProps,
-		noColorPrefix,
 		onChangeInline,
 		onChange,
 		isHover,
@@ -152,7 +151,7 @@ const ColorControl = props => {
 				blockStyle,
 			})},${paletteOpacity || 1})`;
 
-			onChangeInline({ color: defaultColor });
+			onChangeInline && onChangeInline({ color: defaultColor });
 			onChange({
 				paletteStatus,
 				paletteColor,


### PR DESCRIPTION
# Description

StyleCards doesn't have inline styles for a moment and `onChangeInline` function as well, so I've added a check if we have `onChangeInline` function in `onReset` function

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3077 

# How Has This Been Tested?

Opened StyleCards, opened some settings, set custom color, and clicked on the reset button

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the custom color reset button in StyleCards

**_ Pre-Code Testing _**

-   [x] Test the custom color reset button in StyleCards
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
