### PR TITLE
Issue 3397- Responsive switch by gutenberg button breaks editor fix

### DIFF
--- a/e2e-tests/utils/changeResponsive.js
+++ b/e2e-tests/utils/changeResponsive.js
@@ -4,7 +4,10 @@ const changeResponsive = async (page, size) => {
 	);
 
 	await page.evaluate(
-		_size => wp.data.dispatch('maxiBlocks').setMaxiDeviceType(_size),
+		_size =>
+			wp.data
+				.dispatch('maxiBlocks')
+				.setMaxiDeviceType({ deviceType: _size }),
 		((size, winBreakpoint) =>
 			size === 'base' || winBreakpoint === size ? 'general' : size)(
 			size,

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -200,26 +200,7 @@ wp.domReady(() => {
 
 						const editorWrapper = iframeDocument.body;
 
-						editorWrapper.setAttribute(
-							'maxi-blocks-responsive',
-							mutation.target.classList.contains(
-								'is-tablet-preview'
-							)
-								? 's'
-								: 'xs'
-						);
-
-						if (
-							iframe &&
-							!iframeDocument.body.classList.contains(
-								'maxi-blocks--active'
-							)
-						) {
-							// Iframe needs Maxi classes and attributes
-							iframeDocument.body.classList.add(
-								'maxi-blocks--active'
-							);
-							const editorWrapper = iframeDocument.body;
+						if (editorWrapper) {
 							editorWrapper.setAttribute(
 								'maxi-blocks-responsive',
 								mutation.target.classList.contains(
@@ -229,83 +210,107 @@ wp.domReady(() => {
 									: 'xs'
 							);
 
-							// Copy all fonts to iframe
-							loadFonts(getPageFonts(), true, iframeDocument);
-
-							// Get all Maxi blocks <style> from <head>
-							// and move to new iframe
-							const maxiStyles = Array.from(
-								document.querySelectorAll(
-									'div.maxi-blocks__styles'
+							if (
+								iframe &&
+								!iframeDocument.body.classList.contains(
+									'maxi-blocks--active'
 								)
-							);
+							) {
+								// Iframe needs Maxi classes and attributes
+								iframeDocument.body.classList.add(
+									'maxi-blocks--active'
+								);
 
-							if (!isEmpty(maxiStyles))
-								maxiStyles.forEach(rawMaxiStyle => {
-									const maxiStyle =
-										rawMaxiStyle.cloneNode(true);
-									const { id } = maxiStyle;
+								editorWrapper.setAttribute(
+									'maxi-blocks-responsive',
+									mutation.target.classList.contains(
+										'is-tablet-preview'
+									)
+										? 's'
+										: 'xs'
+								);
 
-									iframeDocument
-										.querySelector(`#${id}`)
-										?.remove();
+								// Copy all fonts to iframe
+								loadFonts(getPageFonts(), true, iframeDocument);
 
-									maxiStyle.children[0].innerText =
-										maxiStyle.children[0].innerText.replaceAll(
-											' .edit-post-visual-editor',
-											'.editor-styles-wrapper'
+								// Get all Maxi blocks <style> from <head>
+								// and move to new iframe
+								const maxiStyles = Array.from(
+									document.querySelectorAll(
+										'div.maxi-blocks__styles'
+									)
+								);
+
+								if (!isEmpty(maxiStyles))
+									maxiStyles.forEach(rawMaxiStyle => {
+										const maxiStyle =
+											rawMaxiStyle.cloneNode(true);
+										const { id } = maxiStyle;
+
+										iframeDocument
+											.querySelector(`#${id}`)
+											?.remove();
+
+										maxiStyle.children[0].innerText =
+											maxiStyle.children[0].innerText.replaceAll(
+												' .edit-post-visual-editor',
+												'.editor-styles-wrapper'
+											);
+
+										iframe.contentDocument.head.appendChild(
+											maxiStyle
 										);
+									});
 
-									iframe.contentDocument.head.appendChild(
-										maxiStyle
-									);
-								});
-
-							// Move Maxi variables to iframe
-							const maxiVariables = document
-								.querySelector(
-									'#maxi-blocks-sc-vars-inline-css'
-								)
-								?.cloneNode(true);
-
-							if (maxiVariables) {
-								iframeDocument
+								// Move Maxi variables to iframe
+								const maxiVariables = document
 									.querySelector(
 										'#maxi-blocks-sc-vars-inline-css'
 									)
-									?.remove();
+									?.cloneNode(true);
 
-								iframe.contentDocument.head.appendChild(
-									maxiVariables
-								);
-							}
+								if (maxiVariables) {
+									iframeDocument
+										.querySelector(
+											'#maxi-blocks-sc-vars-inline-css'
+										)
+										?.remove();
 
-							// Ensures all Maxi styles are loaded on iframe
-							const editStyles = iframeDocument.querySelector(
-								'#maxi-blocks-block-editor-css'
-							);
-							const frontStyles = iframeDocument.querySelector(
-								'#maxi-blocks-block-css'
-							);
+									iframe.contentDocument.head.appendChild(
+										maxiVariables
+									);
+								}
 
-							if (!editStyles) {
-								const rawEditStyles = document.querySelector(
+								// Ensures all Maxi styles are loaded on iframe
+								const editStyles = iframeDocument.querySelector(
 									'#maxi-blocks-block-editor-css'
 								);
+								const frontStyles =
+									iframeDocument.querySelector(
+										'#maxi-blocks-block-css'
+									);
 
-								iframe.contentDocument.head.appendChild(
-									rawEditStyles.cloneNode(true)
-								);
-							}
+								if (!editStyles) {
+									const rawEditStyles =
+										document.querySelector(
+											'#maxi-blocks-block-editor-css'
+										);
 
-							if (!frontStyles) {
-								const rawFrontStyles = document.querySelector(
-									'#maxi-blocks-block-css'
-								);
+									iframe.contentDocument.head.appendChild(
+										rawEditStyles.cloneNode(true)
+									);
+								}
 
-								iframe.contentDocument.head.appendChild(
-									rawFrontStyles.cloneNode(true)
-								);
+								if (!frontStyles) {
+									const rawFrontStyles =
+										document.querySelector(
+											'#maxi-blocks-block-css'
+										);
+
+									iframe.contentDocument.head.appendChild(
+										rawFrontStyles.cloneNode(true)
+									);
+								}
 							}
 						}
 					}

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -360,7 +360,10 @@ wp.domReady(() => {
 										if (value === 'Desktop')
 											editorWrapper.style.width = '';
 
-										setMaxiDeviceType(maxiValue);
+										setMaxiDeviceType({
+											deviceType: maxiValue,
+											isGutenbergButton: true,
+										});
 									});
 								});
 							}

--- a/src/extensions/store/actions.js
+++ b/src/extensions/store/actions.js
@@ -37,19 +37,21 @@ const actions = {
 			deviceType,
 		};
 	},
-	setMaxiDeviceType(deviceType, width) {
-		const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
-			dispatch('core/edit-post');
+	setMaxiDeviceType({ deviceType, width, isGutenbergButton = false }) {
+		if (!isGutenbergButton) {
+			const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
+				dispatch('core/edit-post');
 
-		const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
+			const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
 
-		const gutenbergDeviceType =
-			(deviceType === 'general' && 'Desktop') ||
-			(width >= breakpoints.m && 'Desktop') ||
-			(width >= breakpoints.s && 'Tablet') ||
-			(width < breakpoints.s && 'Mobile');
+			const gutenbergDeviceType =
+				(deviceType === 'general' && 'Desktop') ||
+				(width >= breakpoints.m && 'Desktop') ||
+				(width >= breakpoints.s && 'Tablet') ||
+				(width < breakpoints.s && 'Mobile');
 
-		if (gutenbergDeviceType) setPreviewDeviceType(gutenbergDeviceType);
+			if (gutenbergDeviceType) setPreviewDeviceType(gutenbergDeviceType);
+		}
 
 		return {
 			type: 'SET_DEVICE_TYPE',

--- a/src/extensions/styles/setScreenSize.js
+++ b/src/extensions/styles/setScreenSize.js
@@ -4,12 +4,13 @@ const setScreenSize = size => {
 	const xxlSize = select('maxiBlocks').receiveXXLSize();
 	const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
 
-	if (size === 'general') dispatch('maxiBlocks').setMaxiDeviceType('general');
+	if (size === 'general')
+		dispatch('maxiBlocks').setMaxiDeviceType({ deviceType: 'general' });
 	else
-		dispatch('maxiBlocks').setMaxiDeviceType(
-			size,
-			size !== 'xxl' ? breakpoints[size] : xxlSize
-		);
+		dispatch('maxiBlocks').setMaxiDeviceType({
+			deviceType: size,
+			width: size !== 'xxl' ? breakpoints[size] : xxlSize,
+		});
 };
 
 export default setScreenSize;


### PR DESCRIPTION
# Description

Changes:
- prevent gutenberg device type change on gutenberg button click
- transformed `setMaxiDeviceType` function props into object
- removed console error related with undefined `editorWrapper` + remove duplication of initializing `editorWrapper` variable

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3397 

# How Has This Been Tested?
Tested if responsive switching works fine everywhere

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the responsive switch from gutenberg buttons
-   [x] Test the responsive switch from maxi top bar
-   [x] Test the responsive switch from sidebar responsive buttons

**_ Pre-Code Testing _**

-   [x] Test the responsive switch from gutenberg buttons
-   [x] Test the responsive switch from maxi top bar
-   [x] Test the responsive switch from sidebar responsive buttons
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [X] New and existing unit tests pass locally with my changes
