### PR TITLE
Issue 3100 - New CalloutArrow InfoBox, InfoBox close button

### DIFF
--- a/src/components/arrow-control/index.js
+++ b/src/components/arrow-control/index.js
@@ -80,14 +80,6 @@ const ArrowControl = props => {
 
 	return (
 		<div className={classes}>
-			{props['show-warning-box'] && (
-				<InfoBox
-					message={__(
-						'Please ensure that the background color is not the same as the page background color.'
-					)}
-					onClose={() => onChange({ 'show-warning-box': false })}
-				/>
-			)}
 			{!isBackgroundColor && (
 				<InfoBox
 					message={__(
@@ -102,6 +94,19 @@ const ArrowControl = props => {
 					]}
 				/>
 			)}
+			{getLastBreakpointAttribute({
+				target: 'arrow-status',
+				breakpoint,
+				attributes: props,
+			}) &&
+				props['show-warning-box'] && (
+					<InfoBox
+						message={__(
+							'Please ensure that the background color is not the same as the page background color.'
+						)}
+						onClose={() => onChange({ 'show-warning-box': false })}
+					/>
+				)}
 			<ToggleSwitch
 				label={__('Show arrow on boundary', 'maxi-blocks')}
 				selected={getLastBreakpointAttribute({

--- a/src/components/arrow-control/index.js
+++ b/src/components/arrow-control/index.js
@@ -80,13 +80,14 @@ const ArrowControl = props => {
 
 	return (
 		<div className={classes}>
-			<InfoBox
-				message={__(
-					'Please ensure that the background color is not the same as the page background color.'
-				)}
-				hide={!props['show-warning-box']}
-				onClose={() => onChange({ 'show-warning-box': false })}
-			/>
+			{props['show-warning-box'] && (
+				<InfoBox
+					message={__(
+						'Please ensure that the background color is not the same as the page background color.'
+					)}
+					onClose={() => onChange({ 'show-warning-box': false })}
+				/>
+			)}
 			{!isBackgroundColor && (
 				<InfoBox
 					message={__(

--- a/src/components/arrow-control/index.js
+++ b/src/components/arrow-control/index.js
@@ -80,6 +80,13 @@ const ArrowControl = props => {
 
 	return (
 		<div className={classes}>
+			<InfoBox
+				message={__(
+					'Please ensure that the background color is not the same as the page background color.'
+				)}
+				hide={!props['show-warning-box']}
+				onClose={() => onChange({ 'show-warning-box': false })}
+			/>
 			{!isBackgroundColor && (
 				<InfoBox
 					message={__(

--- a/src/components/info-box/editor.scss
+++ b/src/components/info-box/editor.scss
@@ -1,4 +1,5 @@
 .maxi-warning-box {
+	position: relative;
 	padding: 1rem;
 	background: #fcf8e3;
 	color: #8a6d3b !important;
@@ -22,6 +23,12 @@
 				opacity: 0.6;
 			}
 		}
+	}
+
+	&__close-button {
+		position: absolute;
+		top: 5px;
+		right: 5px;
 	}
 }
 .maxi-accordion-control__item__panel {

--- a/src/components/info-box/editor.scss
+++ b/src/components/info-box/editor.scss
@@ -29,6 +29,7 @@
 		position: absolute;
 		top: 5px;
 		right: 5px;
+		cursor: pointer;
 	}
 }
 .maxi-accordion-control__item__panel {

--- a/src/components/info-box/index.js
+++ b/src/components/info-box/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { openSidebarAccordion } from '../../extensions/inspector';
+import Icon from '../icon';
 
 /**
  * External dependencies
@@ -15,41 +16,39 @@ import { isEmpty, uniqueId } from 'lodash';
 import { closeIcon } from '../../icons';
 import './editor.scss';
 
-const InfoBox = ({ className, message, links, tab = 0, hide, onClose }) => {
+const InfoBox = ({ className, message, links, tab = 0, onClose }) => {
 	const classes = classnames('maxi-warning-box', className);
 
 	return (
-		!hide && (
-			<div className={classes}>
-				{message}
-				{links && (
-					<div className='maxi-warning-box__links'>
-						{links.map(item => (
-							<a
-								key={uniqueId('maxi-warning-box__links__item')}
-								onClick={() => {
-									if (!isEmpty(item.panel))
-										openSidebarAccordion(tab, item.panel);
+		<div className={classes}>
+			{message}
+			{links && (
+				<div className='maxi-warning-box__links'>
+					{links.map(item => (
+						<a
+							key={uniqueId('maxi-warning-box__links__item')}
+							onClick={() => {
+								if (!isEmpty(item.panel))
+									openSidebarAccordion(tab, item.panel);
 
-									if (!isEmpty(item.href))
-										window.open(item.href, '_blank');
-								}}
-							>
-								{item.title}
-							</a>
-						))}
-					</div>
-				)}
-				{hide === false && (
-					<div
-						className='maxi-warning-box__close-button'
-						onClick={onClose}
-					>
-						{closeIcon}
-					</div>
-				)}
-			</div>
-		)
+								if (!isEmpty(item.href))
+									window.open(item.href, '_blank');
+							}}
+						>
+							{item.title}
+						</a>
+					))}
+				</div>
+			)}
+			{onClose && (
+				<div
+					className='maxi-warning-box__close-button'
+					onClick={onClose}
+				>
+					<Icon icon={closeIcon} />
+				</div>
+			)}
+		</div>
 	);
 };
 

--- a/src/components/info-box/index.js
+++ b/src/components/info-box/index.js
@@ -10,35 +10,46 @@ import classnames from 'classnames';
 import { isEmpty, uniqueId } from 'lodash';
 
 /**
- * Styles
+ * Styles and icons
  */
+import { closeIcon } from '../../icons';
 import './editor.scss';
 
-const InfoBox = ({ className, message, links, tab = 0 }) => {
+const InfoBox = ({ className, message, links, tab = 0, hide, onClose }) => {
 	const classes = classnames('maxi-warning-box', className);
 
 	return (
-		<div className={classes}>
-			{message}
-			{links && (
-				<div className='maxi-warning-box__links'>
-					{links.map(item => (
-						<a
-							key={uniqueId('maxi-warning-box__links__item')}
-							onClick={() => {
-								if (!isEmpty(item.panel))
-									openSidebarAccordion(tab, item.panel);
+		!hide && (
+			<div className={classes}>
+				{message}
+				{links && (
+					<div className='maxi-warning-box__links'>
+						{links.map(item => (
+							<a
+								key={uniqueId('maxi-warning-box__links__item')}
+								onClick={() => {
+									if (!isEmpty(item.panel))
+										openSidebarAccordion(tab, item.panel);
 
-								if (!isEmpty(item.href))
-									window.open(item.href, '_blank');
-							}}
-						>
-							{item.title}
-						</a>
-					))}
-				</div>
-			)}
-		</div>
+									if (!isEmpty(item.href))
+										window.open(item.href, '_blank');
+								}}
+							>
+								{item.title}
+							</a>
+						))}
+					</div>
+				)}
+				{hide === false && (
+					<div
+						className='maxi-warning-box__close-button'
+						onClick={onClose}
+					>
+						{closeIcon}
+					</div>
+				)}
+			</div>
+		)
 	);
 };
 

--- a/src/extensions/styles/defaults/arrow.js
+++ b/src/extensions/styles/defaults/arrow.js
@@ -19,8 +19,14 @@ const rawArrow = {
 	},
 };
 
-const arrow = breakpointAttributesCreator({
-	obj: rawArrow,
-});
+const arrow = {
+	...breakpointAttributesCreator({
+		obj: rawArrow,
+	}),
+	'show-warning-box': {
+		type: 'boolean',
+		default: true,
+	},
+};
 
 export default arrow;


### PR DESCRIPTION
# Description

![image](https://user-images.githubusercontent.com/46112160/168878926-8d03da5c-82c4-4e6e-b059-979f0b0345c6.png)

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

After some discussion with @kyrapieterse, a decision was made. We will have an `Infobox` in Callout arrow that users will be able to close and which will inform them in which cases they cannot see the arrow.

Changes:
- add to `arrow` attributes `'show-warning-box'` attribute
- add option in `InfoBox` to have a close button
- add new `InfoBox` to Callout arrow

Fixes #3100 

# How Has This Been Tested?
Added container-maxi → Opened Callout arrow → Checked if we have new `InfoBox` → Closed him → Save page → Check if new `InfoBox` gone

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the new Callout arrow InfoBox
-   [x] Test if others InfoBoxes save their default behaviour
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the new Callout arrow InfoBox
-   [x] Test if others InfoBoxes save their default behaviour
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
