### PR TITLE
Fixes divider size

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -173,6 +173,7 @@ class edit extends MaxiBlockComponent {
 				isOverflowHidden={getIsOverflowHidden()}
 				minWidth='1px'
 				defaultSize={{
+					width: '100%',
 					height: `${getLastBreakpointAttribute({
 						target: 'height',
 						breakpoint: deviceType,

--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -39,21 +39,39 @@ class edit extends MaxiBlockComponent {
 	}
 
 	maxiBlockDidUpdate() {
-		const height = `${getLastBreakpointAttribute({
-			target: 'height',
-			breakpoint: this.props.deviceType,
-			attributes: this.props.attributes,
-		})}${getLastBreakpointAttribute({
-			target: 'height-unit',
-			breakpoint: this.props.deviceType,
-			attributes: this.props.attributes,
-		})}`;
-
-		if (this.resizableObject.current?.state.height !== height) {
-			this.resizableObject.current.updateSize({
-				width: '100%',
-				height,
+		if (this.resizableObject.current) {
+			const width = getLastBreakpointAttribute({
+				target: 'width',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
 			});
+			const widthUnit = getLastBreakpointAttribute({
+				target: 'width-unit',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+			const height = `${getLastBreakpointAttribute({
+				target: 'height',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			})}${getLastBreakpointAttribute({
+				target: 'height-unit',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			})}`;
+
+			const { width: resizerWidth, height: resizerHeight } =
+				this.resizableObject.current.state;
+
+			if (
+				resizerWidth !== `${width}${widthUnit}` ||
+				resizerHeight !== height
+			) {
+				this.resizableObject.current.updateSize({
+					width: width ? `${width}${widthUnit}` : '100%',
+					height,
+				});
+			}
 		}
 	}
 
@@ -153,8 +171,8 @@ class edit extends MaxiBlockComponent {
 				{...getMaxiBlockAttributes(this.props)}
 				tagName={BlockResizer}
 				isOverflowHidden={getIsOverflowHidden()}
+				minWidth='1px'
 				defaultSize={{
-					width: '100%',
 					height: `${getLastBreakpointAttribute({
 						target: 'height',
 						breakpoint: deviceType,


### PR DESCRIPTION
# Description

@Olekrut reported a situation like:
<img width="1133" alt="Captura de pantalla 2022-05-24 a las 12 01 41" src="https://user-images.githubusercontent.com/50477222/170007213-1422ebda-2d13-47ab-8107-c43cd333ce82.png">

where we are having issues between `blockResizer` component and some styles. Has been fixed to look like:
<img width="1133" alt="Captura de pantalla 2022-05-24 a las 12 01 24" src="https://user-images.githubusercontent.com/50477222/170007329-945bd2c6-ab09-417e-ab52-422579296a34.png">

But is a fast fix. Needs more love, so going to open an issue for it 👍  Also I'm not 100% sure if the way it has been done with customCSS is the correct in terms of pattern creation; will have a look also 👍 

# How Has This Been Tested?

Check [this pattern](https://github.com/yeahcan/maxi-blocks/files/8761673/dividersize.txt) on master and on this branch

# Test checklist

**_ Front/Back Testing _**

-   [x] Check the pattern from master and in this branch on back and frontend
- [x] Check Divider Maxi resizable options and canvas size (width && height)

**_ Pre-Code Testing _**

-   [ ] Check the pattern from master and in this branch on back and frontend
- [ ] Check Divider Maxi resizable options and canvas size (width && height)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
