### PR TITLE
Issue 3809 xxl default values

### DIFF
--- a/src/components/axis-control/index.js
+++ b/src/components/axis-control/index.js
@@ -55,7 +55,6 @@ const AxisInput = props => {
 		label,
 		target,
 		singleTarget = null,
-		getValue,
 		getLastBreakpointValue,
 		breakpoint,
 		disableAuto,
@@ -67,7 +66,6 @@ const AxisInput = props => {
 		onReset,
 	} = props;
 
-	const value = getValue(target, breakpoint);
 	const lastValue = getLastBreakpointValue(target);
 	const unit = getLastBreakpointValue(`${target}-unit`, breakpoint);
 	return (
@@ -78,7 +76,7 @@ const AxisInput = props => {
 				`maxi-axis-control__content__item__${kebabCase(label)}`
 			)}
 			placeholder={lastValue}
-			value={value}
+			value={lastValue}
 			onChangeValue={val => onChangeValue(val, singleTarget, breakpoint)}
 			minMaxSettings={minMaxSettings}
 			enableAuto={!disableAuto}

--- a/src/extensions/styles/getGroupAttributes.js
+++ b/src/extensions/styles/getGroupAttributes.js
@@ -41,6 +41,8 @@ const getGroupAttributes = (
 				});
 		});
 
+	if (target === 'padding') console.log(response);
+
 	return response;
 };
 

--- a/src/extensions/styles/getGroupAttributes.js
+++ b/src/extensions/styles/getGroupAttributes.js
@@ -41,8 +41,6 @@ const getGroupAttributes = (
 				});
 		});
 
-	if (target === 'padding') console.log(response);
-
 	return response;
 };
 


### PR DESCRIPTION
# Description

Looks like a too easy fix  :thinking: 

Fixes #3809 

# How Has This Been Tested?

Need to test default attributes for AxisInput (padding/ margin / position), especially when the base is XXL. 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-3 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-3 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
