### PR TITLE
Issue 3623 - MVP: remove Line Width on IB Icon Maxi block

### DIFF
--- a/src/components/relation-control/settings.js
+++ b/src/components/relation-control/settings.js
@@ -425,28 +425,29 @@ const settings = {
 					prefix: 'svg-',
 				}),
 		},
-		{
-			label: __('Icon line width', 'maxi-blocks'),
-			attrGroupName: 'svg',
-			component: props => {
-				const { attributes } = props;
-				const { content } = attributes;
+		// TODO: fix #3619
+		// {
+		// 	label: __('Icon line width', 'maxi-blocks'),
+		// 	attrGroupName: 'svg',
+		// 	component: props => {
+		// 		const { attributes } = props;
+		// 		const { content } = attributes;
 
-				return (
-					<Controls.SvgStrokeWidthControl
-						{...props}
-						content={content}
-						prefix='svg-'
-					/>
-				);
-			},
-			helper: props =>
-				styleHelpers.getSVGStyles({
-					...props,
-					target: ' .maxi-svg-icon-block__icon',
-					prefix: 'svg-',
-				}),
-		},
+		// 		return (
+		// 			<Controls.SvgStrokeWidthControl
+		// 				{...props}
+		// 				content={content}
+		// 				prefix='svg-'
+		// 			/>
+		// 		);
+		// 	},
+		// 	helper: props =>
+		// 		styleHelpers.getSVGStyles({
+		// 			...props,
+		// 			target: ' .maxi-svg-icon-block__icon',
+		// 			prefix: 'svg-',
+		// 		}),
+		// },
 		{
 			label: __('Icon background', 'maxi-blocks'),
 			attrGroupName: [


### PR DESCRIPTION
# Description

Commented the lines that allows adding Line Width on IB as MVP facing #3619 

Fixes #3623 

# How Has This Been Tested?

Check we can't add `Icon Line Width` on an Icon Maxi block from IB 👍 

# Test checklist

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
