### PR TITLE
Issue 3276 - fix underline

### DIFF
--- a/src/blocks/text-maxi/style.scss
+++ b/src/blocks/text-maxi/style.scss
@@ -72,5 +72,6 @@ body.maxi-blocks--active .maxi-text-block {
 	}
 	a {
 		text-decoration: none;
+		text-decoration-skip-ink: none;
 	}
 }


### PR DESCRIPTION
# Description
WordPress theme 2021 changed the a tag style on hover. I changed it on normal state also. Although, the standard underline should be as on normal state. Maybe we could add a switch to select whether to underline letters with descenders or not.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3276 

# How Has This Been Tested?
Paste [this pattern](https://github.com/yeahcan/maxi-blocks/files/8946951/text-underline.txt) with theme 2021 on.
Check if underline is same on normal state and on hover.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Test the pattern

**_Pre-Code Testing_**

-   [ ] Test the pattern
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
