### PR TITLE
Back old full-width css code to prevent breaking non-updated posts

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -12,6 +12,12 @@
 	position: relative;
 	z-index: 0;
 
+	// To not break pages full-width which wasn't updated after #3269
+	&[data-align='full'] {
+		width: 100% !important;
+		max-width: 100% !important;
+	}
+
 	span.maxi-block-anchor {
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3356 

# How Has This Been Tested?
Checked if not updated patterns containers full-width not broking

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

- [ ] Test with a clone of the maxi dress on your local if the non-updated patterns are not broken.

**_ Pre-Code Testing _**

-   [x] Test with a clone of the maxi dress on your local if the non-updated patterns are not broken.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors


