### PR TITLE
Issue 3359 - Grid correct positioning after switching from code editor

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -147,9 +147,9 @@ class MaxiBlockComponent extends Component {
 	}
 
 	componentDidMount() {
-		if (!this.getBreakpoints.xxl) this.forceUpdate();
-
 		if (this.maxiBlockDidMount) this.maxiBlockDidMount();
+
+		if (!this.getBreakpoints.xxl) this.forceUpdate();
 	}
 
 	/**

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -156,15 +156,6 @@ class MaxiBlockComponent extends Component {
 	 * Prevents rendering
 	 */
 	shouldComponentUpdate(nextProps, nextState) {
-		// Even when not rendering, on breakpoint stage change
-		// re-render the styles
-		const breakpoint = select('maxiBlocks').receiveMaxiDeviceType();
-
-		if (breakpoint !== this.currentBreakpoint) {
-			this.currentBreakpoint = breakpoint;
-			this.displayStyles();
-		}
-
 		// Force rendering the block when SC related values change
 		if (this.scProps) {
 			const SC = select(
@@ -286,7 +277,14 @@ class MaxiBlockComponent extends Component {
 	}
 
 	componentDidUpdate(prevProps, prevState, shouldDisplayStyles) {
-		if (!shouldDisplayStyles) this.displayStyles();
+		// Even when not rendering, on breakpoint stage change
+		// re-render the styles
+		const breakpoint = select('maxiBlocks').receiveMaxiDeviceType();
+
+		if (!shouldDisplayStyles || breakpoint !== this.currentBreakpoint) {
+			this.currentBreakpoint = breakpoint;
+			this.displayStyles();
+		}
 
 		if (this.maxiBlockDidUpdate)
 			this.maxiBlockDidUpdate(prevProps, prevState, shouldDisplayStyles);

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -261,6 +261,13 @@ class MaxiBlockComponent extends Component {
 		// Force render styles when changing state
 		if (!isEqual(prevState, this.state)) return false;
 
+		if (this.maxiBlockGetSnapshotBeforeUpdate) {
+			return (
+				this.maxiBlockGetSnapshotBeforeUpdate(prevProps) &&
+				isEqual(prevProps.attributes, this.props.attributes)
+			);
+		}
+
 		// For render styles when there's no <style> element for the block
 		// Normally happens when duplicate the block
 		if (
@@ -274,12 +281,6 @@ class MaxiBlockComponent extends Component {
 			)
 		)
 			return false;
-
-		if (this.maxiBlockGetSnapshotBeforeUpdate)
-			return (
-				this.maxiBlockGetSnapshotBeforeUpdate(prevProps) &&
-				isEqual(prevProps.attributes, this.props.attributes)
-			);
 
 		return isEqual(prevProps.attributes, this.props.attributes);
 	}


### PR DESCRIPTION
# Description

Looks like problem with switching between breakpoint had already resolved, in this branch I've fixed grid positioning after switching from code editor (video with problem in issue)

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3359 

# How Has This Been Tested?
Opened patterns with grids, switched to code editor, then switched back to editor, and checked if grid is correct on backend and frontend

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the grid correct position (backend/frontend) after switching between breakpoints (looks like it was fixed before, just to ensure)
-   [x] Test the grid correct position (backend/frontend) after switching to code editor and back
-   [x] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [x] Test the grid correct position (backend/frontend) after switching between breakpoints (looks like it was fixed before, just to ensure)
-   [x] Test the grid correct position (backend/frontend) after switching to code editor and back
-   [x] Check that backend works and saves the settings after the editor reload
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [X] New and existing unit tests pass locally with my changes
