### PR TITLE
issue-3374-caption

### DIFF
--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -415,7 +415,7 @@ class edit extends MaxiBlockComponent {
 																this.setState(
 																	newState
 																);
-															}, 10);
+															}, 300);
 													},
 													richTextValues,
 												})
@@ -477,8 +477,24 @@ class edit extends MaxiBlockComponent {
 													maxiSetAttributes,
 													oldFormatValue:
 														this.state.formatValue,
-													onChange: newState =>
-														this.setState(newState),
+													onChange: newState => {
+														if (
+															this
+																.typingTimeoutFormatValue
+														) {
+															clearTimeout(
+																this
+																	.typingTimeoutFormatValue
+															);
+														}
+
+														this.typingTimeoutFormatValue =
+															setTimeout(() => {
+																this.setState(
+																	newState
+																);
+															}, 300);
+													},
 													richTextValues,
 												})
 											}

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -415,7 +415,7 @@ class edit extends MaxiBlockComponent {
 																this.setState(
 																	newState
 																);
-															}, 300);
+															}, 600);
 													},
 													richTextValues,
 												})
@@ -493,7 +493,7 @@ class edit extends MaxiBlockComponent {
 																this.setState(
 																	newState
 																);
-															}, 300);
+															}, 600);
 													},
 													richTextValues,
 												})

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -493,7 +493,6 @@ const Inspector = props => {
 																	type: 'p',
 																}}
 																styleCardPrefix=''
-																allowLink
 															/>
 														</>
 													)}

--- a/src/components/toolbar/captionToolbar.js
+++ b/src/components/toolbar/captionToolbar.js
@@ -25,7 +25,6 @@ import {
 	TextBold,
 	TextColor,
 	TextItalic,
-	TextLink,
 	TextOptions,
 } from './components';
 
@@ -54,13 +53,7 @@ const CaptionToolbar = memo(
 			cleanInlineStyles,
 			isSelected,
 		} = props;
-		const {
-			isList = false,
-			linkSettings,
-			textLevel = 'p',
-			uniqueID,
-			blockStyle,
-		} = attributes;
+		const { isList = false, textLevel = 'p', uniqueID } = attributes;
 
 		const typography = { ...getGroupAttributes(props, 'typography') };
 
@@ -199,17 +192,6 @@ const CaptionToolbar = memo(
 						<TextItalic
 							onChangeFormat={onChangeFormat}
 							getValue={getValue}
-							isCaptionToolbar
-						/>
-						<TextLink
-							{...getGroupAttributes(attributes, 'typography')}
-							onChange={obj => processAttributes(obj)}
-							isList={isList}
-							linkSettings={linkSettings}
-							breakpoint={breakpoint}
-							textLevel={textLevel}
-							blockStyle={blockStyle}
-							styleCard={styleCard}
 							isCaptionToolbar
 						/>
 					</div>


### PR DESCRIPTION
- Removed link from the caption toolbar and link options from the sidebar.
- Increased the new format value timeout to fix the speed of typing and deleting. If I understand the code, we are setting the new caption value when you stop typing. Is that how it must work or we can trigger the change on a different event?

Fixes #3374

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Make sure the caption toolbar doesn't have the link option anymore and that the link options do not show in the sidebar.
-   [ ] Compare with master and make sure caption speed is better. Try top and bottom caption.


**_ Pre-Code Testing _**

-   [ ] Make sure the caption toolbar doesn't have the link option anymore and that the link options do not show in the sidebar.
-   [ ] Compare with master and make sure caption speed is better. Try top and bottom caption.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
