### PR TITLE
Issue 3108 - fix resizer with force responsive off

### DIFF
--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -237,7 +237,7 @@ class edit extends MaxiBlockComponent {
 									attributes,
 								})
 									? '100%'
-									: null
+									: undefined
 							}
 							defaultSize={{
 								width: `${getLastBreakpointAttribute({


### PR DESCRIPTION
# Description
The problem was in the way re-resizable handles the max and min size properties.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3108 

# How to test?
Resize icon with force responsive both on and off. Switch on small breakpoint and check if you can resize icon more than max width of block when force responsive is off.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check if icon resizes correctly
-   [ ] Test force responsive

**_Pre-Code Testing_**

-   [ ] Check if icon resizes correctly
-   [ ] Test force responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
