### PR TITLE
Resizer fix

### DIFF
--- a/src/blocks/column-maxi/edit.js
+++ b/src/blocks/column-maxi/edit.js
@@ -264,6 +264,7 @@ class edit extends MaxiBlockComponent {
 								? () => <BlockInserter clientId={clientId} />
 								: false,
 						}}
+						cleanStyles
 					/>,
 				]}
 			</RowContext.Consumer>

--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -121,18 +121,6 @@ class edit extends MaxiBlockComponent {
 			});
 		};
 
-		const position = getLastBreakpointAttribute({
-			target: 'position',
-			breakpoint: deviceType,
-			attributes,
-		});
-
-		// BlockResizer component comes with inherit styles where position is 'relative',
-		// so we need to give style prop to change it when positioning is set 👌
-		const style = {
-			...(position && { position }),
-		};
-
 		const inlineStylesTargets = {
 			dividerColor: '.maxi-divider-block__divider',
 		};
@@ -177,7 +165,7 @@ class edit extends MaxiBlockComponent {
 				}}
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}
-				style={style}
+				cleanStyles
 			>
 				{getLastBreakpointAttribute({
 					target: 'divider-border-style',

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -380,7 +380,6 @@ class edit extends MaxiBlockComponent {
 									),
 								})
 							}
-							cleanStyles={false}
 						>
 							{captionType !== 'none' &&
 								captionPosition === 'top' && (

--- a/src/blocks/number-counter-maxi/edit.js
+++ b/src/blocks/number-counter-maxi/edit.js
@@ -152,7 +152,6 @@ const NumberCounter = attributes => {
 			}}
 			{...resizerProps}
 			showHandle={!circleStatus ? resizerProps.showHandle : false}
-			cleanStyles={false}
 		>
 			{!circleStatus && (
 				<svg

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -241,7 +241,6 @@ class edit extends MaxiBlockComponent {
 								topLeft: true,
 							}}
 							onResizeStop={handleOnResizeStop}
-							cleanStyles={false}
 						>
 							<RawHTML>{content}</RawHTML>
 						</BlockResizer>

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { forwardRef, memo } from '@wordpress/element';
+import { forwardRef, memo, useRef } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -28,11 +28,12 @@ const BlockResizer = memo(
 			resizableObject,
 			isOverflowHidden = false,
 			onResizeStop,
-			cleanStyles = true,
+			cleanStyles = false,
 			...rest
 		} = props;
 		// Needed for memo part only
 		delete rest.deviceType;
+		const hasCleanedStyles = useRef(false);
 
 		const classes = classnames(
 			'maxi-block__resizer',
@@ -61,7 +62,10 @@ const BlockResizer = memo(
 		const handleRef = newRef => {
 			if (newRef) {
 				// Needed to clean styles before first onResizeStop, so that blocks don't jump after resizing
-				if (cleanStyles) newRef.resizable.style = null;
+				if (cleanStyles && !hasCleanedStyles.current) {
+					newRef.resizable.style = null;
+					hasCleanedStyles.current = true;
+				}
 				if (resizableObject) resizableObject.current = newRef;
 				if (ref) {
 					if (typeof ref === 'function') ref(newRef.resizable);

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -245,6 +245,7 @@ class MaxiBlockComponent extends Component {
 		) {
 			const obj = this.getStylesObject;
 			styleResolver(obj, true);
+			this.removeStyles();
 		}
 
 		dispatch('maxiBlocks/customData').removeCustomData(
@@ -504,10 +505,11 @@ class MaxiBlockComponent extends Component {
 			if (!wrapper) {
 				wrapper = document.createElement('div');
 				wrapper.id = `maxi-blocks__styles--${uniqueID}`;
+				this.stylesWrapperId = `maxi-blocks__styles--${uniqueID}`;
 				wrapper.classList.add('maxi-blocks__styles');
 				document.head.appendChild(wrapper);
 			}
-
+			console.log(this.stylesWrapperId);
 			render(
 				<StyleComponent
 					uniqueID={uniqueID}
@@ -551,6 +553,11 @@ class MaxiBlockComponent extends Component {
 				}
 			}
 		}
+	}
+
+	removeStyles() {
+		console.log(this.stylesWrapperId);
+		document.getElementById(this.stylesWrapperId).remove();
 	}
 }
 

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -40,6 +40,7 @@ import * as blocksData from '../../blocks/data';
  * External dependencies
  */
 import { isEmpty, isEqual, cloneDeep, isNil } from 'lodash';
+import { getStylesWrapperId } from './utils';
 
 /**
  * Style Component
@@ -99,7 +100,6 @@ class MaxiBlockComponent extends Component {
 		// eslint-disable-next-line react/no-unused-class-component-methods
 		this.blockRef = createRef();
 		this.typography = getGroupAttributes(attributes, 'typography');
-		this.stylesWrapperId = `maxi-blocks__styles--${uniqueID}`;
 
 		// Init
 		const newUniqueID = this.uniqueIDChecker(uniqueID);
@@ -499,11 +499,13 @@ class MaxiBlockComponent extends Component {
 		dispatch('maxiBlocks/customData').updateCustomData(customData);
 
 		if (document.body.classList.contains('maxi-blocks--active')) {
-			let wrapper = document.querySelector(`#${this.stylesWrapperId}`);
+			let wrapper = document.querySelector(
+				`#${getStylesWrapperId(uniqueID)}`
+			);
 
 			if (!wrapper) {
 				wrapper = document.createElement('div');
-				wrapper.id = this.stylesWrapperId;
+				wrapper.id = getStylesWrapperId(uniqueID);
 				wrapper.classList.add('maxi-blocks__styles');
 				document.head.appendChild(wrapper);
 			}
@@ -528,12 +530,12 @@ class MaxiBlockComponent extends Component {
 
 				if (iframeDocument.head) {
 					let iframeWrapper = iframeDocument.querySelector(
-						`#maxi-blocks__styles--${uniqueID}`
+						`#${getStylesWrapperId(uniqueID)}`
 					);
 
 					if (!iframeWrapper) {
 						iframeWrapper = iframeDocument.createElement('div');
-						iframeWrapper.id = `maxi-blocks__styles--${uniqueID}`;
+						iframeWrapper.id = getStylesWrapperId(uniqueID);
 						iframeWrapper.classList.add('maxi-blocks__styles');
 						iframeDocument.head.appendChild(iframeWrapper);
 					}
@@ -554,7 +556,9 @@ class MaxiBlockComponent extends Component {
 	}
 
 	removeStyles() {
-		document.getElementById(this.stylesWrapperId).remove();
+		document
+			.getElementById(getStylesWrapperId(this.props.attributes.uniqueID))
+			.remove();
 	}
 }
 

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -99,6 +99,7 @@ class MaxiBlockComponent extends Component {
 		// eslint-disable-next-line react/no-unused-class-component-methods
 		this.blockRef = createRef();
 		this.typography = getGroupAttributes(attributes, 'typography');
+		this.stylesWrapperId = `maxi-blocks__styles--${uniqueID}`;
 
 		// Init
 		const newUniqueID = this.uniqueIDChecker(uniqueID);
@@ -498,18 +499,15 @@ class MaxiBlockComponent extends Component {
 		dispatch('maxiBlocks/customData').updateCustomData(customData);
 
 		if (document.body.classList.contains('maxi-blocks--active')) {
-			let wrapper = document.querySelector(
-				`#maxi-blocks__styles--${uniqueID}`
-			);
+			let wrapper = document.querySelector(`#${this.stylesWrapperId}`);
 
 			if (!wrapper) {
 				wrapper = document.createElement('div');
-				wrapper.id = `maxi-blocks__styles--${uniqueID}`;
-				this.stylesWrapperId = `maxi-blocks__styles--${uniqueID}`;
+				wrapper.id = this.stylesWrapperId;
 				wrapper.classList.add('maxi-blocks__styles');
 				document.head.appendChild(wrapper);
 			}
-			console.log(this.stylesWrapperId);
+
 			render(
 				<StyleComponent
 					uniqueID={uniqueID}
@@ -556,7 +554,6 @@ class MaxiBlockComponent extends Component {
 	}
 
 	removeStyles() {
-		console.log(this.stylesWrapperId);
 		document.getElementById(this.stylesWrapperId).remove();
 	}
 }

--- a/src/extensions/maxi-block/utils.js
+++ b/src/extensions/maxi-block/utils.js
@@ -23,3 +23,7 @@ export const getResizerSize = (elt, blockRef, unit, axis = 'width') => {
 			return pxSize.toString();
 	}
 };
+
+export const getStylesWrapperId = uniqueID => {
+	return `maxi-blocks__styles--${uniqueID}`;
+};

--- a/src/extensions/maxi-block/utils.js
+++ b/src/extensions/maxi-block/utils.js
@@ -24,6 +24,5 @@ export const getResizerSize = (elt, blockRef, unit, axis = 'width') => {
 	}
 };
 
-export const getStylesWrapperId = uniqueID => {
-	return `maxi-blocks__styles--${uniqueID}`;
-};
+export const getStylesWrapperId = uniqueID =>
+	`maxi-blocks__styles--${uniqueID}`;


### PR DESCRIPTION
# Description
After #3658 the styles in resizers are cleaned. But they don't need to be cleaned in resizer in TransformControl.
Changes:

- Changed `cleanStyles` to `false` by default, and set it to true on certain blocks, so now styles should be good everywhere.
- Previously styles were cleaned every time ref is set, now they are only cleaned first time, and after resizing stops.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3685 

# How Has This Been Tested?
Checked that resizer works and looks good on all blocks, and TransformControl.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that resizer works and looks good on all blocks
-   [x] Check that resizer works and looks good on TransformControl

**_ Pre-Code Testing _**

-   [x] Check that resizer works and looks good on all blocks
-   [x] Check that resizer works and looks good on TransformControl
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
