### PR TITLE
Fixes #3221

### DIFF
--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -36,7 +36,6 @@ const FullSizeControl = props => {
 		prefix = '',
 		isBlockFullWidth,
 		allowForceAspectRatio = false,
-		isFirstOnHierarchy,
 	} = props;
 
 	const classes = classnames('maxi-full-size-control', className);
@@ -87,8 +86,7 @@ const FullSizeControl = props => {
 			target: `${prefix}width-fit-content`,
 			breakpoint,
 			attributes: props,
-		}) &&
-		isFirstOnHierarchy;
+		});
 
 	return (
 		<div className={classes}>

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -87,7 +87,6 @@ const size = ({
 						hideMaxWidth={hideMaxWidth || isBlockFullWidth}
 						isBlockFullWidth={isBlockFullWidth}
 						allowForceAspectRatio={block}
-						isFirstOnHierarchy={isFirstOnHierarchy}
 					/>
 				</>
 			</ResponsiveTabsControl>


### PR DESCRIPTION
# Description

Give back `width` option for inner blocks 👍 

Fixes #3221 

# How Has This Been Tested?

Create a Grid and add a block there: it should have `width` option 👍 

# Test checklist

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Test the block inside the grid (Container + Row + Column)

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
