### PR TITLE
Issue 3358 - Avoid Gutenberg `deviceType` change from ResponsiveBar

### DIFF
--- a/src/extensions/store/actions.js
+++ b/src/extensions/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, select } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 
 const actions = {
 	receiveMaxiSettings() {
@@ -47,15 +47,7 @@ const actions = {
 			const { __experimentalSetPreviewDeviceType: setPreviewDeviceType } =
 				dispatch('core/edit-post');
 
-			const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
-
-			const gutenbergDeviceType =
-				(deviceType === 'general' && 'Desktop') ||
-				(width >= breakpoints.m && 'Desktop') ||
-				(width >= breakpoints.s && 'Tablet') ||
-				(width < breakpoints.s && 'Mobile');
-
-			if (gutenbergDeviceType) setPreviewDeviceType(gutenbergDeviceType);
+			setPreviewDeviceType('Desktop');
 		}
 
 		return {

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -1,7 +1,17 @@
-import { dispatch } from '@wordpress/data';
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
 
-import { omit } from 'lodash';
+/**
+ * Internal dependencies
+ */
 import getWinBreakpoint from '../dom/getWinBreakpoint';
+
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
 
 const breakpointResizer = ({
 	size,
@@ -37,9 +47,17 @@ const breakpointResizer = ({
 				winHeight > responsiveWidth ? '0 auto' : '';
 
 			if (isGutenbergButton) editorWrapper.style = null;
-			else if (['s', 'xs'].includes(size))
-				editorWrapper.style.width = 'fit-content';
-			else if (editorWrapper.style.width !== `${responsiveWidth}px`)
+			else if (['s', 'xs'].includes(size)) {
+				const {
+					__experimentalGetPreviewDeviceType: getPreviewDeviceType,
+				} = select('core/edit-post');
+
+				const gutenbergDeviceType = getPreviewDeviceType();
+
+				if (gutenbergDeviceType !== 'Desktop')
+					editorWrapper.style.width = 'fit-content';
+				else editorWrapper.style.width = `${responsiveWidth}px`;
+			} else if (editorWrapper.style.width !== `${responsiveWidth}px`)
 				editorWrapper.style.width = `${responsiveWidth}px`;
 		}
 	}


### PR DESCRIPTION
# Description

As part of the optimization requested on #3358, a possible solution as MVP has been to avoid the change of the Gutenberg `deviceType` when clicking on some of the Maxi responsive stages. The main problem is that when changing the `deviceType` of Gutnberg to `Tablet` or `Mobile`, Gutenberg transforms the canvas editor into an `iframe` that reloads all the blocks from the beginning. Maxi blocks are heavy and need time to be load, so that results in a long waiting while the blocks are rendered from scratch again. The solution presented on this implementation changes the way we interact with Gutenberg `deviceType`, and where since now clicking on `S` swapped the `deviceType` to `Tablet`, and the same for `XS` to `mobile`, now we aren't changing it. The result is that our block aren't rendered again, so there's no trace of waiting. If a creator changes the `deviceType` from the `Preview` dropdown, it will swap to `iframe` and will take that long to be loaded 👍 

This is an MVP that will work perfectly but has some conflicts we should fix in future for a better integration with Gutenberg and other plugins/blocks 👍 

Fixes #3358 

# How Has This Been Tested?

Change the responsive breakpoint from the Maxi topbar menu or from the settings; it should change fast. When clicking on `Tablet` or `Mobile` on the `Preview` dropdown, it should take longer, and then if clicking to any Maxi responsive button it should get the correct size 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test what has been commented above

**_ Pre-Code Testing _**

-   [x] Test what has been commented above
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
