### PR TITLE
Popover console error (Firefox only)

### DIFF
--- a/src/components/toolbar/components/toolbar-popover/index.js
+++ b/src/components/toolbar/components/toolbar-popover/index.js
@@ -46,17 +46,19 @@ class ToolbarPopover extends Component {
 	 * Ensures the popover closes when clicking outside
 	 */
 	onClickOutside(event) {
+		const path = event.path || (event.composedPath && event.composedPath());
 		if (
 			this.ref.current?.ownerDocument.querySelectorAll(
 				'.toolbar-item__popover'
 			).length >= 2 ||
 			// If the click isn't inside the popover and isn't inside the button
-			(event.path && !event.path.includes(
-				this.ref.current?.ownerDocument.querySelector(
-					'.toolbar-item__popover'
-				)
-			) &&
-				!event.path.includes(this.ref.current))
+			(path &&
+				!path.includes(
+					this.ref.current?.ownerDocument.querySelector(
+						'.toolbar-item__popover'
+					)
+				) &&
+				!path.includes(this.ref.current))
 		)
 			this.state.onClose();
 	}

--- a/src/components/toolbar/components/toolbar-popover/index.js
+++ b/src/components/toolbar/components/toolbar-popover/index.js
@@ -51,7 +51,7 @@ class ToolbarPopover extends Component {
 				'.toolbar-item__popover'
 			).length >= 2 ||
 			// If the click isn't inside the popover and isn't inside the button
-			(!event.path.includes(
+			(event.path && !event.path.includes(
 				this.ref.current?.ownerDocument.querySelector(
 					'.toolbar-item__popover'
 				)


### PR DESCRIPTION
# Description

![Screenshot_3](https://user-images.githubusercontent.com/19425503/168559937-7f6770df-7793-4d69-a832-7d5ad1de7914.jpg)

# How Has This Been Tested?

Checked that error is gone after adding the code and that this implementation still works: https://github.com/yeahcan/maxi-blocks/pull/3054

# Test checklist

**_ Front/Back Testing _**

-   [ ] Make sure that the error is gone (it was showing in FF only). Test with a few blocks and popover settings (such as row's column templates)
-   [ ] Make sure popover closes on click away as implemented in #3054 

**_ Pre-Code Testing _**

-   [ ] Make sure that error is gone (it was showing in FF only)
-   [ ] Make sure popover closes on click away as implemented in #3054 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
