### PR TITLE
Fixes #3641

### DIFF
--- a/js/maxi-relations.js
+++ b/js/maxi-relations.js
@@ -147,6 +147,7 @@ const relations = () => {
 		effectsObj,
 		isIcon = false,
 		remove = false,
+		hoverStatus = false,
 	}) => {
 		const isSVG = target.includes('svg-icon-maxi');
 		const targets = stylesObj?.isTargets ? Object.keys(stylesObj) : null;
@@ -162,11 +163,24 @@ const relations = () => {
 							effectsObj,
 							isIcon,
 							remove,
+							hoverStatus,
 						});
 				});
 			else {
+				const targetEl = document.querySelector(target);
+
+				// Checks if the element needs special CSS to be avoided in case the element is hovered
+				const avoidHover =
+					hoverStatus &&
+					targetEl &&
+					targetEl.isSameNode(
+						targetEl
+							.closest('.maxi-block')
+							.querySelector(transitionTarget)
+					);
+
 				const svgTarget = `${target} ${
-					transitionTarget?.endsWith('> *')
+					avoidHover && transitionTarget?.endsWith('> *')
 						? transitionTarget.slice(0, -4) +
 						  ':not(:hover)' +
 						  transitionTarget.slice(transitionTarget.length - 4)
@@ -179,6 +193,7 @@ const relations = () => {
 					effectsObj,
 					isIcon: isIcon || isSVG,
 					remove,
+					hoverStatus,
 				});
 			}
 		} else {
@@ -288,6 +303,7 @@ const relations = () => {
 							isIcon:
 								item.settings === 'Icon colour' ||
 								item.settings === 'Button icon',
+							hoverStatus,
 						});
 
 						toggleInlineStyles({
@@ -343,6 +359,7 @@ const relations = () => {
 											transitionTarget,
 											effectsObj,
 											remove: true,
+											hoverStatus,
 										});
 									}
 								);
@@ -362,6 +379,7 @@ const relations = () => {
 														'Icon colour' ||
 													item.settings ===
 														'Button icon',
+												hoverStatus,
 											});
 										}, transitionDuration);
 									}
@@ -386,6 +404,7 @@ const relations = () => {
 								isIcon:
 									item.settings === 'Icon colour' ||
 									item.settings === 'Button icon',
+								hoverStatus,
 							});
 
 						dataTimeout = setTimeout(() => {
@@ -411,6 +430,7 @@ const relations = () => {
 								transitionTarget,
 								effectsObj,
 								remove: true,
+								hoverStatus,
 							});
 						}, item.effects['transition-duration-general'] * 1000 + 1000);
 					});

--- a/src/blocks/column-maxi/style.scss
+++ b/src/blocks/column-maxi/style.scss
@@ -1,5 +1,6 @@
 body.maxi-blocks--active div.maxi-column-block {
 	display: inline-flex;
+	flex-direction: column;
 	position: relative;
 	height: auto;
 	margin: 0;

--- a/src/blocks/container-maxi/style.scss
+++ b/src/blocks/container-maxi/style.scss
@@ -1,7 +1,8 @@
 body.maxi-blocks--active .maxi-container-block {
+	display: flex;
+	flex-direction: column;
 	position: relative;
 	margin-top: 0;
 	margin-bottom: 0;
-	display: flex;
 	padding: 0;
 }

--- a/src/blocks/group-maxi/style.scss
+++ b/src/blocks/group-maxi/style.scss
@@ -1,5 +1,6 @@
 body.maxi-blocks--active .maxi-group-block {
 	display: flex;
+	flex-direction: column;
 	position: relative;
 	margin-top: 0;
 	margin-bottom: 0;

--- a/src/blocks/row-maxi/style.scss
+++ b/src/blocks/row-maxi/style.scss
@@ -1,6 +1,7 @@
 body.maxi-blocks--active .maxi-row-block {
 	position: relative;
 	display: flex;
+	flex-direction: row;
 	justify-content: space-between;
 
 	&:focus {

--- a/src/extensions/styles/migrators/SVGIBTargetsMigrator.js
+++ b/src/extensions/styles/migrators/SVGIBTargetsMigrator.js
@@ -1,0 +1,79 @@
+import { getSVGStyles } from '../helpers/getSVGStyles';
+import { merge } from 'lodash';
+
+// Copied from src/components/relation-control/index.js
+const getStyles = (stylesObj, isFirst = false) => {
+	// Using basic breakpoints as they can't be changed yet
+	const breakpoints = {
+		xs: 480,
+		s: 767,
+		m: 1024,
+		l: 1366,
+		xl: 1920,
+	};
+
+	if (Object.keys(stylesObj).some(key => key.includes('general'))) {
+		const styles = Object.keys(stylesObj).reduce((acc, key) => {
+			if (breakpoints[key] || key === 'xxl' || key === 'general') {
+				acc[key] = {
+					styles: stylesObj[key],
+					breakpoint: breakpoints[key] || null,
+				};
+
+				return acc;
+			}
+
+			return acc;
+		}, {});
+
+		return styles;
+	}
+
+	const styles = Object.keys(stylesObj).reduce((acc, key) => {
+		if (isFirst) {
+			if (!key.includes(':hover')) acc[key] = getStyles(stylesObj[key]);
+
+			return acc;
+		}
+
+		const newAcc = merge(acc, getStyles(stylesObj[key]));
+
+		return newAcc;
+	}, {});
+
+	return styles;
+};
+
+const isEligible = blockAttributes =>
+	!!blockAttributes?.relations &&
+	blockAttributes.relations.some(
+		relation =>
+			relation.uniqueID.includes('svg-icon-maxi') &&
+			relation.settings === 'Icon colour' &&
+			!Object.keys(relation.css).some(
+				target =>
+					target.includes('svg[data-fill]:not([fill^="none"]) *') ||
+					target.includes('svg[data-stroke]:not([stroke^="none"]) *')
+			)
+	);
+
+const migrate = ({ newAttributes }) => {
+	const { relations } = newAttributes;
+
+	relations.forEach((relation, i) => {
+		if (relation.uniqueID.includes('svg-icon-maxi')) {
+			const styles = getSVGStyles({
+				obj: relation.attributes,
+				target: ' .maxi-svg-icon-block__icon',
+				prefix: 'svg-',
+				blockStyle: newAttributes.blockStyle,
+			});
+
+			relations[i].css = getStyles(styles, true);
+		}
+	});
+
+	return { ...newAttributes, relations };
+};
+
+export default { isEligible, migrate };

--- a/src/extensions/styles/migrators/blockMigrator.js
+++ b/src/extensions/styles/migrators/blockMigrator.js
@@ -6,6 +6,7 @@ import transformMigrator from './transformMigrator';
 import positionToNumberMigrator from './positionToNumberMigrator';
 import positionUnitsToAxisMigrator from './positionUnitsToAxisMigrator';
 import transformIBMigrator from './transformIBMigrator';
+import SVGIBTargetsMigrator from './SVGIBTargetsMigrator';
 import { getMigratorsCombinations } from './utils';
 
 /**
@@ -103,6 +104,7 @@ const blockMigrator = blockMigratorProps => {
 		fullWidthNonToResponsiveMigrator,
 		transformMigrator,
 		transformIBMigrator,
+		SVGIBTargetsMigrator,
 		...(blockMigratorProps.migrators ?? []),
 	];
 

--- a/src/extensions/styles/migrators/transitionMigrator.js
+++ b/src/extensions/styles/migrators/transitionMigrator.js
@@ -5,7 +5,8 @@ const NEW_KEYS = [
 	'icon border',
 ];
 
-const isEligible = blockAttributes => !!blockAttributes?.transition?.block?.icon;
+const isEligible = blockAttributes =>
+	!!blockAttributes?.transition?.block?.icon;
 
 const migrate = ({ newAttributes }) => {
 	const { transition } = newAttributes;
@@ -16,7 +17,7 @@ const migrate = ({ newAttributes }) => {
 				...transition.block.icon,
 			};
 		});
-		
+
 		delete transition.block.icon;
 	}
 


### PR DESCRIPTION
# Description

Fixes the 3 issues found after updating devdemo and commented on #3641:
1. Broken grids: have been fixed recovering some lines of CSS that ensure a `flex-direction` CSS property for wrapper blocks.
2. Some IB effects aren't working with the new targets: a new migrator has created for it.
3. Some IB transitions doesn't work correctly on frontend: frontend js file has been fixed.

Fixes #3641 

# How Has This Been Tested?

To check 1:
Check this one is really hard, so we'll do it in a reverse way. The changes done affect to 3 `style.scss` files where the same line has been added: `flex-direction: column`. It should work as a backup of the inner block style created from the attributes, so is basically like it was before. So, to test it, check an icon or footer page of devdemo ([this one is an example](https://devdemo.maxiblocks.com/pure-footers-dark-pfd/)) and look for this CSS boxes to add the commented line `flex-direction: column` (row uses `flex-direction: row`!):
| Container  |  Column | Group  | Row |
|---|---|---|---|
| <img width="498" alt="Captura de Pantalla 2022-09-01 a las 16 51 18" src="https://user-images.githubusercontent.com/50477222/187944820-8d6ee31c-9fc9-454b-a825-0fb0c482bfbf.png">  |  <img width="498" alt="Captura de Pantalla 2022-09-01 a las 16 53 05" src="https://user-images.githubusercontent.com/50477222/187945700-c334f0f1-9bc3-4369-a750-4346b10442db.png"> | <img width="498" alt="Captura de Pantalla 2022-09-01 a las 16 53 21" src="https://user-images.githubusercontent.com/50477222/187945764-9142bdd9-f67e-4267-bb56-594bb6b51583.png">  | <img width="498" alt="Captura de Pantalla 2022-09-01 a las 16 52 50" src="https://user-images.githubusercontent.com/50477222/187945864-6b90198d-4248-4afe-994a-25c258264779.png">

After adding that lines the site should look good and is the same implementation done in this branch 👍 

To check 2:
Using master, copy some of the broken IB Icon Maxi colour interactions or use this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/9471007/broken.IB.txt) and check this is the result:


https://user-images.githubusercontent.com/50477222/187946960-1e4c8b0f-e3d5-4b61-8c44-5e62c61c4010.mp4


Then change to this branch and check it again:

https://user-images.githubusercontent.com/50477222/187948300-f5f7ce9a-ac38-4aa0-ab99-74a2ed7204f1.mp4

To check 3:
It can be tested as the last video (on hovering directly to the element, the transition still works correctly). Also, can be tested with many IB relations using this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/9471070/IB-tests.txt). 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the 3 checks exposed above

**_ Pre-Code Testing _**

-   [x] Test the 3 checks exposed above
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
