### PR TITLE
Issue 3689 - Aria label selector removed

### DIFF
--- a/src/blocks/container-maxi/editor.scss
+++ b/src/blocks/container-maxi/editor.scss
@@ -1,11 +1,6 @@
 .maxi-container-block {
 	margin: auto;
 
-	.block-list-appender
-		.block-editor-button-block-appender[aria-label='Add Row Maxi'] {
-		left: 50%;
-		border-radius: 50%;
-	}
 	.block-list-appender--show {
 		.block-editor-button-block-appender {
 			visibility: visible;

--- a/src/components/icon-control/editor.scss
+++ b/src/components/icon-control/editor.scss
@@ -5,19 +5,19 @@
 				fill: var(--maxi-secondary-color);
 				stroke: transparent;
 			}
-			&[aria-label='color'] {
-				path {
-					&:first-child {
-						fill: #f1f1f1;
-					}
-				}
+		}
+	}
+	.maxi-tabs-control__button-color.maxi-tabs-control__button--selected {
+		path {
+			&:first-child {
+				fill: #f1f1f1;
 			}
-			&[aria-label='border'] {
-				path {
-					fill: transparent;
-					stroke: var(--maxi-secondary-color);
-				}
-			}
+		}
+	}
+	.maxi-tabs-control__button-border.maxi-tabs-control__button--selected {
+		path {
+			fill: transparent;
+			stroke: var(--maxi-secondary-color);
 		}
 	}
 }

--- a/src/components/icon-control/editor.scss
+++ b/src/components/icon-control/editor.scss
@@ -10,7 +10,7 @@
 	.maxi-tabs-control__button-color.maxi-tabs-control__button--selected {
 		path {
 			&:first-child {
-				fill: #f1f1f1;
+				fill: var(--maxi-white-1-color);
 			}
 		}
 	}

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -115,8 +115,3 @@ body.maxi-blocks--active.page-template-full-width-template .ast-container {
 		width: 100%;
 	}
 }
-
-/*Seedlet theme overrides*/
-body.maxi-blocks--active span:focus {
-	outline: none;
-}

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -115,3 +115,8 @@ body.maxi-blocks--active.page-template-full-width-template .ast-container {
 		width: 100%;
 	}
 }
+
+/*Seedlet theme overrides*/
+body.maxi-blocks--active span:focus {
+	outline: none;
+}


### PR DESCRIPTION
We had CSS selectors using aria-label text, which was in English. However, this CSS would not work for other languages as labels would change.

We had this in two occasions - for the row block inserter and icon sidebar settings.

Fixes #3689

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that block inserter looks good (try adding new container, row, columns, blocks). Check responsive too.
-   [ ] Add a button and check that the icon settings tab look good when selected (fill colour, border colour).

**_ Pre-Code Testing _**

-   [x] Test that block inserter looks good (try adding new container, row, columns, blocks). Check responsive too.
-   [x] Add a button and check that the icon settings tab look good when selected (fill colour, border colour).
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
