### PR TITLE
issue 3579 - fix SC fonts not loading in iframe editor

### DIFF
--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -234,7 +234,11 @@ wp.domReady(() => {
 								);
 
 								// Copy all fonts to iframe
-								loadFonts(getPageFonts(), true, iframeDocument);
+								loadFonts(
+									getPageFonts(true),
+									true,
+									iframeDocument
+								);
 
 								// Get all Maxi blocks <style> from <head>
 								// and move to new iframe

--- a/src/extensions/text/fonts/utils.js
+++ b/src/extensions/text/fonts/utils.js
@@ -21,7 +21,8 @@ export const getAllFonts = (
 	recursiveKey = false,
 	isHover = false,
 	textLevel = 'p',
-	blockStyle = 'light'
+	blockStyle = 'light',
+	onlyBackend = false
 ) => {
 	const { receiveMaxiSelectedStyleCard } = select('maxiBlocks/style-cards');
 	const styleCard = receiveMaxiSelectedStyleCard()?.value || {};
@@ -48,7 +49,8 @@ export const getAllFonts = (
 						breakpoint,
 						isHover,
 						textLevel,
-						avoidSC: true,
+						avoidSC: !onlyBackend,
+						styleCard,
 					}) ??
 					`sc_font_${blockStyle}_${textLevel}`;
 
@@ -147,7 +149,7 @@ const mergeDeep = (target, source) => {
 	return target;
 };
 
-export const getPageFonts = () => {
+export const getPageFonts = (onlyBackend = false) => {
 	const { getBlocks } = select('core/block-editor');
 
 	let response = {};
@@ -208,14 +210,16 @@ export const getPageFonts = () => {
 							false,
 							false,
 							textLevel,
-							blockStyle
+							blockStyle,
+							onlyBackend
 						),
 						getAllFonts(
 							typographyHover,
 							false,
 							true,
 							textLevel,
-							blockStyle
+							blockStyle,
+							onlyBackend
 						)
 					);
 				else
@@ -224,7 +228,8 @@ export const getPageFonts = () => {
 						false,
 						false,
 						textLevel,
-						blockStyle
+						blockStyle,
+						onlyBackend
 					);
 
 				mergedResponse = mergeDeep(


### PR DESCRIPTION
# Description
Added `onlyBackend` prop to `getPageFonts`, which makes it return style cards fonts with font name instead of `sc_font_${blockStyle}_${textLevel}`
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3579

# How Has This Been Tested?
Checked that fonts load on small breakpoints. Also tested that this implementation doesn't break #2952.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Change font on SC, and check if it is loaded on small breakpoints in editor

**_ Pre-Code Testing _**

-   [x] Change font on SC, and check if it is loaded on small breakpoints in editor
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
