### PR TITLE
Fix responsive container button bug

### DIFF
--- a/src/blocks/container-maxi/editor.scss
+++ b/src/blocks/container-maxi/editor.scss
@@ -2,12 +2,12 @@
 	margin: auto;
 
 	.block-list-appender
-		.block-editor-button-block-appender[aria-label='Add Row Maxi'] {
+		.block-editor-button-block-appender.button[aria-label='Add Row Maxi'] {
 		left: 50%;
 		border-radius: 50%;
 	}
 	.block-list-appender--show {
-		.block-editor-button-block-appender {
+		.block-editor-button-block-appender.button {
 			visibility: visible;
 			opacity: 1;
 		}

--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -21,9 +21,9 @@
 	&__button {
 		display: block;
 		position: relative;
-		width: 16px;
-		height: 16px;
-		margin: auto;
+		width: 16px !important;
+		height: 16px !important;
+		margin: auto !important;
 		padding: 0 !important;
 		background: #ff4a17 !important;
 		box-shadow: none;

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -88,7 +88,7 @@ body {
 	&:hover {
 		& > .block-editor-block-list__layout {
 			& > .block-list-appender {
-				.block-editor-button-block-appender {
+				.block-editor-button-block-appender.button {
 					opacity: 1 !important;
 					visibility: visible !important;
 				}


### PR DESCRIPTION
# Description

Fixes https://github.com/yeahcan/maxi-blocks/issues/3362

A class has been added to make the specificity work correctly, also some !important have been added to make sure the button is generated correctly.

The important additions are because in the tests I have done to solve the problem, the button was off-centre.

# How Has This Been Tested?
First add this code in Maxi's code editor, then switch to responsive S
[code (6).txt](https://github.com/yeahcan/maxi-blocks/files/9103043/code.6.txt)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that the button does not occupy the whole column.
-   [ ] Check that in the button styles inside the column there are not two .block-editor-button-button-block-appender
-   [ ] Check that in the button styles inside the column there are the new !important  .maxi-block-inserter__button

**_ Pre-Code Testing _**

-   [ ] check that the new !importants are working properly and are needed
-   [ ] check that the new classes work correctly
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
