### PR TITLE
Issue 3115 - Mover come back

### DIFF
--- a/src/components/toolbar/components/mover/index.js
+++ b/src/components/toolbar/components/mover/index.js
@@ -143,8 +143,8 @@ const Mover = props => {
 				}}
 				__experimentalTransferDataType='wp-blocks'
 			>
-				{({ onDraggableStart, onDraggableEnd }, ...rest) => {
-					return !tooltipsHide ? (
+				{({ onDraggableStart, onDraggableEnd }, ...rest) =>
+					!tooltipsHide ? (
 						<Tooltip
 							text={__('Mover', 'maxi-blocks')}
 							position='bottom center'
@@ -179,8 +179,8 @@ const Mover = props => {
 								/>
 							</Button>
 						</div>
-					);
-				}}
+					)
+				}
 			</Draggable>
 			<div className='toolbar-item-move__vertically'>
 				{!tooltipsHide && (

--- a/src/components/toolbar/components/mover/index.js
+++ b/src/components/toolbar/components/mover/index.js
@@ -144,7 +144,7 @@ const Mover = props => {
 				__experimentalTransferDataType='wp-blocks'
 			>
 				{({ onDraggableStart, onDraggableEnd }, ...rest) => {
-					!tooltipsHide && (
+					return !tooltipsHide ? (
 						<Tooltip
 							text={__('Mover', 'maxi-blocks')}
 							position='bottom center'
@@ -164,8 +164,7 @@ const Mover = props => {
 								</Button>
 							</div>
 						</Tooltip>
-					);
-					tooltipsHide && (
+					) : (
 						<div className='toolbar-item'>
 							<Button
 								className='toolbar-item toolbar-item__move'


### PR DESCRIPTION
# Description

Mover wasn't showing because in #3055  hide tool tips was added and because of this we were having a small problem that a part of code which should return mover wasn't returning anything

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3115 
# How Has This Been Tested?
Test if we have a mover in this branch, if it works with on/off tooltips

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the mover with enabled tooltips
-   [x] Test the mover with disabled tooltips

**_ Pre-Code Testing _**

-   [ ] Test the mover with enabled tooltips
-   [ ] Test the mover with disabled tooltips
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
