### PR TITLE
Issue 3086 - Transform RotateControl optimization, FF sliders fix

### DIFF
--- a/src/components/transform-control/rotate-control.js
+++ b/src/components/transform-control/rotate-control.js
@@ -55,7 +55,6 @@ const RotateControl = props => {
 						}}
 						min={0}
 						max={360}
-						orient='vertical'
 					/>
 					<input
 						type='number'
@@ -109,7 +108,6 @@ const RotateControl = props => {
 						}}
 						min={0}
 						max={360}
-						orient='vertical'
 					/>
 					<input
 						type='number'
@@ -163,7 +161,6 @@ const RotateControl = props => {
 						}}
 						min={0}
 						max={360}
-						orient='vertical'
 					/>
 					<input
 						type='number'

--- a/src/components/transform-control/rotate-control.js
+++ b/src/components/transform-control/rotate-control.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,16 +25,6 @@ import { reset } from '../../icons';
 const RotateControl = props => {
 	const { x, y, z, defaultX, defaultY, defaultZ, onChange } = props;
 
-	const [xAxis, changeXAxis] = useState(x);
-	const [yAxis, changeYAxis] = useState(y);
-	const [zAxis, changeZAxis] = useState(z);
-
-	useEffect(() => {
-		changeXAxis(x);
-		changeYAxis(y);
-		changeZAxis(z);
-	}, [x, y, z]);
-
 	return (
 		<div className='maxi-transform-control__rotate-control'>
 			<div className='maxi-transform-control__rotate-control__item'>
@@ -46,12 +35,11 @@ const RotateControl = props => {
 					<input
 						type='range'
 						className='maxi-transform-control__rotate-control__item__range'
-						value={xAxis || 0}
+						value={x || 0}
 						onChange={e => {
 							const value = +e.target.value;
 
-							changeXAxis(value);
-							onChange(value, yAxis, zAxis);
+							onChange(value, y, z);
 						}}
 						min={0}
 						max={360}
@@ -60,30 +48,25 @@ const RotateControl = props => {
 						type='number'
 						placeholder='0deg'
 						className='maxi-transform-control__rotate-control__item__input'
-						value={isNil(xAxis) ? '' : xAxis}
+						value={isNil(x) ? '' : x}
 						min={0}
 						max={360}
 						onChange={e => {
 							if (e.target.value === '') {
-								changeXAxis(defaultX);
-								onChange(defaultX, yAxis, zAxis);
+								onChange(defaultX, y, z);
 							} else {
 								let value = +e.target.value;
 
 								if (value > 360) value = 360;
 								if (value < 0) value = 0;
 
-								changeXAxis(value);
-								onChange(value, yAxis, zAxis);
+								onChange(value, y, z);
 							}
 						}}
 					/>
 					<Button
 						className='components-maxi-control__reset-button'
-						onClick={() => {
-							changeXAxis(defaultX);
-							onChange(defaultX, yAxis, zAxis);
-						}}
+						onClick={() => onChange(defaultX, y, z)}
 						action='reset'
 						type='reset'
 					>
@@ -99,12 +82,11 @@ const RotateControl = props => {
 					<input
 						type='range'
 						className='maxi-transform-control__rotate-control__item__range'
-						value={yAxis || 0}
+						value={y || 0}
 						onChange={e => {
 							const value = +e.target.value;
 
-							changeYAxis(value);
-							onChange(xAxis, value, zAxis);
+							onChange(x, value, z);
 						}}
 						min={0}
 						max={360}
@@ -113,30 +95,25 @@ const RotateControl = props => {
 						type='number'
 						placeholder='0deg'
 						className='maxi-transform-control__rotate-control__item__input'
-						value={isNil(yAxis) ? '' : yAxis}
+						value={isNil(y) ? '' : y}
 						min={0}
 						max={360}
 						onChange={e => {
 							if (e.target.value === '') {
-								changeYAxis(defaultY);
-								onChange(xAxis, defaultY, zAxis);
+								onChange(x, defaultY, z);
 							} else {
 								let value = +e.target.value;
 
 								if (value > 360) value = 360;
 								if (value < 0) value = 0;
 
-								changeYAxis(value);
-								onChange(xAxis, value, zAxis);
+								onChange(x, value, z);
 							}
 						}}
 					/>
 					<Button
 						className='components-maxi-control__reset-button'
-						onClick={() => {
-							changeYAxis(defaultY);
-							onChange(xAxis, defaultY, zAxis);
-						}}
+						onClick={() => onChange(x, defaultY, z)}
 						action='reset'
 						type='reset'
 					>
@@ -152,12 +129,11 @@ const RotateControl = props => {
 					<input
 						type='range'
 						className='maxi-transform-control__rotate-control__item__range'
-						value={zAxis || 0}
+						value={z || 0}
 						onChange={e => {
 							const value = +e.target.value;
 
-							changeZAxis(value);
-							onChange(xAxis, yAxis, value);
+							onChange(x, y, value);
 						}}
 						min={0}
 						max={360}
@@ -166,30 +142,25 @@ const RotateControl = props => {
 						type='number'
 						placeholder='0deg'
 						className='maxi-transform-control__rotate-control__item__input'
-						value={isNil(zAxis) ? '' : zAxis}
+						value={isNil(z) ? '' : z}
 						min={0}
 						max={360}
 						onChange={e => {
 							if (e.target.value === '') {
-								changeZAxis(defaultZ);
-								onChange(xAxis, yAxis, defaultZ);
+								onChange(x, y, defaultZ);
 							} else {
 								let value = +e.target.value;
 
 								if (value > 360) value = 360;
 								if (value < 0) value = 0;
 
-								changeZAxis(value);
-								onChange(xAxis, yAxis, value);
+								onChange(x, y, value);
 							}
 						}}
 					/>
 					<Button
 						className='components-maxi-control__reset-button'
-						onClick={() => {
-							changeZAxis(defaultZ);
-							onChange(xAxis, yAxis, defaultZ);
-						}}
+						onClick={() => onChange(z, y, defaultZ)}
 						action='reset'
 						type='reset'
 					>


### PR DESCRIPTION
# Description

Changes:
- remove `orient='vertical'` in inputs to fix FF
- remove state in `RotateControl`, we don't need him

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3086 

# How Has This Been Tested?
Checked sliders in transform correct work in FF and rotate control correct work after removing from there not necessary states. More optimization to all sliders will come when we'll take a look at inline styles sequel.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the RotateControl in transform section in sidebar
-   [x] Test the transform in normal state in sidebar in FF (sliders in priority)
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [ ] Test the Rotate Control in transform section in sidebar
-   [ ] Test the transform in normal state in sidebar in FF (sliders in priority)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
