### PR TITLE
Image disappearing on overflow hidden + transform scale fix

### DIFF
--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -24,6 +24,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 		width: 100%;
 		max-width: 100%;
 		max-height: 100%;
+		min-height: 1px;
 		flex-grow: 1;
 		box-sizing: border-box;
 

--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -24,6 +24,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 		width: 100%;
 		max-width: 100%;
 		max-height: 100%;
+		// Overflow hidden + transform scale bug fix #3457
 		min-height: 1px;
 		flex-grow: 1;
 		box-sizing: border-box;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3457 

# How Has This Been Tested?
Tested if it works here with this [code_editor ](https://github.com/yeahcan/maxi-blocks/files/9160164/transform-overflow-bug-pattern.txt), also created on my local container with group and image inside, changed transform scale,  enabled the hidden overflow for group and checked if the image disappeared.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test image-maxi with overflow and transform scale
-   [x] Test if this [code_editor ](https://github.com/yeahcan/maxi-blocks/files/9160164/transform-overflow-bug-pattern.txt) hasn't problems with images disappearing
-   [x] Test if we haven't any side effects from added styles code

**_ Pre-Code Testing _**

-   [x] Test image-maxi with overflow and transform scale
-   [x] Test if this [code_editor ](https://github.com/yeahcan/maxi-blocks/files/9160164/transform-overflow-bug-pattern.txt) hasn't problems with images disappearing
-   [x] Test if we haven't any side effects from added styles code
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors

