### PR TITLE
Issue 3550 breadcrumbs

### DIFF
--- a/src/components/toolbar/editor.scss
+++ b/src/components/toolbar/editor.scss
@@ -86,6 +86,7 @@
 				font-family: 'Roboto', sans-serif !important;
 				line-height: 100%;
 				height: 20px;
+				white-space: pre;
 
 				&__block-style {
 					text-transform: capitalize;


### PR DESCRIPTION
# Description
Fixes breadcrumbs dropping into two lines.

Fixes #3550 

Example: https://devdemo.maxiblocks.com/story-mix-light-part-6/
![image](https://user-images.githubusercontent.com/19425503/186167295-59b7546c-18a5-4e61-8ea8-43884899e128.png)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-  [ ] Test breadcrumbs in various blocks and make sure they look OK.
-  [ ] Test the block from the example page.

**_ Front/Back Testing _**

-  [x] Test breadcrumbs in various blocks and make sure they look OK.
-  [x] Test the block from the example page.
-  [x] Check no commented code and no unnecessary imports
-  [x] Standards of the project have been followed
-  [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
