### PR TITLE
Issue 3064 - Number counter replay bug

### DIFF
--- a/src/blocks/number-counter-maxi/edit.js
+++ b/src/blocks/number-counter-maxi/edit.js
@@ -110,7 +110,10 @@ const NumberCounter = attributes => {
 			attributes,
 		}) === 'hidden';
 
-	replayCounter(() => setReplayStatus(true));
+	replayCounter(() => {
+		setCount(startCountValue);
+		setReplayStatus(true);
+	});
 
 	return (
 		<BlockResizer


### PR DESCRIPTION
# Description
Changes: add count reset on replay button click

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3064 

# How Has This Been Tested?

Click on the replay button when number counter doesn't finish the count

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the number-counter replay button

**_ Pre-Code Testing _**

-   [x] Test the number-counter replay button
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
