### PR TITLE
Issue 3105 - Have min/max values opened by default for container and row

### DIFF
--- a/src/blocks/container-maxi/attributes.js
+++ b/src/blocks/container-maxi/attributes.js
@@ -56,6 +56,10 @@ const attributes = {
 	...attributesData.boxShadowHover,
 	...{
 		...attributesData.size,
+		'size-advanced-options': {
+			type: 'boolean',
+			default: true,
+		},
 		'max-width-xxl': {
 			type: 'string',
 			default: '1690',
@@ -136,7 +140,7 @@ const attributes = {
 			type: 'string',
 			default: 'px',
 		},
-	}
+	},
 };
 
 export default attributes;

--- a/src/blocks/container-maxi/styles.js
+++ b/src/blocks/container-maxi/styles.js
@@ -34,7 +34,6 @@ const getNormalObject = props => {
 		size: getSizeStyles({
 			...getGroupAttributes(props, 'size'),
 			fullWidth: props.blockFullWidth,
-			showMaxWidth: true,
 		}),
 		boxShadow: getBoxShadowStyles({
 			obj: {

--- a/src/blocks/row-maxi/attributes.js
+++ b/src/blocks/row-maxi/attributes.js
@@ -36,6 +36,10 @@ const attributes = {
 	...attributesData.boxShadowHover,
 	...{
 		...attributesData.size,
+		'size-advanced-options': {
+			type: 'boolean',
+			default: true,
+		},
 		'max-width-xxl': {
 			type: 'string',
 			default: '1690',

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -24,12 +24,7 @@ const getSizeStyles = (obj, prefix = '') => {
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
 			if (!obj['size-advanced-options']) {
-				if (!obj?.showMaxWidth && target === 'max-width') return null;
-
-				if (
-					target !== 'max-width' &&
-					(target.includes('max') || target.includes('min'))
-				)
+				if (target.includes('max') || target.includes('min'))
 					return null;
 			}
 

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -24,7 +24,7 @@ const getSizeStyles = (obj, prefix = '') => {
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
 			if (!obj['size-advanced-options']) {
-				if (!!obj?.showMaxWidth && target === 'max-width') return null;
+				if (!obj?.showMaxWidth && target === 'max-width') return null;
 
 				if (
 					target !== 'max-width' &&


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3105 

# How Has This Been Tested?

Checked if column and row have min/max values opened by default, checked if min/max values working well in all cases

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test min/max values logic(if everything works as it was)
-   [x] Test if container and row have min/max values switch on by default
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [x] Test min/max values logic  (if everything works as it was)
-   [x] Test if container and row have min/max values switch on by default
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
