### PR TITLE
Issue 3774 - Cloud library image placeholder with shapes fix

### DIFF
--- a/src/editor/library/util.js
+++ b/src/editor/library/util.js
@@ -255,18 +255,18 @@ export const onRequestInsertPattern = (
 		const imagesLinks = [];
 		const imagesIds = [];
 
-		const allImagesRegexp = /mediaID":(.*)",/g;
+		const allImagesRegexp = /(mediaID|imageID)":(.*)",/g;
 
 		const allImagesLinks = parsedContent.match(allImagesRegexp);
 
 		allImagesLinks?.forEach(image => {
 			const parsed = image.replace(/\\/g, '');
 
-			const idRegexp = /(?<=mediaID":)(.*?)(?=,)/g;
+			const idRegexp = /(?<=(mediaID|imageID)":)(\d+)(?=)/g;
 			const id = parsed.match(idRegexp);
 			imagesIds.push(...id);
 
-			const urlRegexp = /(?<=mediaURL":")(.*?)(?=",)/g;
+			const urlRegexp = /(?<=(mediaURL|imageURL)":")([^"]+)(?=")/g;
 			const url = parsed.match(urlRegexp);
 			imagesLinks.push(...url);
 		});

--- a/src/editor/library/util.js
+++ b/src/editor/library/util.js
@@ -12,7 +12,7 @@ import { getBlockStyle, getPaletteAttributes } from '../../extensions/styles';
 /**
  * External dependencies
  */
-import { isNil, uniq, isEmpty } from 'lodash';
+import { isEmpty, isNil, uniq } from 'lodash';
 
 export const rgbToHex = color => {
 	if (isNil(color)) return '';

--- a/src/extensions/styles/migrators/SVGTransitionMigrator.js
+++ b/src/extensions/styles/migrators/SVGTransitionMigrator.js
@@ -7,6 +7,8 @@ const name = 'SVG Transition Migrator';
 
 const isEligible = blockAttributes => {
 	const { uniqueID, transition } = blockAttributes;
+	if (!transition) return false;
+
 	const blockName = getBlockNameFromUniqueID(uniqueID);
 	const blockDataTransition = getTransitionData(blockName);
 


### PR DESCRIPTION
# Description

Update:
- fixed placeholder work with shapes by adding in regexp `imageID`, `imageURL` check
- changed `idRegexp`, now it's searching only for digits ID string
- changed `urlRegexp` `.*?` → `[^"]+` to avoid bugs when `"imageURL": ""` (empty)
- removed check for comma in the end of `idRegexp` and `urlRegexp` (in some cases may be the last value and won't have a comma)
- fixed `SVGTransitionMigrator` error when `!transition` attribute

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3774 

# How Has This Been Tested?
Inserted on the page `Hero Light HOL-40`, which have a shape with image, checked whether the image is a gray placeholder, checked whether the placeholder works with other patterns after changes.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the placeholder with patterns which contain shapes with images (for example: `Hero Light HOL-40`)
-   [x] Test the placeholder with other patterns

**_ Pre-Code Testing _**

-   [ ] Test the placeholder with patterns which contain shapes with images (for example: `Hero Light HOL-40`)
-   [ ] Test the placeholder with other patterns
-   [ ] Test if no error from `SVGTransitionMigrator` on pattern add (for example: `Hero Light HOL-40`)
-   [ ] Check changes in `regex`
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
