### PR TITLE
Issue 3215 - Strange breakpoints on maxidress

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -220,7 +220,7 @@ class MaxiBlocks_Styles
         // TODO: It may connect to the API to centralize the default values there
         return (object) [
             'xs' => 480,
-            's' => 7,
+            's' => 767,
             'm' => 1024,
             'l' => 1366,
             'xl' => 1920,

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -217,10 +217,10 @@ class MaxiBlocks_Styles
             return $breakpoints;
         }
 
-        // It may connect to the API to centralize the default values there
+        // TODO: It may connect to the API to centralize the default values there
         return (object) [
             'xs' => 480,
-            's' => 768,
+            's' => 7,
             'm' => 1024,
             'l' => 1366,
             'xl' => 1920,
@@ -343,7 +343,7 @@ class MaxiBlocks_Styles
     public function update_color_palette_backups($style)
     {
         global $wpdb;
-    
+
         $style_card = maybe_unserialize(
             $wpdb->get_var(
                 $wpdb->prepare(

--- a/src/extensions/store/selectors.js
+++ b/src/extensions/store/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, inRange } from 'lodash';
+import { isEmpty } from 'lodash';
 
 const selectors = {
 	receiveMaxiSettings(state) {
@@ -64,15 +64,21 @@ const selectors = {
 
 		if (winWidth > breakpoints.xl) return 'xxl';
 
-		return Object.entries(breakpoints)
-			.reduce(([prevKey, prevValue], [currKey, currValue]) => {
-				if (!prevValue) return [prevKey];
-				if (inRange(winWidth, prevValue, currValue + 1))
-					return [currKey];
+		// Objects are unordered collection of properties, so as we can't rely on
+		// its own order, we need to iterate over an ordered array
+		const getBreakpointRange = (obj, minWidth) => {
+			let result;
 
-				return [prevKey, prevValue];
-			})[0]
-			.toLowerCase();
+			['xl', 'l', 'm', 's', 'xs'].forEach(breakpoint => {
+				if (obj[breakpoint] >= minWidth) {
+					result = breakpoint;
+				}
+			});
+
+			return result;
+		};
+
+		return getBreakpointRange(breakpoints, winWidth);
 	},
 };
 

--- a/src/extensions/store/selectors.js
+++ b/src/extensions/store/selectors.js
@@ -56,7 +56,7 @@ const selectors = {
 			? state.breakpoints
 			: {
 					xs: 480,
-					s: 768,
+					s: 767,
 					m: 1024,
 					l: 1366,
 					xl: 1920,

--- a/src/extensions/styles/test/__snapshots__/styleResolver.js.snap
+++ b/src/extensions/styles/test/__snapshots__/styleResolver.js.snap
@@ -6,7 +6,7 @@ Object {
     "breakpoints": Object {
       "l": 1366,
       "m": 1024,
-      "s": 768,
+      "s": 767,
       "xl": 1920,
       "xs": 480,
       "xxl": 1920,

--- a/src/extensions/styles/test/frontendStyleGenerator.js
+++ b/src/extensions/styles/test/frontendStyleGenerator.js
@@ -9,7 +9,7 @@ describe('frontendStyleGenerator', () => {
 					xl: 1920,
 					l: 1366,
 					m: 1024,
-					s: 768,
+					s: 767,
 					xs: 480,
 				},
 				content: {

--- a/src/extensions/styles/test/styleGenerator.js
+++ b/src/extensions/styles/test/styleGenerator.js
@@ -56,7 +56,7 @@ describe('styleGenerator', () => {
 			xl: 1920,
 			l: 1366,
 			m: 1024,
-			s: 768,
+			s: 767,
 			xs: 480,
 		};
 
@@ -119,7 +119,7 @@ describe('styleGenerator', () => {
 			xl: 1920,
 			l: 1366,
 			m: 1024,
-			s: 768,
+			s: 767,
 			xs: 480,
 		};
 
@@ -182,7 +182,7 @@ describe('styleGenerator', () => {
 			xl: 1920,
 			l: 1366,
 			m: 1024,
-			s: 768,
+			s: 767,
 			xs: 480,
 		};
 

--- a/src/extensions/styles/test/styleResolver.js
+++ b/src/extensions/styles/test/styleResolver.js
@@ -133,7 +133,7 @@ describe('styleResolver', () => {
 			xl: 1920,
 			l: 1366,
 			m: 1024,
-			s: 768,
+			s: 767,
 			xs: 480,
 		};
 


### PR DESCRIPTION
# Description

After trying to reproduce these errors in many ways, finally we found what was happening. Basically, for some reason, on maxidress site the breakpoint array was saved with a different order that the one we were expecting on the `receiveWinBreakpoint` selector of the `maxiBlocks` store; and on that selector the function on charge to return the winBreakpoint had a bug and was depending on the order to return one result or another. The fix has been to do something simple that deals with any ordered object to return the correct value.

Also fixed some default S breakpoints that were running with the old value

Fixes #3215 

# How Has This Been Tested?

Created the function you can find on the PR and checked it with different objects with different orders and always returned the same value. Here are a couple of objects, one coming from my local and the other coming from maxidress. Both should return the same result:
```
const obj1 = {
    xl: 1920,
    l: 1366,
    m: 1024,
    s: 767,
    xs: 480,
};

const obj2 = {
    xs: 480,
    s: 767,
    m: 1024,
    l: 1366,
    xl: 1920,
};
```

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

This implementation can't be tested on Front/back testing 👍 

**_ Pre-Code Testing _**

-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
