### PR TITLE
Custom CSS slow speed #3129

### DIFF
--- a/e2e-tests/blocks/container-maxi/index.spec.js
+++ b/e2e-tests/blocks/container-maxi/index.spec.js
@@ -50,6 +50,7 @@ describe('Container Maxi', () => {
 		);
 
 		await page.keyboard.type('background: red');
+		await page.waitForTimeout(200);
 
 		// check second background
 		await accordionTab.$eval(
@@ -58,6 +59,7 @@ describe('Container Maxi', () => {
 		);
 
 		await page.keyboard.type('background: blue');
+		await page.waitForTimeout(200);
 
 		await expect(await addCustomCSS(page)).toMatchSnapshot();
 	}, 500000);

--- a/e2e-tests/components/custom-css-control/index.spec.js
+++ b/e2e-tests/components/custom-css-control/index.spec.js
@@ -41,6 +41,7 @@ describe('Custom-Css-Control', () => {
 
 		await pressKeyWithModifier('primary', 'a');
 		await page.keyboard.type('background: blue');
+		await page.waitForTimeout(200);
 
 		// change xs responsive
 		await changeResponsive(page, 'xs');
@@ -81,6 +82,7 @@ describe('Custom-Css-Control', () => {
 		);
 
 		await page.keyboard.type('VALIDATE ERROR');
+		await page.waitForTimeout(200);
 
 		await accordionPanel.$eval(
 			'.maxi-additional__css-group button',

--- a/e2e-tests/components/custom-css/index.spec.js
+++ b/e2e-tests/components/custom-css/index.spec.js
@@ -41,6 +41,7 @@ describe('Custom-Css-Control', () => {
 
 		await pressKeyWithModifier('primary', 'a');
 		await page.keyboard.type('background: blue');
+		await page.waitForTimeout(200);
 
 		// change xs responsive
 		await changeResponsive(page, 'xs');
@@ -81,6 +82,7 @@ describe('Custom-Css-Control', () => {
 		);
 
 		await page.keyboard.type('VALIDATE ERROR');
+		await page.waitForTimeout(200);
 
 		await accordionPanel.$eval(
 			'.maxi-additional__css-group button',

--- a/e2e-tests/utils/addCustomCSS.js
+++ b/e2e-tests/utils/addCustomCSS.js
@@ -12,6 +12,7 @@ const checkCSS = async ({ page, cssInstances }) => {
 		await cssTextArea.focus();
 
 		await page.keyboard.type('background: red');
+		await page.waitForTimeout(200);
 
 		// validate css
 		await page.$$eval(

--- a/src/components/custom-css-control/index.js
+++ b/src/components/custom-css-control/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+
 /**
  * External dependencies
  */
@@ -151,6 +152,8 @@ const CustomCssControl = props => {
 			return !isEmpty(notValidValue) ? notValidValue : validValue;
 		};
 
+		let typingTimeout = null;
+
 		return (
 			<BaseControl
 				key={`${label}`}
@@ -178,9 +181,13 @@ const CustomCssControl = props => {
 				<CodeEditor
 					language='css'
 					value={getValue()}
-					onChange={textarea =>
-						onChangeCssCode(textarea?.target?.value)
-					}
+					onChange={textarea => {
+						if (typingTimeout) clearTimeout(typingTimeout);
+						typingTimeout = setTimeout(
+							() => onChangeCssCode(textarea?.target?.value),
+							200
+						);
+					}}
 					onBlur={textarea => {
 						validateCss(textarea?.target?.value);
 					}}


### PR DESCRIPTION
# Description
Added timeout for custom CSS so that it will wait for 200 milliseconds before applying the styles.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3129 

# How Has This Been Tested?
Type on custom CSS and now check it is not slow as before.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Type on custom CSS and now check it is not slow as before.


**_ Pre-Code Testing _**

-   [x] Type on custom CSS and now check it is not slow as before.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
