### PR TITLE
Issue 3136 - fix divider width on resize

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -51,6 +51,7 @@ class edit extends MaxiBlockComponent {
 
 		if (this.resizableObject.current?.state.height !== height) {
 			this.resizableObject.current.updateSize({
+				width: '100%',
 				height,
 			});
 		}


### PR DESCRIPTION
# Description
the defaultSize property on resizer is ignored once the size property is set. The height on size was set, and the width wasn't, so it was set to auto.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3136 

# How to test?
Test resizer on divider
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check if divider resizes normally
-   [x] Check if divider width doesn't break in container

**_Pre-Code Testing_**

-   [x] Check if divider resizes normally
-   [x] Check if divider width doesn't break in container
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes
