### PR TITLE
Issue 3449 long block names

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -254,7 +254,10 @@ const MaxiToolbar = memo(
 										</span>
 									</span>
 								)}
-								{customLabel.substring(0, 30)}
+								{customLabel.length > 30
+									? `${customLabel.substring(0, 30)}...`
+									: customLabel}
+
 								<span className='toolbar-block-custom-label__block-style'>
 									{` | ${blockStyle}`}
 								</span>

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -254,7 +254,7 @@ const MaxiToolbar = memo(
 										</span>
 									</span>
 								)}
-								{customLabel}
+								{customLabel.substring(0, 30)}
 								<span className='toolbar-block-custom-label__block-style'>
 									{` | ${blockStyle}`}
 								</span>


### PR DESCRIPTION
Truncate long block names. I couldn't come up with a better solution. As long as we allow the name to break into two lines it doesn't look good. Truncating fixes it easily, and IMO you can till clearly see your custom name in breadcrumbs because we can allow a lot of characters - and of course, when you select the block you see the full custom block name in the sidebar.

If you do have better ideas, be free to suggest.

Fixes #3449

# Test checklist

**_ Front/Back Testing _**

-   [ ] Add a long custom block name and make sure it truncates in the breadcrumbs but you can see the full block name in the sidebar.


**_ Pre-Code Testing _**
-   [ ] Add a long custom block name and make sure it truncates in the breadcrumbs but you can see the full block name in the sidebar.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
