### PR TITLE
Issue 3226 - Box-shadow and border turn off didn't work on responsive

### DIFF
--- a/e2e-tests/components/box-shadow-control/index.spec.js
+++ b/e2e-tests/components/box-shadow-control/index.spec.js
@@ -123,13 +123,13 @@ describe('BoxShadowControl', () => {
 		);
 
 		const expectBoxShadow = {
-			'box-shadow-blur-general': undefined,
+			'box-shadow-blur-general': 0,
 			'box-shadow-blur-general-hover': 50,
-			'box-shadow-horizontal-general': undefined,
+			'box-shadow-horizontal-general': 0,
 			'box-shadow-horizontal-general-hover': 0,
-			'box-shadow-spread-general': undefined,
+			'box-shadow-spread-general': 0,
 			'box-shadow-spread-general-hover': 0,
-			'box-shadow-vertical-general': undefined,
+			'box-shadow-vertical-general': 0,
 			'box-shadow-vertical-general-hover': 30,
 		};
 

--- a/e2e-tests/components/toolbar/components/copy-paste/index.spec.js
+++ b/e2e-tests/components/toolbar/components/copy-paste/index.spec.js
@@ -214,7 +214,7 @@ describe('CopyPaste from Toolbar', () => {
 			'border-bottom-right-radius-general': 96,
 			'border-top-left-radius-general': 56,
 			'border-top-right-radius-general': 15,
-			'box-shadow-blur-general': undefined,
+			'box-shadow-blur-general': 0,
 			'box-shadow-color-general': undefined,
 		};
 		const attributesResult = await getAttributes([

--- a/src/components/border-control/defaults.js
+++ b/src/components/border-control/defaults.js
@@ -19,7 +19,7 @@ const getBorderDefault = (
 	};
 };
 
-export const borderNone = (prefix = '', borderStyle) => {
+export const borderNone = (prefix = '', hasBorderStyle) => {
 	let response = {};
 
 	const currentDefaultBorder = prefix
@@ -42,7 +42,7 @@ export const borderNone = (prefix = '', borderStyle) => {
 				.default,
 		[`${prefix}border-color`]:
 			currentDefaultBorder[`${prefix}border-color-general`].default,
-		[`${prefix}border-style`]: borderStyle
+		[`${prefix}border-style`]: hasBorderStyle
 			? 'none'
 			: currentDefaultBorder[`${prefix}border-style-general`].default,
 		[`${prefix}border-top-width`]:

--- a/src/components/border-control/defaults.js
+++ b/src/components/border-control/defaults.js
@@ -19,7 +19,7 @@ const getBorderDefault = (
 	};
 };
 
-export const borderNone = (prefix = '', isHover) => {
+export const borderNone = (prefix = '', borderStyle) => {
 	let response = {};
 
 	const currentDefaultBorder = prefix
@@ -31,8 +31,6 @@ export const borderNone = (prefix = '', isHover) => {
 		: defaultBorderWidth;
 
 	response = {
-		[`${prefix}border-style`]:
-			currentDefaultBorder[`${prefix}border-style-general`].default,
 		[`${prefix}border-palette-status`]:
 			currentDefaultBorder[`${prefix}border-palette-status-general`]
 				.default,
@@ -44,7 +42,7 @@ export const borderNone = (prefix = '', isHover) => {
 				.default,
 		[`${prefix}border-color`]:
 			currentDefaultBorder[`${prefix}border-color-general`].default,
-		[`${prefix}border-style`]: isHover
+		[`${prefix}border-style`]: borderStyle
 			? 'none'
 			: currentDefaultBorder[`${prefix}border-style-general`].default,
 		[`${prefix}border-top-width`]:

--- a/src/components/border-control/defaults.js
+++ b/src/components/border-control/defaults.js
@@ -31,13 +31,17 @@ export const borderNone = (prefix = '', isHover) => {
 		: defaultBorderWidth;
 
 	response = {
+		[`${prefix}border-style`]:
+			currentDefaultBorder[`${prefix}border-style-general`].default,
 		[`${prefix}border-palette-status`]:
 			currentDefaultBorder[`${prefix}border-palette-status-general`]
 				.default,
 		[`${prefix}border-palette-color`]:
 			currentDefaultBorder[`${prefix}border-palette-color-general`]
 				.default,
-		[`${prefix}border-palette-opacity`]: 1,
+		[`${prefix}border-palette-opacity`]:
+			currentDefaultBorder[`${prefix}border-palette-opacity-general`]
+				.default,
 		[`${prefix}border-color`]:
 			currentDefaultBorder[`${prefix}border-color-general`].default,
 		[`${prefix}border-style`]: isHover

--- a/src/components/border-control/index.js
+++ b/src/components/border-control/index.js
@@ -269,7 +269,17 @@ const BorderControl = props => {
 							/>
 						),
 						onChange: () =>
-							onChangeDefault(borderNone(prefix, isHover)),
+							onChangeDefault(
+								borderNone(
+									prefix,
+									getLastBreakpointAttribute({
+										target: `${prefix}border-style`,
+										breakpoint,
+										attributes: props,
+										isHover,
+									}) && breakpoint !== 'general'
+								)
+							),
 					},
 					{
 						activeItem: getIsActive() === 'solid',

--- a/src/components/box-shadow-control/defaults.js
+++ b/src/components/box-shadow-control/defaults.js
@@ -5,23 +5,23 @@ export const boxShadowNone = prefix => {
 
 	response = {
 		[`${[prefix]}box-shadow-palette-opacity`]:
-			boxShadow[`${[prefix]}box-shadow-palette-opacity-general`].default,
+			boxShadow['box-shadow-palette-opacity-general'].default,
 		[`${[prefix]}box-shadow-horizontal`]:
-			boxShadow[`${[prefix]}box-shadow-horizontal-general`].default,
+			boxShadow['box-shadow-horizontal-general'].default,
 		[`${[prefix]}box-shadow-horizontal-unit`]:
-			boxShadow[`${[prefix]}box-shadow-horizontal-unit-general`].default,
+			boxShadow['box-shadow-horizontal-unit-general'].default,
 		[`${[prefix]}box-shadow-vertical`]:
-			boxShadow[`${[prefix]}box-shadow-vertical-general`].default,
+			boxShadow['box-shadow-vertical-general'].default,
 		[`${[prefix]}box-shadow-vertical-unit`]:
-			boxShadow[`${[prefix]}box-shadow-vertical-unit-general`].default,
+			boxShadow['box-shadow-vertical-unit-general'].default,
 		[`${[prefix]}box-shadow-blur`]:
-			boxShadow[`${[prefix]}box-shadow-blur-general`].default,
+			boxShadow['box-shadow-blur-general'].default,
 		[`${[prefix]}box-shadow-blur-unit`]:
-			boxShadow[`${[prefix]}box-shadow-blur-unit-general`].default,
+			boxShadow['box-shadow-blur-unit-general'].default,
 		[`${[prefix]}box-shadow-spread`]:
-			boxShadow[`${[prefix]}box-shadow-spread-general`].default,
+			boxShadow['box-shadow-spread-general'].default,
 		[`${[prefix]}box-shadow-spread-unit`]:
-			boxShadow[`${[prefix]}box-shadow-spread-unit-general`].default,
+			boxShadow['box-shadow-spread-unit-general'].default,
 	};
 
 	return response;

--- a/src/components/box-shadow-control/defaults.js
+++ b/src/components/box-shadow-control/defaults.js
@@ -5,15 +5,36 @@ export const boxShadowNone = prefix => {
 
 	response = {
 		[`${[prefix]}box-shadow-palette-opacity`]:
-			boxShadow['box-shadow-palette-opacity-general']?.default,
+			boxShadow[`${[prefix]}box-shadow-palette-opacity-general`].default,
 		[`${[prefix]}box-shadow-horizontal`]:
-			boxShadow['box-shadow-horizontal-general']?.default,
+			boxShadow[`${[prefix]}box-shadow-horizontal-general`].default,
+		[`${[prefix]}box-shadow-horizontal-unit`]:
+			boxShadow[`${[prefix]}box-shadow-horizontal-unit-general`].default,
 		[`${[prefix]}box-shadow-vertical`]:
-			boxShadow['box-shadow-vertical-general']?.default,
+			boxShadow[`${[prefix]}box-shadow-vertical-general`].default,
+		[`${[prefix]}box-shadow-vertical-unit`]:
+			boxShadow[`${[prefix]}box-shadow-vertical-unit-general`].default,
 		[`${[prefix]}box-shadow-blur`]:
-			boxShadow['box-shadow-blur-general']?.default,
+			boxShadow[`${[prefix]}box-shadow-blur-general`].default,
+		[`${[prefix]}box-shadow-blur-unit`]:
+			boxShadow[`${[prefix]}box-shadow-blur-unit-general`].default,
 		[`${[prefix]}box-shadow-spread`]:
-			boxShadow['box-shadow-spread-general']?.default,
+			boxShadow[`${[prefix]}box-shadow-spread-general`].default,
+		[`${[prefix]}box-shadow-spread-unit`]:
+			boxShadow[`${[prefix]}box-shadow-spread-unit-general`].default,
+	};
+
+	return response;
+};
+
+const boxShadowUnits = prefix => {
+	let response = {};
+
+	response = {
+		[`${[prefix]}box-shadow-horizontal-unit`]: 'px',
+		[`${[prefix]}box-shadow-vertical-unit`]: 'px',
+		[`${[prefix]}box-shadow-blur-unit`]: 'px',
+		[`${[prefix]}box-shadow-spread-unit`]: 'px',
 	};
 
 	return response;
@@ -28,6 +49,7 @@ export const boxShadowTotal = prefix => {
 		[`${prefix}box-shadow-vertical`]: 30,
 		[`${prefix}box-shadow-blur`]: 50,
 		[`${prefix}box-shadow-spread`]: 0,
+		...boxShadowUnits(prefix),
 	};
 
 	return response;
@@ -42,6 +64,7 @@ export const boxShadowBottom = prefix => {
 		[`${prefix}box-shadow-vertical`]: 30,
 		[`${prefix}box-shadow-blur`]: 50,
 		[`${prefix}box-shadow-spread`]: 0,
+		...boxShadowUnits(prefix),
 	};
 
 	return response;
@@ -56,6 +79,7 @@ export const boxShadowSolid = prefix => {
 		[`${prefix}box-shadow-vertical`]: 6,
 		[`${prefix}box-shadow-blur`]: 0,
 		[`${prefix}box-shadow-spread`]: 0,
+		...boxShadowUnits(prefix),
 	};
 
 	return response;

--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -25,7 +25,7 @@ import {
  * External dependencies
  */
 import classnames from 'classnames';
-import { isNil, capitalize } from 'lodash';
+import { capitalize } from 'lodash';
 
 /**
  * Styles and icons
@@ -112,8 +112,20 @@ const BoxShadowControl = props => {
 	const onChangeDefault = defaultProp => {
 		const response = {};
 
-		defaultProp[`${prefix}box-shadow-color`] =
-			props[`${prefix}box-shadow-color-${breakpoint}`];
+		defaultProp[`${prefix}box-shadow-palette-color`] =
+			getLastBreakpointAttribute({
+				target: `${prefix}box-shadow-palette-color`,
+				breakpoint,
+				attributes: props,
+				isHover,
+			});
+
+		defaultProp[`${prefix}box-shadow-color`] = getLastBreakpointAttribute({
+			target: `${prefix}box-shadow-color`,
+			breakpoint,
+			attributes: props,
+			isHover,
+		});
 
 		Object.entries(defaultProp).forEach(([key, value]) => {
 			response[`${key}-${breakpoint}${isHover ? '-hover' : ''}`] = value;
@@ -122,27 +134,18 @@ const BoxShadowControl = props => {
 		onChange(response);
 	};
 
-	const getIsActive = (typeObj, type) => {
+	const getIsActive = typeObj => {
 		const items = [
 			`${prefix}box-shadow-palette-opacity`,
 			`${prefix}box-shadow-horizontal`,
+			`${prefix}box-shadow-horizontal-unit`,
 			`${prefix}box-shadow-vertical`,
+			`${prefix}box-shadow-vertical-unit`,
 			`${prefix}box-shadow-blur`,
+			`${prefix}box-shadow-blur-unit`,
 			`${prefix}box-shadow-spread`,
+			`${prefix}box-shadow-spread-unit`,
 		];
-
-		const hasBoxShadow = items.some(item => {
-			const itemValue = getLastBreakpointAttribute({
-				target: item,
-				breakpoint,
-				attributes: props,
-				isHover,
-			});
-
-			return !isNil(itemValue) && itemValue !== 0;
-		});
-		if (!hasBoxShadow && type === 'none') return true;
-		if (type === 'none') return false;
 
 		const isActive = !items.some(item => {
 			const itemValue = getLastBreakpointAttribute({
@@ -160,7 +163,7 @@ const BoxShadowControl = props => {
 		return false;
 	};
 
-	const isNone = getIsActive(boxShadowNone, 'none');
+	const isNone = getIsActive(boxShadowNone(prefix));
 
 	const classes = classnames(
 		'maxi-shadow-control',
@@ -173,10 +176,7 @@ const BoxShadowControl = props => {
 			<DefaultStylesControl
 				items={[
 					{
-						activeItem: getIsActive(
-							{ ...boxShadowNone(prefix) },
-							'none'
-						),
+						activeItem: getIsActive({ ...boxShadowNone(prefix) }),
 						content: (
 							<Icon
 								className='maxi-default-styles-control__button__icon'
@@ -186,20 +186,14 @@ const BoxShadowControl = props => {
 						onChange: () => onChangeDefault(boxShadowNone(prefix)),
 					},
 					{
-						activeItem: getIsActive(
-							{ ...boxShadowTotal(prefix) },
-							'total'
-						),
+						activeItem: getIsActive({ ...boxShadowTotal(prefix) }),
 						content: (
 							<div className='maxi-shadow-control__default maxi-shadow-control__default__total' />
 						),
 						onChange: () => onChangeDefault(boxShadowTotal(prefix)),
 					},
 					{
-						activeItem: getIsActive(
-							{ ...boxShadowBottom(prefix) },
-							'bottom'
-						),
+						activeItem: getIsActive({ ...boxShadowBottom(prefix) }),
 						content: (
 							<div className='maxi-shadow-control__default maxi-shadow-control__default__bottom' />
 						),
@@ -207,10 +201,7 @@ const BoxShadowControl = props => {
 							onChangeDefault(boxShadowBottom(prefix)),
 					},
 					{
-						activeItem: getIsActive(
-							{ ...boxShadowSolid(prefix) },
-							'solid'
-						),
+						activeItem: getIsActive({ ...boxShadowSolid(prefix) }),
 						content: (
 							<div className='maxi-shadow-control__default maxi-shadow-control__default__solid' />
 						),

--- a/src/extensions/styles/defaults/border.js
+++ b/src/extensions/styles/defaults/border.js
@@ -4,9 +4,10 @@ import paletteAttributesCreator from '../paletteAttributesCreator';
 const prefix = 'border-';
 
 export const rawBorder = {
-	...paletteAttributesCreator({ prefix, palette: 2 }),
+	...paletteAttributesCreator({ prefix, palette: 2, opacity: 1 }),
 	'border-style': {
 		type: 'string',
+		default: 'none',
 	},
 };
 

--- a/src/extensions/styles/defaults/border.js
+++ b/src/extensions/styles/defaults/border.js
@@ -7,7 +7,6 @@ export const rawBorder = {
 	...paletteAttributesCreator({ prefix, palette: 2, opacity: 1 }),
 	'border-style': {
 		type: 'string',
-		default: 'none',
 	},
 };
 

--- a/src/extensions/styles/defaults/border.js
+++ b/src/extensions/styles/defaults/border.js
@@ -4,7 +4,7 @@ import paletteAttributesCreator from '../paletteAttributesCreator';
 const prefix = 'border-';
 
 export const rawBorder = {
-	...paletteAttributesCreator({ prefix, palette: 2, opacity: 1 }),
+	...paletteAttributesCreator({ prefix, palette: 2 }),
 	'border-style': {
 		type: 'string',
 	},

--- a/src/extensions/styles/defaults/boxShadow.js
+++ b/src/extensions/styles/defaults/boxShadow.js
@@ -4,9 +4,10 @@ import paletteAttributesCreator from '../paletteAttributesCreator';
 const prefix = 'box-shadow-';
 
 const rawBoxShadow = {
-	...paletteAttributesCreator({ prefix, palette: 8 }),
+	...paletteAttributesCreator({ prefix, palette: 8, opacity: 1 }),
 	'box-shadow-horizontal': {
 		type: 'number',
+		default: 0,
 	},
 	'box-shadow-horizontal-unit': {
 		type: 'string',
@@ -14,6 +15,7 @@ const rawBoxShadow = {
 	},
 	'box-shadow-vertical': {
 		type: 'number',
+		default: 0,
 	},
 	'box-shadow-vertical-unit': {
 		type: 'string',
@@ -21,6 +23,7 @@ const rawBoxShadow = {
 	},
 	'box-shadow-blur': {
 		type: 'number',
+		default: 0,
 	},
 	'box-shadow-blur-unit': {
 		type: 'string',
@@ -28,6 +31,7 @@ const rawBoxShadow = {
 	},
 	'box-shadow-spread': {
 		type: 'number',
+		default: 0,
 	},
 	'box-shadow-spread-unit': {
 		type: 'string',


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3226 

# How Has This Been Tested?
Turned off box-shadow and border on responsive

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Test the component in hover state in sidebar (if hover exists)
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points for the toolbar
-   [x] Same 1-4 points on responsive
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block
-   [x] Duplicate the block, test that the settings of the first do not affect the second
-   [x] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
