### PR TITLE
Issue-3107: icon padding issue

### DIFF
--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -686,6 +686,7 @@ const IconControl = props => {
 							breakpoint={breakpoint}
 							target='icon-padding'
 							disableAuto
+							optionType='string'
 							minMaxSettings={minMaxSettings}
 						/>
 					)}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->
Fixed Icon padding not saving after reload.
Fixes #3107 

# How Has This Been Tested?
Checked Icon padding value is saved both in backend and frontend.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test Icon padding for button maxi value is saved both in backend and frontend.


**_ Pre-Code Testing _**

-   [x] Test Icon padding for button maxi value is saved both in backend and frontend.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
