### PR TITLE
Remove propsToAvoidStyling

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -81,8 +81,6 @@ const StyleComponent = ({
  * Class
  */
 class MaxiBlockComponent extends Component {
-	propsToAvoidRendering = [];
-
 	constructor(...args) {
 		super(...args);
 
@@ -186,24 +184,6 @@ class MaxiBlockComponent extends Component {
 
 		// Check changes on states
 		if (!isEqual(this.state, nextState)) return true;
-
-		// Check changes on props
-		if (!isEmpty(this.propsToAvoidRendering)) {
-			const oldAttributes = cloneDeep(nextProps.attributes);
-			const newAttributes = cloneDeep(this.props.attributes);
-
-			this.propsToAvoidRendering.forEach(prop => {
-				delete oldAttributes[prop];
-				delete newAttributes[prop];
-			});
-
-			// eslint-disable-next-line no-constant-condition
-			if (!isEqual(oldAttributes, newAttributes) && false)
-				// Just for debugging 👍
-				this.difference(oldAttributes, newAttributes);
-
-			return !isEqual(oldAttributes, newAttributes);
-		}
 
 		if (this.shouldMaxiBlockUpdate)
 			return (

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -83,8 +83,6 @@ const StyleComponent = ({
 class MaxiBlockComponent extends Component {
 	propsToAvoidRendering = [];
 
-	propsToAvoidStyling = [];
-
 	constructor(...args) {
 		super(...args);
 
@@ -231,24 +229,6 @@ class MaxiBlockComponent extends Component {
 	 * Prevents styling
 	 */
 	getSnapshotBeforeUpdate(prevProps, prevState) {
-		if (!isEmpty(this.propsToAvoidStyling)) {
-			const oldAttributes = cloneDeep(prevProps.attributes);
-			const newAttributes = cloneDeep(this.props.attributes);
-
-			this.propsToAvoidStyling.forEach(prop => {
-				delete oldAttributes[prop];
-				delete newAttributes[prop];
-			});
-
-			if (!isEqual(oldAttributes, newAttributes))
-				this.difference(oldAttributes, newAttributes);
-
-			if (this.maxiBlockGetSnapshotBeforeUpdate)
-				this.maxiBlockGetSnapshotBeforeUpdate(prevProps, prevState);
-
-			return isEqual(oldAttributes, newAttributes);
-		}
-
 		// Force render styles when changing state
 		if (!isEqual(prevState, this.state)) return false;
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Remove propsToAvoidStyling as it is not necessary because it is not used. https://github.com/yeahcan/maxi-blocks/issues/3440

# How Has This Been Tested?

**_ Pre-Code Testing _**

-   [ ] Check that nothing has been accidentally deleted.
-   [ ] Check that the deleted lines do not affect the structure of the code.


# Checklist

-   [ ]  My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings/errors
