### PR TITLE
Fix 3698 - Duplicate content on changing column number

### DIFF
--- a/src/extensions/column-templates/loadColumnsTemplate.js
+++ b/src/extensions/column-templates/loadColumnsTemplate.js
@@ -34,7 +34,7 @@ const updateTemplate = (template, columnsBlockObjects, clientId) => {
 	const newAttributes = template.attributes;
 	const leftoverContent = compact(
 		columnsBlockObjects.map((column, i) => {
-			if (i < templateLength) return null;
+			if (i < templateLength || i > 0) return null;
 
 			return column.innerBlocks;
 		})


### PR DESCRIPTION
I have been added only first block content when new column number is small than origin column number.

Fixes #3698 

# How Has This Been Tested?

# Test checklist

**_ Front/Back Testing _**

-   [ ] Check this solution is good for this issue.
- 
**_ Pre-Code Testing _**

-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Test with 2 blocks of the same type
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
