### PR TITLE
Fixes changes between SC and fonts

### DIFF
--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -105,8 +105,8 @@ class MaxiBlocks_StyleCards {
 		}
 	}
 
-	public function get_maxi_blocks_active_style_card() {
-		$maxi_blocks_style_cards = $this->get_maxi_blocks_current_style_cards();
+	public static function get_maxi_blocks_active_style_card() {
+		$maxi_blocks_style_cards = self::get_maxi_blocks_current_style_cards();
 
 		$maxi_blocks_style_cards_array = json_decode(
 			$maxi_blocks_style_cards,
@@ -123,17 +123,17 @@ class MaxiBlocks_StyleCards {
 
 	public static function get_maxi_blocks_style_card_fonts($block_style, $text_level)
 	{
-		$maxi_blocks_style_cards = json_decode(self::get_maxi_blocks_current_style_cards());
-
-		$style_card_name = array_key_first((array) $maxi_blocks_style_cards);
+		$maxi_blocks_style_cards = (object) self::get_maxi_blocks_active_style_card();
+		$block_style_values = (object) $maxi_blocks_style_cards->$block_style;
+		$default_values = $block_style_values->defaultStyleCard;
+		$values = $block_style_values->styleCard;
 
 		$style_card_values = (object) array_merge(
-			(array) $maxi_blocks_style_cards->$style_card_name->$block_style->defaultStyleCard,
-			(array) $maxi_blocks_style_cards->$style_card_name->$block_style->styleCard
+			(array) $default_values,
+			(array) $values
 		);
 
-
-		$text_level_values = $style_card_values->$text_level;
+		$text_level_values = (object) $style_card_values->$text_level;
 
 		$font = $text_level_values->{'font-family-general'};
 


### PR DESCRIPTION
# Description

Fixes the font loading when changing the SC from another one.

Fixes #3126 

# How Has This Been Tested?

Create a post with a Text Maxi and publish it. Then, download a SC and apply it. On master, when reloading the post on frontend, didn't show the new font; this implementation should fix it 👍 

# Test checklist

**_ Front/Back Testing _**

-   [x] Test the new SC font is loaded when reloading a previous published post

**_ Pre-Code Testing _**

-   [x] Test the new SC font is loaded when reloading a previous published post
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
