### PR TITLE
Fixes Text Maxi removing when pressing backspace

### DIFF
--- a/src/blocks/text-maxi/edit.js
+++ b/src/blocks/text-maxi/edit.js
@@ -95,7 +95,6 @@ class edit extends MaxiBlockComponent {
 			blockFullWidth,
 			clientId,
 			isSelected,
-			onRemove,
 			onReplace,
 			maxiSetAttributes,
 		} = this.props;
@@ -210,6 +209,9 @@ class edit extends MaxiBlockComponent {
 									);
 							}}
 							onMerge={forward => onMerge(this.props, forward)}
+							// onRemove needs to be commented to avoid removing the block
+							// on pressing backspace with the content empty 👍
+							// onRemove={onRemove}
 							__unstableEmbedURLOnPaste
 							withoutInteractiveFormatting
 							preserveWhiteSpace
@@ -274,7 +276,9 @@ class edit extends MaxiBlockComponent {
 									);
 							}}
 							onMerge={forward => onMerge(this.props, forward)}
-							onRemove={onRemove}
+							// onRemove needs to be commented to avoid removing the block
+							// on pressing backspace with the content empty 👍
+							// onRemove={onRemove}
 							start={listStart}
 							reversed={listReversed}
 							type={typeOfList}

--- a/src/blocks/text-maxi/utils.js
+++ b/src/blocks/text-maxi/utils.js
@@ -70,7 +70,9 @@ const onMerge = (props, forward) => {
 		const blockName = getBlock(previousBlockClientId)?.name;
 
 		if (!previousBlockClientId || blockName !== 'maxi-blocks/text-maxi') {
-			removeBlock(clientId);
+			// Basically removes the block when pressing backspace and there's not block before
+			// Commented as is something we might want to come back in future
+			// removeBlock(clientId);
 		} else {
 			const previousBlockAttributes = getBlockAttributes(
 				previousBlockClientId

--- a/src/extensions/text/formats/onChangeRichText.js
+++ b/src/extensions/text/formats/onChangeRichText.js
@@ -17,8 +17,7 @@ const onChangeRichText = ({
 	onChange,
 	richTextValues,
 }) => {
-	const { value: formatValue } = richTextValues;
-	const { onChange: onChangeRichText } = richTextValues;
+	const { value: formatValue, onChange: onChangeRichText } = richTextValues;
 
 	/**
 	 * As Gutenberg doesn't allow to modify pasted content, let's do some cheats


### PR DESCRIPTION
# Description

@Olekrut shared that after the last optimization tasks, when pressing backspace on an empty Text Maxi it was removed. This implementation should prevent the block to be removed on that situation

# How Has This Been Tested?

Create a Text Maxi and press backspace; one time, two times, three times... several times. Get crazy pressing backspace. Has the Text Maxi been removed? No, right? so then is fixed lolol

# Test checklist

**_ Front/Back Testing _**

-   [x] Get crazy pressing backspace on Text Maxi
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block

**_ Pre-Code Testing _**

-   [x] Get crazy pressing backspace on Text Maxi
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block
-   [ ] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
