### PR TITLE
Issue 3636 - fix values not saving on unit switch

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -224,7 +224,11 @@ const AdvancedNumberControl = props => {
 
 								if (value > minMaxSettings[val]?.max) {
 									onChangeValue(
-										minMaxSettings[val]?.max,
+										optionType === 'string'
+											? minMaxSettings[
+													val
+											  ]?.max.toString()
+											: minMaxSettings[val]?.max,
 										val
 									);
 								}


### PR DESCRIPTION
# Description
Didn't work because even with `optionType === 'string'` it used numbers in `onChangevalue`.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3636 

# How Has This Been Tested?
Checked that values that were set to not exceed the max value are saved after reload.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that values that were set to not exceed the max value are saved after reload

**_ Pre-Code Testing _**

-   [x] Check that values that were set to not exceed the max value are saved after reload
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
