### PR TITLE
Issue 3847 - fix type value in rangeControl

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -263,9 +263,11 @@ const AdvancedNumberControl = props => {
 						label={label}
 						className='maxi-advanced-number-control__range'
 						value={
-							+(!isNil(value)
+							+(!isNil(value) && Number.isFinite(value)
 								? value
-								: defaultValue || initial || placeholder || 0)
+								: Number.isFinite(defaultValue)
+								? defaultValue
+								: initial || placeholder || 0)
 						}
 						onChange={val => {
 							onChangeValue(


### PR DESCRIPTION
# Description

In #3800
When we select the responsive point - and the value = general, then the slider goes to 0.  
https://user-images.githubusercontent.com/88348091/197869870-f0cd8397-86b8-4de8-8f34-354e22a1bf55.mov

Fixes #3847

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist



# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
