### PR TITLE
Fix SettingTabsControl buttons classes

### DIFF
--- a/e2e-tests/components/background/SVGIconBackground.spec.js
+++ b/e2e-tests/components/background/SVGIconBackground.spec.js
@@ -52,7 +52,7 @@ describe('Icon background', () => {
 			button.click()
 		);
 
-		await accordion.$eval('.maxi-tabs-control__button-Hover', button =>
+		await accordion.$eval('.maxi-tabs-control__button-hover', button =>
 			button.click()
 		);
 

--- a/e2e-tests/components/toolbar/components/copy-paste/index.spec.js
+++ b/e2e-tests/components/toolbar/components/copy-paste/index.spec.js
@@ -179,7 +179,7 @@ describe('CopyPaste from Toolbar', () => {
 		);
 		// open advanced
 		await page.$eval(
-			'.components-popover__content .maxi-tabs-control__button-Advanced',
+			'.components-popover__content .maxi-tabs-control__button-advanced',
 			button => button.click()
 		);
 

--- a/src/components/responsive-tabs-control/editor.scss
+++ b/src/components/responsive-tabs-control/editor.scss
@@ -20,15 +20,15 @@
 			}
 		}
 
-		.maxi-tabs-control__button-Position,
-		.maxi-tabs-control__button-Size,
-		.maxi-tabs-control__button-Start,
-		.maxi-tabs-control__button-Mid,
-		.maxi-tabs-control__button-End,
-		.maxi-tabs-control__button-Flex-parent, 
-		.maxi-tabs-control__button-Flex-child,
-		.maxi-tabs-control__button-Normal,
-		.maxi-tabs-control__button-Hover {
+		.maxi-tabs-control__button-position,
+		.maxi-tabs-control__button-size,
+		.maxi-tabs-control__button-start,
+		.maxi-tabs-control__button-mid,
+		.maxi-tabs-control__button-end,
+		.maxi-tabs-control__button-flex-parent,
+		.maxi-tabs-control__button-flex-child,
+		.maxi-tabs-control__button-normal,
+		.maxi-tabs-control__button-hover {
 			color: var(--maxi-grey-5-color);
 		}
 	}

--- a/src/components/setting-tabs-control/index.js
+++ b/src/components/setting-tabs-control/index.js
@@ -118,11 +118,11 @@ const SettingTabsControl = props => {
 							: item;
 						return (
 							<Button
-								key={`maxi-tabs-control__button-${buttonLabel}`}
+								key={`maxi-tabs-control__button-${buttonLabel.toLowerCase()}`}
 								label={item.value}
 								className={classnames(
 									'maxi-tabs-control__button',
-									`maxi-tabs-control__button-${buttonLabel}`,
+									`maxi-tabs-control__button-${buttonLabel.toLowerCase()}`,
 									selected === item.value &&
 										'maxi-tabs-control__button--selected',
 									getIsActiveTab(


### PR DESCRIPTION
Fix the classes so that they are generated without capital letters
 https://github.com/yeahcan/maxi-blocks/issues/3439

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that the buttons of settingTabsControl generate the class without capital letters

**_ Pre-Code Testing _**

-   [ ] Check no commented code and no unnecessary imports
-   [ ]  Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works

