### PR TITLE
Issue 3082 SVG height

### DIFF
--- a/src/blocks/svg-icon-maxi/style.scss
+++ b/src/blocks/svg-icon-maxi/style.scss
@@ -8,8 +8,6 @@ body.maxi-blocks--active .maxi-svg-icon-block {
 
 	.maxi-svg-icon-block__icon {
 		display: flex;
-		width: 100%;
-		height: 100%;
 
 		svg {
 			position: relative;


### PR DESCRIPTION
# Description

The reason this was happening was that the SVG had the height set to 100% in CSS.  So, when you add a margin to the SVG, that was increasing the container's total height, and SVG would just be 100% of anything that container height is.

Fixes #3082 

# How Has This Been Tested?

Added an SVG icon and tested with different widths and margins on all screen sizes, in Chrome and Firefox.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add an SVG icon and try different widths and margins.
-   [ ] Test responsive.

**_ Pre-Code Testing _**

-   [x] Add an SVG icon and try different widths and margins.
-   [x] Test responsive.
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
