### PR TITLE
Issue 3783 - Stroke width toolbar fix

### DIFF
--- a/src/components/toolbar/components/icon-size/index.js
+++ b/src/components/toolbar/components/icon-size/index.js
@@ -43,6 +43,7 @@ const IconSize = props => {
 				<SvgStrokeWidthControl
 					prefix='icon-'
 					{...props}
+					content={props['icon-content']}
 					onChange={onChange}
 					breakpoint={breakpoint}
 				/>

--- a/src/components/toolbar/components/svg-width/index.js
+++ b/src/components/toolbar/components/svg-width/index.js
@@ -7,7 +7,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ToolbarPopover from '../toolbar-popover';
-import { setSVGStrokeWidth } from '../../../../extensions/svg';
 
 /**
  * Styles & Icons
@@ -43,15 +42,8 @@ const SvgWidth = props => {
 				{type !== 'Shape' && (
 					<SvgStrokeWidthControl
 						{...props}
-						onChange={obj => {
-							onChange({
-								...obj,
-								content: setSVGStrokeWidth(
-									props.content,
-									obj[`svg-stroke-${breakpoint}`]
-								),
-							});
-						}}
+						content={props.content}
+						onChange={onChange}
 						breakpoint={breakpoint}
 						prefix='svg-'
 					/>

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -401,6 +401,7 @@ const MaxiToolbar = memo(
 								)}
 								<SvgWidth
 									{...getGroupAttributes(attributes, 'svg')}
+									content={attributes.content}
 									blockName={name}
 									onChange={obj => {
 										maxiSetAttributes(obj);


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3783 

# How Has This Been Tested?
Checked if svg stroke is working in svg-icon-maxi toolbar and button-maxi icon toolbar.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Svg stroke is working in svg-icon-maxi toolbar
-   [x] Svg stroke is working in button-maxi icon toolbar

**_ Pre-Code Testing _**

-   [ ] Svg stroke is working in svg-icon-maxi toolbar
-   [ ] Svg stroke is working in button-maxi icon toolbar
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
