### PR TITLE
Issue 3634 - Fix `fit-content` styles disappearing on responsive

### DIFF
--- a/src/extensions/styles/helpers/getColumnSizeStyles.js
+++ b/src/extensions/styles/helpers/getColumnSizeStyles.js
@@ -50,7 +50,11 @@ const getColumnSizeStyles = (obj, rowGapProps, clientId) => {
 	const response = {};
 
 	breakpoints.forEach(breakpoint => {
-		const fitContent = obj[`column-fit-content-${breakpoint}`];
+		const fitContent = getLastBreakpointAttribute({
+			target: 'column-fit-content',
+			breakpoint,
+			attributes: obj,
+		});
 		let columnSize = obj[`column-size-${breakpoint}`];
 
 		if (fitContent) {

--- a/src/extensions/styles/helpers/test/__snapshots__/getColumnSizeStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getColumnSizeStyles.js.snap
@@ -44,12 +44,12 @@ Object {
     "width": "fit-content",
   },
   "m": Object {
-    "flex-basis": "100%",
-    "width": "100%",
+    "flex-basis": "fit-content",
+    "width": "fit-content",
   },
   "s": Object {
-    "flex-basis": "calc(2% - 0px)",
-    "width": "calc(2% - 0px)",
+    "flex-basis": "fit-content",
+    "width": "fit-content",
   },
   "xl": Object {
     "flex-basis": "calc(3% - 1.6667%)",
@@ -76,9 +76,13 @@ Object {
     "flex-basis": "fit-content",
     "width": "fit-content",
   },
+  "m": Object {
+    "flex-basis": "fit-content",
+    "width": "fit-content",
+  },
   "s": Object {
-    "flex-basis": "calc(2% - 0px)",
-    "width": "calc(2% - 0px)",
+    "flex-basis": "fit-content",
+    "width": "fit-content",
   },
   "xl": Object {
     "flex-basis": "calc(3% - 0px)",
@@ -105,9 +109,13 @@ Object {
     "flex-basis": "fit-content",
     "width": "fit-content",
   },
+  "m": Object {
+    "flex-basis": "fit-content",
+    "width": "fit-content",
+  },
   "s": Object {
-    "flex-basis": "100%",
-    "width": "100%",
+    "flex-basis": "fit-content",
+    "width": "fit-content",
   },
   "xl": Object {
     "flex-basis": "calc(3% - 0px)",


### PR DESCRIPTION
# Description
Switch in sidebar on responsive was showing value from general, while style helper was ignoring that value and getting `fit-content` only from the current breakpoint. Changed the helper to get value from last breakpoint.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3634 

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that the problem from the issue is fixed

**_ Pre-Code Testing _**

-   [ ] Check that the problem from the issue is fixed
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
