### PR TITLE
Issue 3766 - HandleResizer blocks selecting block

### DIFF
--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -102,9 +102,13 @@ body.maxi-blocks--active .maxi-block__resizer {
 			position: absolute;
 			height: 100%;
 			width: 100%;
-			z-index: 30;
+			z-index: -1;
 			top: 0;
 			left: 0;
+
+			&:has(.maxi-resizable__corner-handle) {
+				z-index: 30;
+			}
 		}
 	}
 	.maxi-resizable__handle--overflow,


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3766 

# How Has This Been Tested?
Tested if, after changes #3522 didn't break, column content is clickable. Tested it with this simple [code editor](https://github.com/maxi-blocks/maxi-blocks/files/9718150/resizer-test.txt)


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if content in column is clickable (check video from linked issue to understand better)
-   [ ] Test if #3522 fix still works

**_ Pre-Code Testing _**

-   [ ] Test if content in column is clickable (check video from linked issue to understand better)
-   [ ] Test if #3522 fix still works
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

