### PR TITLE
h3 line height correction

### DIFF
--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -307,7 +307,7 @@ class MaxiBlocks_StyleCards {
 							"font-size-unit-s": "px",
 							"line-height-general": 40,
 							"line-height-unit-general": "px",
-							"line-height-xxl": 30,
+							"line-height-xxl": 50,
 							"line-height-unit-xxl": "px",
 							"line-height-xl": 40,
 							"line-height-unit-xl": "px",


### PR DESCRIPTION
# Description

Corrected default SC h3 line-height from 30 to 50px (dark tone).

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test that the line-height is 50px for h3 dark.

**_ Pre-Code Testing _**

-   [ ] Test that the line-height is 50px for h3 dark.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
