### PR TITLE
Fix 3634 - Fit column after use column gap

### DIFF
--- a/src/components/column-size-control/index.js
+++ b/src/components/column-size-control/index.js
@@ -17,10 +17,33 @@ import SelectControl from '../select-control';
 import { ToggleSwitch } from '../../components';
 
 /**
+ * General
+ */
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+/**
  * Component
  */
 const ColumnSizeControl = props => {
 	const { breakpoint, rowPattern, clientId, onChange } = props;
+
+	breakpoints.forEach(breakpoint => {
+		const breakpointAttribute = getLastBreakpointAttribute({
+			target: 'column-fit-content',
+			breakpoint,
+			attributes: props,
+		});
+
+		onChange({
+			[`column-fit-content-${breakpoint}`]: !breakpointAttribute
+				? false
+				: getLastBreakpointAttribute({
+						target: 'column-fit-content',
+						breakpoint,
+						attributes: props,
+				  }),
+		});
+	});
 
 	return (
 		<>


### PR DESCRIPTION
I have set initial value column-fit-content value each breakpoints(xxl, xl, etc...).

https://watch.screencastify.com/v/CBPGLrnsXmYArBSnTGrg
please check this video.
If user didn't set the column-fit-content for each breakpoints, the column gap will not work.


Fixes #3634 

# How Has This Been Tested?

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check this is good solution for this issue
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
