### PR TITLE
Issue 3358 - Suspense and block registry update

### DIFF
--- a/src/blocks/accordion-maxi/accordion-maxi.js
+++ b/src/blocks/accordion-maxi/accordion-maxi.js
@@ -7,12 +7,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 
 /**
@@ -44,6 +46,10 @@ registerBlockType('maxi-blocks/accordion-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 });

--- a/src/blocks/accordion-maxi/accordion-maxi.js
+++ b/src/blocks/accordion-maxi/accordion-maxi.js
@@ -26,26 +26,14 @@ import { accordionIcon } from '../../icons';
 /**
  * Block
  */
-
 registerBlockType('maxi-blocks/accordion-maxi', {
 	title: __('Accordion Maxi', 'maxi-blocks'),
 	icon: accordionIcon,
 	description: 'Expand or collapse content inside of a panel',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
-
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	apiVersion: 2,
+	variations: [],
+	attributes,
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/button-maxi/button-maxi.js
+++ b/src/blocks/button-maxi/button-maxi.js
@@ -44,20 +44,9 @@ registerBlockType('maxi-blocks/button-maxi', {
 	icon: buttonIcon,
 	description: 'Insert, modify or style a button',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
-
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	apiVersion: 2,
+	variations: [],
+	attributes,
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/button-maxi/button-maxi.js
+++ b/src/blocks/button-maxi/button-maxi.js
@@ -10,12 +10,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -56,7 +58,11 @@ registerBlockType('maxi-blocks/button-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/cloud-maxi/cloud-maxi.js
+++ b/src/blocks/cloud-maxi/cloud-maxi.js
@@ -25,6 +25,8 @@ registerBlockType('maxi-blocks/maxi-cloud', {
 	description: __('Find templates or patterns'),
 	icon: library,
 	category: 'maxi-blocks',
+	apiVersion: 2,
+	variations: [],
 	keywords: [__('layout', 'maxi-blocks'), __('block', 'maxi-blocks')],
 	attributes: {
 		className: {

--- a/src/blocks/column-maxi/column-maxi.js
+++ b/src/blocks/column-maxi/column-maxi.js
@@ -9,6 +9,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Styles and icons
@@ -20,8 +22,8 @@ import { columnIcon } from '../../icons';
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -54,7 +56,11 @@ registerBlockType('maxi-blocks/column-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/column-maxi/column-maxi.js
+++ b/src/blocks/column-maxi/column-maxi.js
@@ -41,21 +41,12 @@ registerBlockType('maxi-blocks/column-maxi', {
 	icon: columnIcon,
 	description: 'Stack blocks vertically inside a column',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	parent: ['maxi-blocks/row-maxi'],
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+	parent: ['maxi-blocks/row-maxi'],
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/container-maxi/container-maxi.js
+++ b/src/blocks/container-maxi/container-maxi.js
@@ -9,12 +9,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -34,7 +36,6 @@ import shapeDividerMigrator from '../../extensions/styles/migrators/shapeDivider
 /**
  * Block
  */
-
 registerBlockType('maxi-blocks/container-maxi', {
 	title: __('Container Maxi', 'maxi-blocks'),
 	icon: containerIcon,
@@ -44,9 +45,7 @@ registerBlockType('maxi-blocks/container-maxi', {
 		align: true,
 		lightBlockWrapper: true,
 	},
-	attributes: {
-		...attributes,
-	},
+	attributes,
 	getEditWrapperProps(attributes) {
 		const { uniqueID } = attributes;
 
@@ -54,7 +53,11 @@ registerBlockType('maxi-blocks/container-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/container-maxi/container-maxi.js
+++ b/src/blocks/container-maxi/container-maxi.js
@@ -41,18 +41,9 @@ registerBlockType('maxi-blocks/container-maxi', {
 	icon: containerIcon,
 	description: 'Wrap blocks within a container',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
+	apiVersion: 2,
+	variations: [],
 	attributes,
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
-
-		return {
-			uniqueid: uniqueID,
-		};
-	},
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/divider-maxi/divider-maxi.js
+++ b/src/blocks/divider-maxi/divider-maxi.js
@@ -10,12 +10,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -52,7 +54,11 @@ registerBlockType('maxi-blocks/divider-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/divider-maxi/divider-maxi.js
+++ b/src/blocks/divider-maxi/divider-maxi.js
@@ -40,20 +40,11 @@ registerBlockType('maxi-blocks/divider-maxi', {
 	icon: dividerIcon,
 	description: 'Create a divider between visual elements',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/group-maxi/group-maxi.js
+++ b/src/blocks/group-maxi/group-maxi.js
@@ -42,20 +42,11 @@ registerBlockType('maxi-blocks/group-maxi', {
 	icon: groupIcon,
 	description: 'Combine a set of blocks in a group',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/group-maxi/group-maxi.js
+++ b/src/blocks/group-maxi/group-maxi.js
@@ -9,12 +9,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
 import attributes from './attributes';
-import edit from './edit';
+
+const Edit = lazy(() => import('./edit'));
 import save from './save';
 import { customCss } from './data';
 
@@ -53,7 +56,11 @@ registerBlockType('maxi-blocks/group-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/image-maxi/image-maxi.js
+++ b/src/blocks/image-maxi/image-maxi.js
@@ -10,12 +10,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -53,7 +55,11 @@ registerBlockType('maxi-blocks/image-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/image-maxi/image-maxi.js
+++ b/src/blocks/image-maxi/image-maxi.js
@@ -41,20 +41,11 @@ registerBlockType('maxi-blocks/image-maxi', {
 	icon: imageBox,
 	description: 'Insert, modify or style an image',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/map-maxi/map-maxi.js
+++ b/src/blocks/map-maxi/map-maxi.js
@@ -9,12 +9,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -53,7 +55,11 @@ registerBlockType('maxi-blocks/map-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/map-maxi/map-maxi.js
+++ b/src/blocks/map-maxi/map-maxi.js
@@ -41,20 +41,11 @@ registerBlockType('maxi-blocks/map-maxi', {
 	icon: mapIcon,
 	description: __('Create a map with marker and description', 'maxi-blocks'),
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/number-counter-maxi/number-counter-maxi.js
+++ b/src/blocks/number-counter-maxi/number-counter-maxi.js
@@ -40,20 +40,11 @@ registerBlockType('maxi-blocks/number-counter-maxi', {
 	icon: numberCounterIcon,
 	description: __('Create a number counter', 'maxi-blocks'),
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/number-counter-maxi/number-counter-maxi.js
+++ b/src/blocks/number-counter-maxi/number-counter-maxi.js
@@ -9,12 +9,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -52,7 +54,11 @@ registerBlockType('maxi-blocks/number-counter-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/pane-maxi/pane-maxi.js
+++ b/src/blocks/pane-maxi/pane-maxi.js
@@ -7,12 +7,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -51,7 +53,11 @@ registerBlockType('maxi-blocks/pane-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/pane-maxi/pane-maxi.js
+++ b/src/blocks/pane-maxi/pane-maxi.js
@@ -38,21 +38,12 @@ registerBlockType('maxi-blocks/pane-maxi', {
 	description: __('Hide some content inside of it', 'maxi-blocks'),
 	icon: groupIcon,
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	parent: ['maxi-blocks/accordion-maxi'],
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+	parent: ['maxi-blocks/accordion-maxi'],
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/row-maxi/row-maxi.js
+++ b/src/blocks/row-maxi/row-maxi.js
@@ -41,21 +41,12 @@ registerBlockType('maxi-blocks/row-maxi', {
 	icon: rowIcon,
 	description: 'Configure columns inside a row',
 	category: 'maxi-blocks',
+	apiVersion: 2,
+	variations: [],
 	parent: ['maxi-blocks/container-maxi'],
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/row-maxi/row-maxi.js
+++ b/src/blocks/row-maxi/row-maxi.js
@@ -9,6 +9,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Styles and icons
@@ -20,8 +22,8 @@ import { rowIcon } from '../../icons';
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -54,7 +56,11 @@ registerBlockType('maxi-blocks/row-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/search-maxi/search-maxi.js
+++ b/src/blocks/search-maxi/search-maxi.js
@@ -9,12 +9,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -52,7 +54,11 @@ registerBlockType('maxi-blocks/search-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/search-maxi/search-maxi.js
+++ b/src/blocks/search-maxi/search-maxi.js
@@ -40,20 +40,11 @@ registerBlockType('maxi-blocks/search-maxi', {
 	icon: searchIcon,
 	description: 'Add a search bar with icon',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/svg-icon-maxi/svg-icon-maxi.js
+++ b/src/blocks/svg-icon-maxi/svg-icon-maxi.js
@@ -44,20 +44,11 @@ registerBlockType('maxi-blocks/svg-icon-maxi', {
 	icon: iconBox,
 	description: 'Add icon or shape and style it',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/svg-icon-maxi/svg-icon-maxi.js
+++ b/src/blocks/svg-icon-maxi/svg-icon-maxi.js
@@ -10,12 +10,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -56,7 +58,11 @@ registerBlockType('maxi-blocks/svg-icon-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/text-maxi/text-maxi.js
+++ b/src/blocks/text-maxi/text-maxi.js
@@ -42,20 +42,14 @@ registerBlockType('maxi-blocks/text-maxi', {
 	icon: textIcon,
 	description: 'Insert, modify or style text',
 	category: 'maxi-blocks',
+	apiVersion: 2,
+	variations: [],
 	supports: {
 		align: false,
 		lightBlockWrapper: true,
 	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	attributes,
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />

--- a/src/blocks/text-maxi/text-maxi.js
+++ b/src/blocks/text-maxi/text-maxi.js
@@ -10,12 +10,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import transforms from './transforms';
 import { customCss } from './data';
@@ -54,7 +56,11 @@ registerBlockType('maxi-blocks/text-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	transforms,
 	deprecated: blockMigrator({

--- a/src/blocks/video-maxi/video-maxi.js
+++ b/src/blocks/video-maxi/video-maxi.js
@@ -3,12 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Block dependencies
  */
+const Edit = lazy(() => import('./edit'));
 import attributes from './attributes';
-import edit from './edit';
 import save from './save';
 import { customCss } from './data';
 
@@ -46,7 +48,11 @@ registerBlockType('maxi-blocks/video-maxi', {
 			uniqueid: uniqueID,
 		};
 	},
-	edit,
+	edit: props => (
+		<Suspense fallback={<Spinner />}>
+			<Edit {...props} />
+		</Suspense>
+	),
 	save,
 	deprecated: blockMigrator({
 		attributes,

--- a/src/blocks/video-maxi/video-maxi.js
+++ b/src/blocks/video-maxi/video-maxi.js
@@ -34,20 +34,11 @@ registerBlockType('maxi-blocks/video-maxi', {
 	icon: videoIcon,
 	description: 'Insert a video with controls or lightbox',
 	category: 'maxi-blocks',
-	supports: {
-		align: true,
-		lightBlockWrapper: true,
-	},
-	attributes: {
-		...attributes,
-	},
-	getEditWrapperProps(attributes) {
-		const { uniqueID } = attributes;
+	apiVersion: 2,
+	variations: [],
 
-		return {
-			uniqueid: uniqueID,
-		};
-	},
+	attributes,
+
 	edit: props => (
 		<Suspense fallback={<Spinner />}>
 			<Edit {...props} />


### PR DESCRIPTION
# Description

As part of the optimization process, I've tried to use the new [React `Suspense`](https://beta.reactjs.org/apis/react/Suspense) to check if it would help speeding up while setting a Gutenberg `deviceType` equal to `Tablet` or `Mobile`, as Gutenberg reloads everything on an `iframe`. It didn't make the difference, but I like having the spinner loading while the block and its styles are loading. Here on this video we can see the same page loaded first without `Suspense`, and then with it:


https://user-images.githubusercontent.com/50477222/198586129-2b759b7c-0712-42df-8c96-f6449c81586a.mp4

Also, took advantage of this situation to update the Maxi blocks registration with a lighter object and new `apiVersion` 👍 


# How Has This Been Tested?

Load should have same speed, but with spinners on the loading blocks. Once ended the spinner, block should appear perfect with its correct styles. The rest should work as before 😋 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the spinner effect

**_ Pre-Code Testing _**

-   [ ] Test the spinner effect
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
