### PR TITLE
Issue 3297 - Toolbar z-index

### DIFF
--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -13,6 +13,9 @@
 /*****************
 * General settings
 ******************/
+body.maxi-blocks--active .interface-interface-skeleton__body {
+	z-index: 999;
+}
 .interface-interface-skeleton__sidebar {
 	overflow-x: hidden;
 	scrollbar-gutter: stable;

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -14,8 +14,12 @@
 * General settings
 ******************/
 body.maxi-blocks--active .interface-interface-skeleton__body {
-	z-index: 999;
+	z-index: 99;
 }
+body.maxi-blocks--active .interface-interface-skeleton__header.true {
+	z-index: 100;
+}
+
 .interface-interface-skeleton__sidebar {
 	overflow-x: hidden;
 	scrollbar-gutter: stable;

--- a/src/editor/toolbar-buttons/index.js
+++ b/src/editor/toolbar-buttons/index.js
@@ -22,6 +22,12 @@ import { main } from '../../icons';
 const ToolbarButtons = () => {
 	const [isResponsiveOpen, setIsResponsiveOpen] = useState(false);
 
+	// Rendering true or false for the toolbar visibility so we can use CSS based on the state
+	const toolbarHeader = document.querySelector(
+		'.interface-interface-skeleton__header'
+	);
+	toolbarHeader.className = `interface-interface-skeleton__header ${isResponsiveOpen}`;
+
 	return (
 		<>
 			<div className='maxi-toolbar-layout'>


### PR DESCRIPTION
Increased z-index of the editor body, so that the block toolbar doesn't go behind the main toolbar on scroll.

Fixes #3297 

# How Has This Been Tested?

Add several sections on the page so you can scroll it down. Click on a block from the top section and make sure the block toolbar stays visible.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that the block toolbar doesn't go behind the main toolbar on page scroll.
-   [ ] Test different browsers.

**_ Pre-Code Testing _**


-   [ ] Test that the block toolbar doesn't go behind the main toolbar on page scroll.
-   [ ] Test different browsers.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
