### PR TITLE
Fix box-shadow

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -92,7 +92,12 @@ body.maxi-blocks--active .maxi-link-wrapper {
 body.maxi-blocks--active #wpwrap .maxi-block-inserter__button {
 	margin: auto;
 }
+
 /*Block border radius*/
-body.maxi-blocks--active #wpwrap .maxi-block.maxi-block--backend {
-	border-radius: 0;
+body.maxi-blocks--active.ast-highlight-wpblock-onhover
+	.maxi-block--backend.block-editor-block-list__block {
+	&.is-highlighted,
+	&:hover {
+		border-radius: 0;
+	}
 }


### PR DESCRIPTION
# Description

Fixes #3214 

# How Has This Been Tested?

The fix for Astra's theme border was breaking the shadow on backend when a block had border-radius not = 0.

# Test checklist

**_ Front/Back Testing _**

-   [x] Test the pattern from the issue and make sure that the box-shadow is ok
-   [x] Test the backend with the Astra theme and make sure it's not adding these weird border radii: 
![Edit Page “box shadow bug” ‹ Local Wordpress — WordPress](https://user-images.githubusercontent.com/2401618/170463909-59dada3b-d70e-43c4-9a38-159a0dfa882b.jpg)


**_ Pre-Code Testing _**

-   [x] Test the pattern from the issue and make sure that the box-shadow is ok
-   [x] Test the backend with the Astra theme and make sure it's not adding weird border radii.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] My changes generate no new warnings/errors
-   [ ] New and existing unit tests pass locally with my changes
