### PR TITLE
issue 3169 tabs colour

### DIFF
--- a/src/components/responsive-tabs-control/editor.scss
+++ b/src/components/responsive-tabs-control/editor.scss
@@ -20,6 +20,8 @@
 			}
 		}
 
+		.maxi-tabs-control__button-Position,
+		.maxi-tabs-control__button-Size,
 		.maxi-tabs-control__button-Start,
 		.maxi-tabs-control__button-Mid,
 		.maxi-tabs-control__button-End,


### PR DESCRIPTION
Background shape layer position/size tabs were blue; changed to grey to match the design of other tabs in the sidebar.

Fixes #3169 (A fix was already merged for this issue, but I missed these tabs)

# Test checklist

**_ Front/Back Testing _**

-   [ ] Add any block and add a shape background layer and make sure that the position/size tabs are grey and not blue.

**_ Pre-Code Testing _**

-   [x] Add any block and add a shape background layer and make sure that the position/size tabs are grey and not blue.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
