### PR TITLE
Issues 3123 and 3133

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -198,7 +198,10 @@ const MaxiToolbar = memo(
 					animate={false}
 					position='top center right'
 					focusOnMount={false}
-					getAnchorRect={() => {
+					getAnchorRect={spanEl => {
+						// span element needs to be hidden to don't break the grid
+						spanEl.style.display = 'none';
+
 						const rect = anchorRef.getBoundingClientRect();
 						const popoverRect = popoverRef.current
 							?.querySelector('.components-popover__content')


### PR DESCRIPTION
# Description

With the new Toolbar adaptation to don't stay out of the screen, WP popover creates a span that also breaks the grid

Fixes #3123 and fixes #3133

# How Has This Been Tested?

Create a grid and check the span doesn't break it and it doesn't appear also

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the block inside the grid (Container + Row + Column)

**_ Pre-Code Testing _**

-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
