### PR TITLE
Issue 3621 - Add shape divider custom css

### DIFF
--- a/src/blocks/container-maxi/custom-css.js
+++ b/src/blocks/container-maxi/custom-css.js
@@ -29,12 +29,34 @@ export const selectorsContainer = {
 			target: ':hover::after',
 		},
 	},
+	'top shape divider': {
+		normal: {
+			label: 'top shape divider',
+			target: ' .maxi-shape-divider__top',
+		},
+		hover: {
+			label: 'top shape divider on hover',
+			target: ' .maxi-shape-divider__top:hover',
+		},
+	},
+	'bottom shape divider': {
+		normal: {
+			label: 'bottom shape divider',
+			target: ' .maxi-shape-divider__bottom',
+		},
+		hover: {
+			label: 'bottom shape divider on hover',
+			target: ' .maxi-shape-divider__bottom:hover',
+		},
+	},
 };
 
 export const categoriesContainer = [
 	'container',
 	'before container',
 	'after container',
+	'top shape divider',
+	'bottom shape divider',
 	'background',
 	'background hover',
 ];

--- a/src/blocks/container-maxi/inspector.js
+++ b/src/blocks/container-maxi/inspector.js
@@ -18,6 +18,11 @@ import { selectorsContainer, categoriesContainer } from './custom-css';
 import { withMaxiInspector } from '../../extensions/inspector';
 
 /**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
+/**
  * Inspector
  */
 const Inspector = props => {
@@ -28,6 +33,18 @@ const Inspector = props => {
 		insertInlineStyles,
 		cleanInlineStyles,
 	} = props;
+
+	const getCategoriesCss = () => {
+		const {
+			'shape-divider-top-status': shapeDividerTopStatus,
+			'shape-divider-bottom-status': shapeDividerBottomStatus,
+		} = attributes;
+		return without(
+			categoriesContainer,
+			!shapeDividerTopStatus && 'top shape divider',
+			!shapeDividerBottomStatus && 'bottom shape divider'
+		);
+	};
 
 	return (
 		<InspectorControls>
@@ -116,7 +133,7 @@ const Inspector = props => {
 										props,
 										breakpoint: deviceType,
 										selectors: selectorsContainer,
-										categories: categoriesContainer,
+										categories: getCategoriesCss(),
 									}),
 									...inspectorTabs.scrollEffects({
 										props,
@@ -124,7 +141,7 @@ const Inspector = props => {
 									...inspectorTabs.transform({
 										props,
 										selectors: selectorsContainer,
-										categories: categoriesContainer,
+										categories: getCategoriesCss(),
 									}),
 									...inspectorTabs.transition({
 										props: {


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3621 

# How Has This Been Tested?
Checked if when shape divider is active, custom css target is also available and if it works in general

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test top shape divider custom css
-   [x] Test bottom shape divider custom css
-   [x] Test the component in hover state in sidebar (if hover exists)
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-5 points on responsive

**_ Pre-Code Testing _**

-   [ ] Test top shape divider custom css
-   [ ] Test bottom shape divider custom css
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-5 points on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
