### PR TITLE
Issue 3574 - right width on small breakpoints

### DIFF
--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -473,3 +473,12 @@ html[dir='rtl'] {
 		}
 	}
 }
+
+/**
+* Hide scrollbar in iframe editor #3574
+*/
+body[maxi-blocks-responsive] {
+	&::-webkit-scrollbar {
+		width: 0;
+	}
+}

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -205,7 +205,6 @@ wp.domReady(() => {
 							'iframe[name="editor-canvas"]'
 						);
 						const iframeDocument = iframe.contentDocument;
-
 						const editorWrapper = iframeDocument.body;
 
 						const responsiveWidth = mutation.target
@@ -246,6 +245,10 @@ wp.domReady(() => {
 										? 's'
 										: 'xs'
 								);
+
+								// Hides scrollbar in firefox
+								iframeDocument.documentElement.style.scrollbarWidth =
+									'none';
 
 								// Copy all fonts to iframe
 								loadFonts(getPageFonts(), true, iframeDocument);

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -178,12 +178,16 @@ wp.domReady(() => {
 						const responsiveWidth = mutation.target.getAttribute(
 							'maxi-blocks-responsive-width'
 						);
+						const isMaxiPreview =
+							mutation.target.getAttribute('is-maxi-preview');
 						const breakpoint = mutation.target.getAttribute(
 							'maxi-blocks-responsive'
 						);
 
-						if (['s', 'xs'].includes(breakpoint)) {
-							mutation.target.style.width = '100%';
+						if (!isMaxiPreview) {
+							mutation.target.style = null;
+						} else if (['s', 'xs'].includes(breakpoint)) {
+							mutation.target.style.width = 'fit-content';
 						} else if (
 							mutation.target.style.width !==
 							`${responsiveWidth}px`
@@ -207,11 +211,16 @@ wp.domReady(() => {
 						const iframeDocument = iframe.contentDocument;
 						const editorWrapper = iframeDocument.body;
 
-						const responsiveWidth = mutation.target
-							.closest('.edit-post-visual-editor')
-							.getAttribute('maxi-blocks-responsive-width');
+						const postEditor = mutation.target.closest(
+							'.edit-post-visual-editor'
+						);
+						const responsiveWidth = postEditor.getAttribute(
+							'maxi-blocks-responsive-width'
+						);
+						const isMaxiPreview =
+							postEditor.getAttribute('is-maxi-preview');
 
-						if (mutation.target.getAttribute('is-maxi-preview')) {
+						if (isMaxiPreview) {
 							mutation.target.style.width = `${responsiveWidth}px`;
 							mutation.target.style.boxSizing = 'content-box';
 						}

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -178,8 +178,13 @@ wp.domReady(() => {
 						const responsiveWidth = mutation.target.getAttribute(
 							'maxi-blocks-responsive-width'
 						);
+						const breakpoint = mutation.target.getAttribute(
+							'maxi-blocks-responsive'
+						);
 
-						if (
+						if (['s', 'xs'].includes(breakpoint)) {
+							mutation.target.style.width = '100%';
+						} else if (
 							mutation.target.style.width !==
 							`${responsiveWidth}px`
 						) {
@@ -202,6 +207,15 @@ wp.domReady(() => {
 						const iframeDocument = iframe.contentDocument;
 
 						const editorWrapper = iframeDocument.body;
+
+						const responsiveWidth = mutation.target
+							.closest('.edit-post-visual-editor')
+							.getAttribute('maxi-blocks-responsive-width');
+
+						if (mutation.target.getAttribute('is-maxi-preview')) {
+							mutation.target.style.width = `${responsiveWidth}px`;
+							mutation.target.style.boxSizing = 'content-box';
+						}
 
 						if (editorWrapper) {
 							editorWrapper.setAttribute(

--- a/src/extensions/store/actions.js
+++ b/src/extensions/store/actions.js
@@ -57,6 +57,7 @@ const actions = {
 			type: 'SET_DEVICE_TYPE',
 			deviceType,
 			width,
+			isGutenbergButton,
 		};
 	},
 	setWindowSize(winSize) {

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -8,9 +8,6 @@ const breakpointResizer = (
 	isGutenbergButton = false
 ) => {
 	const editorWrapper = document.querySelector('.edit-post-visual-editor');
-	const editorContent = document.querySelector(
-		'.edit-post-visual-editor__content-area'
-	).firstChild;
 
 	const winHeight = window.outerWidth;
 	const responsiveWidth =
@@ -24,18 +21,23 @@ const breakpointResizer = (
 	);
 	editorWrapper.setAttribute('maxi-blocks-responsive-width', responsiveWidth);
 
-	if (!isGutenbergButton) editorContent.setAttribute('is-maxi-preview', true);
-	else editorContent.removeAttribute('is-maxi-preview');
+	if (!isGutenbergButton) editorWrapper.setAttribute('is-maxi-preview', true);
+	else editorWrapper.removeAttribute('is-maxi-preview');
 
 	if (size === 'general') {
 		editorWrapper.style.width = '';
 		editorWrapper.style.margin = '';
 	} else {
-		if (['s', 'xs'].includes(size)) editorWrapper.style.width = '100%';
-		else editorWrapper.style.width = `${responsiveWidth}px`;
-
 		if (winHeight > responsiveWidth) editorWrapper.style.margin = '0 auto';
 		else editorWrapper.style.margin = '';
+
+		if (isGutenbergButton) {
+			editorWrapper.style = null;
+		} else if (['s', 'xs'].includes(size)) {
+			editorWrapper.style.width = 'fit-content';
+		} else if (editorWrapper.style.width !== `${responsiveWidth}px`) {
+			editorWrapper.style.width = `${responsiveWidth}px`;
+		}
 	}
 };
 

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -4,9 +4,14 @@ const breakpointResizer = (
 	size,
 	breakpoints,
 	xxlSize = breakpoints.xl + 1,
-	winSize = 0
+	winSize = 0,
+	isGutenbergButton = false
 ) => {
 	const editorWrapper = document.querySelector('.edit-post-visual-editor');
+	const editorContent = document.querySelector(
+		'.edit-post-visual-editor__content-area'
+	).firstChild;
+
 	const winHeight = window.outerWidth;
 	const responsiveWidth =
 		(size === 'general' && 'none') ||
@@ -19,11 +24,15 @@ const breakpointResizer = (
 	);
 	editorWrapper.setAttribute('maxi-blocks-responsive-width', responsiveWidth);
 
+	if (!isGutenbergButton) editorContent.setAttribute('is-maxi-preview', true);
+	else editorContent.removeAttribute('is-maxi-preview');
+
 	if (size === 'general') {
 		editorWrapper.style.width = '';
 		editorWrapper.style.margin = '';
 	} else {
-		editorWrapper.style.width = `${responsiveWidth}px`;
+		if (['s', 'xs'].includes(size)) editorWrapper.style.width = '100%';
+		else editorWrapper.style.width = `${responsiveWidth}px`;
 
 		if (winHeight > responsiveWidth) editorWrapper.style.margin = '0 auto';
 		else editorWrapper.style.margin = '';
@@ -66,7 +75,8 @@ const reducer = (
 				action.deviceType,
 				state.breakpoints,
 				action.width,
-				state.settings.window.width
+				state.settings.window.width,
+				action.isGutenbergButton
 			);
 			return {
 				...state,
@@ -100,7 +110,7 @@ const reducer = (
 			} else if (depth < newInspectorPath.length) {
 				newInspectorPath[depth] = newValue;
 
-				for (let i = depth + 1; i <= newInspectorPath.length; i++) {
+				for (let i = depth + 1; i <= newInspectorPath.length; i += 1) {
 					newInspectorPath.splice(i, 1);
 				}
 


### PR DESCRIPTION
# Description
Width on small breakpoints is now set to `.is-${mobile||tablet}-preview` element instead of `.edit-post-visual-editor`, because this is where gutenberg sets width for responsive. Also hid scrollbar on small breakpoints.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3574

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that when clicking maxi responsive buttons, width of editor is correct for that breakpoint.
-   [x] Check that when clicking gutenberg preview buttons, their preview width is set.
-   [x] Check that scrollbar on S and XS breakpoints is hidden in all browsers.

**_ Pre-Code Testing _**

-   [x] Check that when clicking maxi responsive buttons, width of editor is correct for that breakpoint.
-   [x] Check that when clicking gutenberg preview buttons, their preview width is set.
-   [x] Check that scrollbar on S and XS breakpoints is hidden in all browsers.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
