### PR TITLE
Issue 3096 - Don't apply styles if hover preview is off(image-maxi)

### DIFF
--- a/src/blocks/image-maxi/save.js
+++ b/src/blocks/image-maxi/save.js
@@ -34,7 +34,6 @@ const save = props => {
 		SVGElement,
 		fullWidth,
 		'hover-type': hoverType,
-		'hover-preview': hoverPreview,
 		isImageUrl,
 		captionPosition,
 	} = attributes;
@@ -45,10 +44,8 @@ const save = props => {
 
 	const hoverClasses = classnames(
 		hoverType === 'basic' &&
-			hoverPreview &&
 			`maxi-hover-effect-active maxi-hover-effect__${hoverType}__${attributes['hover-basic-effect-type']}`,
 		hoverType === 'text' &&
-			hoverPreview &&
 			`maxi-hover-effect-active maxi-hover-effect__${hoverType}__${attributes['hover-text-effect-type']}`,
 		hoverType !== 'none' &&
 			`maxi-hover-effect__${hoverType === 'basic' ? 'basic' : 'text'}`

--- a/src/blocks/image-maxi/save.js
+++ b/src/blocks/image-maxi/save.js
@@ -77,6 +77,7 @@ const save = props => {
 						'hoverTitleTypography',
 						'hoverContentTypography',
 					])}
+					isSave
 				>
 					{SVGElement ? (
 						<RawHTML>{SVGElement}</RawHTML>

--- a/src/components/hover-effect-control/index.js
+++ b/src/components/hover-effect-control/index.js
@@ -74,11 +74,13 @@ const HoverEffectControl = props => {
 				}}
 				hasBorder
 			/>
-			<ToggleSwitch
-				label={__('Show hover preview', 'maxi-blocks')}
-				selected={props['hover-preview']}
-				onChange={val => onChange({ 'hover-preview': val })}
-			/>
+			{props['hover-type'] !== 'none' && (
+				<ToggleSwitch
+					label={__('Show hover preview', 'maxi-blocks')}
+					selected={props['hover-preview']}
+					onChange={val => onChange({ 'hover-preview': val })}
+				/>
+			)}
 			<ToggleSwitch
 				label={__('Extend outside boundary', 'maxi-blocks')}
 				selected={props['hover-extension']}
@@ -239,38 +241,36 @@ const HoverEffectControl = props => {
 							props['hover-basic-effect-type'] === 'rotate' ||
 							props['hover-basic-effect-type'] === 'blur' ||
 							props['hover-basic-effect-type'] === 'slide') && (
-							<>
-								<AdvancedNumberControl
-									label={__('Amount', 'maxi-blocks')}
-									value={
-										props[
-											`hover-basic-${props['hover-basic-effect-type']}-value`
-										]
-									}
-									onChangeValue={val => {
-										onChange({
-											[`hover-basic-${props['hover-basic-effect-type']}-value`]:
-												val !== undefined && val !== ''
-													? val
-													: '',
-										});
-									}}
-									min={0}
-									step={0.1}
-									max={100}
-									onReset={() =>
-										onChange({
-											[`hover-basic-${props['hover-basic-effect-type']}-value`]:
-												getDefaultAttribute([
-													`hover-basic-${props['hover-basic-effect-type']}-value`,
-												]),
-										})
-									}
-									initialPosition={getDefaultAttribute([
-										`hover-basic-${props['hover-basic-effect-type']}-value`,
-									])}
-								/>
-							</>
+							<AdvancedNumberControl
+								label={__('Amount', 'maxi-blocks')}
+								value={
+									props[
+										`hover-basic-${props['hover-basic-effect-type']}-value`
+									]
+								}
+								onChangeValue={val => {
+									onChange({
+										[`hover-basic-${props['hover-basic-effect-type']}-value`]:
+											val !== undefined && val !== ''
+												? val
+												: '',
+									});
+								}}
+								min={0}
+								step={0.1}
+								max={100}
+								onReset={() =>
+									onChange({
+										[`hover-basic-${props['hover-basic-effect-type']}-value`]:
+											getDefaultAttribute([
+												`hover-basic-${props['hover-basic-effect-type']}-value`,
+											]),
+									})
+								}
+								initialPosition={getDefaultAttribute([
+									`hover-basic-${props['hover-basic-effect-type']}-value`,
+								])}
+							/>
 						)}
 				</>
 			)}

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -60,7 +60,7 @@ const HoverPreview = props => {
 			}`;
 		}
 
-		if (hoverType === 'basic') {
+		if (hoverType === 'basic' && props['hover-preview']) {
 			if (hoverBasicEffectType === 'zoom-in')
 				target.style.transform = `scale(${props['hover-basic-zoom-in-value']})`;
 			else if (hoverBasicEffectType === 'rotate')

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -23,6 +23,7 @@ const HoverPreview = props => {
 		'hover-transition-duration': hoverTransitionDuration,
 		'hover-transition-easing': hoverTransitionEasing,
 		'hover-transition-easing-cubic-bezier': hoverTransitionEasingCB,
+		isSave = false,
 	} = props;
 
 	const transitionDurationEffects = [
@@ -43,6 +44,8 @@ const HoverPreview = props => {
 		hoverType !== 'none' && hoverClassName
 	);
 
+	const showEffects = props['hover-preview'] || isSave;
+
 	const mouseHoverHandle = ({ target }) => {
 		if (
 			hoverType === 'text' ||
@@ -60,7 +63,7 @@ const HoverPreview = props => {
 			}`;
 		}
 
-		if (hoverType === 'basic' && props['hover-preview']) {
+		if (hoverType === 'basic' && showEffects) {
 			if (hoverBasicEffectType === 'zoom-in')
 				target.style.transform = `scale(${props['hover-basic-zoom-in-value']})`;
 			else if (hoverBasicEffectType === 'rotate')
@@ -135,47 +138,37 @@ const HoverPreview = props => {
 	return (
 		<div className={classes}>
 			{enhancedChildren}
-			{hoverType !== 'none' &&
-				hoverType !== 'basic' &&
-				props['hover-preview'] && (
-					<div
-						style={{
-							transitionDuration: `${hoverTransitionDuration}s`,
-							transitionTimingFunction:
-								hoverTransitionEasing !== 'cubic-bezier'
-									? hoverTransitionEasing
-									: !isNil(
-											props[
-												'hover-transition-easing-cubic-bezier'
-											]
-									  )
-									? `cubic-bezier(${props[
+			{hoverType !== 'none' && hoverType !== 'basic' && showEffects && (
+				<div
+					style={{
+						transitionDuration: `${hoverTransitionDuration}s`,
+						transitionTimingFunction:
+							hoverTransitionEasing !== 'cubic-bezier'
+								? hoverTransitionEasing
+								: !isNil(
+										props[
 											'hover-transition-easing-cubic-bezier'
-									  ].join()})`
-									: 'easing',
-						}}
-						className='maxi-hover-details'
+										]
+								  )
+								? `cubic-bezier(${props[
+										'hover-transition-easing-cubic-bezier'
+								  ].join()})`
+								: 'easing',
+					}}
+					className='maxi-hover-details'
+				>
+					<div
+						className={`maxi-hover-details__content maxi-hover-details__content--${props['hover-text-preset']}`}
 					>
-						<div
-							className={`maxi-hover-details__content maxi-hover-details__content--${props['hover-text-preset']}`}
-						>
-							{!isEmpty(
-								props['hover-title-typography-content']
-							) && (
-								<h4>
-									{props['hover-title-typography-content']}
-								</h4>
-							)}
-							{!isEmpty(
-								props['hover-content-typography-content']
-							) && (
-								<p>
-									{props['hover-content-typography-content']}
-								</p>
-							)}
-						</div>
+						{!isEmpty(props['hover-title-typography-content']) && (
+							<h4>{props['hover-title-typography-content']}</h4>
+						)}
+						{!isEmpty(
+							props['hover-content-typography-content']
+						) && <p>{props['hover-content-typography-content']}</p>}
 					</div>
-				)}
+				</div>
+			)}
 		</div>
 	);
 };


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3096 

# How Has This Been Tested?
Added image-maxi → Hover effect → Chose hover → Turned off preview → Checked if we haven't any styles applying on hover 

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
