### PR TITLE
Fix transform IB migrator

### DIFF
--- a/src/extensions/styles/migrators/transformIBMigrator.js
+++ b/src/extensions/styles/migrators/transformIBMigrator.js
@@ -198,18 +198,12 @@ const getAttributesFromStyle = (styles, selector) => {
 									splitValueAndUnit(value);
 
 								return {
-									...result[
-										`transform-origin-${breakpoint}`
-									]?.[selector].normal,
 									[axis]: `${num}`,
 									[`${axis}-unit`]: unit,
 								};
 						  })()
 						: (() => {
 								return {
-									...result[
-										`transform-origin-${breakpoint}`
-									]?.[selector].normal,
 									[axis]: value,
 								};
 						  })()),
@@ -220,6 +214,9 @@ const getAttributesFromStyle = (styles, selector) => {
 					[selector]: {
 						...result[`transform-origin-${breakpoint}`]?.[selector],
 						normal: {
+							...result[`transform-origin-${breakpoint}`]?.[
+								selector
+							].normal,
 							...response,
 						},
 					},

--- a/src/extensions/styles/migrators/transformIBMigrator.js
+++ b/src/extensions/styles/migrators/transformIBMigrator.js
@@ -17,7 +17,7 @@ import { selectorsVideo } from '../../../blocks/video-maxi/custom-css';
 /**
  * External dependencies
  */
-import { isEmpty, findKey } from 'lodash';
+import { isEmpty, findKey, isEqual } from 'lodash';
 import { splitValueAndUnit } from '../utils';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
@@ -54,72 +54,178 @@ const isEligible = blockAttributes => {
 	return isOldStructure;
 };
 
+const transformIBCleaner = relations =>
+	relations.map(relation => {
+		const { attributes, css } = relation;
+
+		const reversedBreakpoints = breakpoints.slice().reverse();
+
+		['scale', 'rotate', 'translate', 'origin'].forEach(type => {
+			reversedBreakpoints.forEach((breakpoint, i) => {
+				if (
+					attributes[`transform-${type}-${breakpoint}`] &&
+					isEqual(
+						attributes[`transform-${type}-${breakpoint}`],
+						attributes[
+							`transform-${type}-${reversedBreakpoints[i + 1]}`
+						]
+					)
+				) {
+					delete attributes[`transform-${type}-${breakpoint}`];
+				}
+			});
+		});
+
+		const cssUsesTarget = Object.keys(css).some(target =>
+			breakpoints.includes(target)
+		);
+
+		if (cssUsesTarget)
+			reversedBreakpoints.forEach((breakpoint, i) => {
+				if (
+					css[breakpoint] &&
+					isEqual(
+						css[breakpoint]?.styles,
+						css[reversedBreakpoints[i + 1]]?.styles
+					)
+				) {
+					delete css[breakpoint];
+				}
+			});
+
+		if (!cssUsesTarget)
+			Object.entries(css).forEach(([target, styles]) => {
+				reversedBreakpoints.forEach((breakpoint, i) => {
+					if (
+						styles[breakpoint] &&
+						isEqual(
+							styles[breakpoint]?.styles,
+							styles[reversedBreakpoints[i + 1]]?.styles
+						)
+					) {
+						delete css[target][breakpoint];
+					}
+				});
+			});
+
+		return { ...relation, attributes, css };
+	});
+
 const getAttributesFromStyle = (styles, selector) => {
 	const result = {};
 
 	breakpoints.forEach(breakpoint => {
 		if (!styles[breakpoint]) return;
 
-		const { transform } = styles[breakpoint].styles;
+		const { transform, 'transform-origin': transformOrigin } =
+			styles[breakpoint].styles;
 
-		if (!transform) return;
+		if (!transform && !transformOrigin) return;
 
-		const transformAttrs = transform.split(' ');
+		if (transform) {
+			const transformAttrs = transform.split(' ');
 
-		transformAttrs.forEach(attr => {
-			const [key, value] = attr.replace(')', '').split('(');
+			transformAttrs.forEach(attr => {
+				const [key, value] = attr.replace(')', '').split('(');
 
-			if (!key || !value) return;
+				if (!key || !value) return;
 
-			const type = key.slice(0, -1);
-			const axis = key.slice(-1).toLowerCase();
+				const type = key.slice(0, -1);
+				const axis = key.slice(-1).toLowerCase();
 
-			const isOriginWithUnit =
-				key.includes('origin') &&
-				!['top', 'right', 'bottom', 'left', 'center'].includes(value);
+				if (['scale', 'rotate'].includes(type)) {
+					let finalValue;
+					if (type === 'scale') {
+						finalValue = parseFloat(value) * 100;
+					}
+					if (type === 'rotate') {
+						finalValue = parseFloat(value.replace('deg', ''));
+					}
 
-			if (
-				['scale', 'rotate'].includes(type) ||
-				(type === 'origin' && !isOriginWithUnit)
-			) {
-				result[`transform-${type}-${breakpoint}`] = {
-					...result[`transform-${type}-${breakpoint}`],
-					[selector]: {
-						...result[`transform-${type}-${breakpoint}`]?.[
-							selector
-						],
-						normal: {
+					result[`transform-${type}-${breakpoint}`] = {
+						...result[`transform-${type}-${breakpoint}`],
+						[selector]: {
 							...result[`transform-${type}-${breakpoint}`]?.[
 								selector
-							].normal,
-							[axis]: value,
+							],
+							normal: {
+								...result[`transform-${type}-${breakpoint}`]?.[
+									selector
+								].normal,
+								[axis]: finalValue,
+							},
+						},
+					};
+				}
+				if (type === 'translate') {
+					const { value: num, unit } = splitValueAndUnit(value);
+
+					result[`transform-${type}-${breakpoint}`] = {
+						...result[`transform-${type}-${breakpoint}`],
+						[selector]: {
+							...result[`transform-${type}-${breakpoint}`]?.[
+								selector
+							],
+							normal: {
+								...result[`transform-${type}-${breakpoint}`]?.[
+									selector
+								].normal,
+								[axis]: num,
+								[`${axis}-unit`]: unit,
+							},
+						},
+					};
+				}
+			});
+		}
+		if (transformOrigin) {
+			const [x, y] = transformOrigin.split(' ');
+			const originAxis = { x, y };
+
+			Object.entries(originAxis).forEach(([axis, value]) => {
+				const isOriginWithUnit = ![
+					'top',
+					'right',
+					'bottom',
+					'left',
+					'center',
+				].includes(value);
+
+				const response = {
+					...(isOriginWithUnit
+						? (() => {
+								const { value: num, unit } =
+									splitValueAndUnit(value);
+
+								return {
+									...result[
+										`transform-origin-${breakpoint}`
+									]?.[selector].normal,
+									[axis]: `${num}`,
+									[`${axis}-unit`]: unit,
+								};
+						  })()
+						: (() => {
+								return {
+									...result[
+										`transform-origin-${breakpoint}`
+									]?.[selector].normal,
+									[axis]: value,
+								};
+						  })()),
+				};
+
+				result[`transform-origin-${breakpoint}`] = {
+					...result[`transform-origin-${breakpoint}`],
+					[selector]: {
+						...result[`transform-origin-${breakpoint}`]?.[selector],
+						normal: {
+							...response,
 						},
 					},
 				};
-			}
-			if (
-				['translate'].includes(type) ||
-				(type === 'origin' && isOriginWithUnit)
-			) {
-				const { value: num, unit } = splitValueAndUnit(value);
-
-				result[`transform-${type}-${breakpoint}`] = {
-					...result[`transform-${type}-${breakpoint}`],
-					[selector]: {
-						...result[`transform-${type}-${breakpoint}`]?.[
-							selector
-						],
-						normal: {
-							...result[`transform-${type}-${breakpoint}`]?.[
-								selector
-							].normal,
-							[axis]: num,
-							[`${axis}-unit`]: unit,
-						},
-					},
-				};
-			}
-		});
+			});
+		}
 	});
 
 	return result;
@@ -152,7 +258,7 @@ const migrate = ({ newAttributes }) => {
 		newRelations[i].css = { '': { ...css } };
 	});
 
-	return { ...newAttributes, relations: newRelations };
+	return { ...newAttributes, relations: transformIBCleaner(newRelations) };
 };
 
 export default { isEligible, migrate };


### PR DESCRIPTION
# Description

⚠️  This PR is necessary to update devdemo site, so please, give max priority ⚠️ 

While checking the differences between the old and new version of Maxi to update devdemo site, found the `transformIBMigrator` is not working correctly. Here's an example:
The migrator should transform this css line:
` "transform": "scaleX(1.08) scaleY(1.08) rotateZ(-2deg) "`
and what we've got is:

<img width="258" alt="Captura de Pantalla 2022-08-09 a las 15 57 20" src="https://user-images.githubusercontent.com/50477222/183667980-2c8c729e-3ffa-4f27-b957-a08a0bfe6c24.png">

where the rotate value is just correct on `general` and on the rest of breakpoints is `-2deg` (which is incorrect, so not corresponding with TransformControl), and also:

<img width="258" alt="Captura de Pantalla 2022-08-09 a las 15 59 44" src="https://user-images.githubusercontent.com/50477222/183668546-180feff9-9964-433c-9ce1-a2ffa5cedc19.png">

where the axis should be 108 (number), but is just on `general`: on the rest of breakpoints is a floating number on a string.

Also, `transform-origin` wasn't working correctly, and the transform wasn't taking the `transform-origin` entry on the `css` part and creating the prop 'transform-origin' `attributes` on the object

Apart from this modifying, other change has been implemented: a cleaner for the `transform` on the IB migrator that ensures `attributes` and `css` are not repeated 👍 

# How Has This Been Tested?

First, a couple of small blocks to see the errors:

[To check 'transform-origin'](https://github.com/yeahcan/maxi-blocks/files/9291437/transformIBmigrator-origin.txt): consider (or check on the code) this block has a `relations` array with an object that contains a `css` entry with `transform-origin: 50% 100%` that on `master` is not migrated to an attribute. When checking it, the expected result is an object like:
````js
{
    "transform-origin-general": {
        "text wrapper": {
            "normal": {
                "x": "50",
                "x-unit": "%",
                "y": "100",
                "y-unit": "%"
            }
        }
    },
}
````

[To check 'transform' values are correct](https://github.com/yeahcan/maxi-blocks/files/9291456/transformIBmigrator-transform.txt): as shown on the description, this block shouldn't contain that errors on the `relations` array. To check it this snippet can be used after pasting on a new post with this branch running:
`wp.data.select('core/block-editor').getBlockAttributes(wp.data.select('core/block-editor').getSelectedBlockClientId()).relations`

or directly the next method:
This issue has been found manually comparing the old version of maxi with the new one; for it you can use the next methodology with some patterns I'll update on the bottom:
1. Paste the pattern on a new post; once loaded, copy the code editor.
2. Compare the original code editor with the new one using [this diff tool](https://www.diffchecker.com/)
3. Compare the attributes changed selecting the as an object and use [this json diff tool](http://www.jsondiff.com/) to see the differences.
PS: the only other differences you've probably going to find comparing patterns is `transitions`, so it is expected 👍 

Here's a video showing how to do it:

https://user-images.githubusercontent.com/50477222/183675631-d6f08a5c-4577-4dbc-8501-343f8b47f2ea.mp4

Random patterns:
[pattern_4.txt](https://github.com/yeahcan/maxi-blocks/files/9291659/pattern_4.txt)
[pattern_3.txt](https://github.com/yeahcan/maxi-blocks/files/9291660/pattern_3.txt)
[pattern_2.txt](https://github.com/yeahcan/maxi-blocks/files/9291661/pattern_2.txt)
[pattern_1.txt](https://github.com/yeahcan/maxi-blocks/files/9291662/pattern_1.txt)


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Transform object on `relations` array attribute looks as expected

**_ Pre-Code Testing _**

-   [ ] Transform object on `relations` array attribute looks as expected
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
