### PR TITLE
Size prefix bug

### DIFF
--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -180,7 +180,7 @@ class edit extends MaxiBlockComponent {
 			});
 
 			if (
-				(!useInitSize && isNumber(maxWidth)) ||
+				(!useInitSize && maxWidth) ||
 				(useInitSize && maxWidth > mediaWidth)
 			)
 				return `${maxWidth}${maxWidthUnit}`;

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -23,7 +23,7 @@ const getSizeStyles = (obj, prefix = '') => {
 
 	breakpoints.forEach(breakpoint => {
 		const getValue = target => {
-			if (!obj['size-advanced-options']) {
+			if (!obj[`${prefix}size-advanced-options`]) {
 				if (target.includes('max') || target.includes('min'))
 					return null;
 			}


### PR DESCRIPTION
# Description

As @Olekrut commented by chat, Image Maxi img element wasn't styling the max-width setting. Also, once fixed, the BlockResizer wasn't getting the corrext max-width value either. Both issues have been fixed. Now, max-width on Image Maxi ('settings' tab, not 'canvas') should work, and BlockResizer handles should wrap the image and not the whole content.

# How Has This Been Tested?

Create an Image Maxi on master and test adding a max-width, shouldn't work. On this branch it should 👍 

# Test checklist

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points on responsive
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
