### PR TITLE
issue 3169 updated tabs text colour

### DIFF
--- a/src/components/responsive-tabs-control/editor.scss
+++ b/src/components/responsive-tabs-control/editor.scss
@@ -13,12 +13,18 @@
 		&__button {
 			padding: 10px;
 			font-weight: 500;
-			font-weight: 500;
 
 			&[aria-pressed='true'] {
 				border-bottom-color: var(--maxi-secondary-color);
 				color: var(--maxi-secondary-color);
 			}
+		}
+
+		.maxi-tabs-control__button-Flex-parent, 
+		.maxi-tabs-control__button-Flex-child,
+		.maxi-tabs-control__button-Normal,
+		.maxi-tabs-control__button-Hover {
+			color: var(--maxi-grey-5-color);
 		}
 	}
 }

--- a/src/components/responsive-tabs-control/editor.scss
+++ b/src/components/responsive-tabs-control/editor.scss
@@ -20,6 +20,9 @@
 			}
 		}
 
+		.maxi-tabs-control__button-Start,
+		.maxi-tabs-control__button-Mid,
+		.maxi-tabs-control__button-End,
 		.maxi-tabs-control__button-Flex-parent, 
 		.maxi-tabs-control__button-Flex-child,
 		.maxi-tabs-control__button-Normal,


### PR DESCRIPTION
# Description

Changed text colour from blue to grey for all the tabs that have an orange border
![image](https://user-images.githubusercontent.com/19425503/169819279-6ab3b891-5dfb-40aa-b231-0024c7a5c7a0.png)


Fixes #3169 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check the sidebar and make sure that all tabs with the orange border have the grey text.

**_ Pre-Code Testing _**

-   [ ] Check the sidebar and make sure that all tabs with the orange border have the grey text.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
