### PR TITLE
Issue 3843 editor wrapper padding

### DIFF
--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -375,6 +375,23 @@ svg path#styleCardBoat_b {
 			box-shadow: none;
 		}
 	}
+
+	&.maxi-container-block {
+		&::after {
+			top: 0px !important;
+			right: 0px !important;
+			bottom: 0px !important;
+			left: 0px !important;
+		}
+		.maxi-indicators__padding--left {
+			position: absolute;
+			left: 4px;
+		}
+		.maxi-indicators__padding--right {
+			position: absolute;
+			right: 4px;
+		}
+	}
 }
 
 /*******************************

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -111,7 +111,7 @@ body.maxi-blocks--active #wpcontent .is-root-container {
 	padding: 0;
 }
 body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
-	padding: 5px;
+	padding: 0px;
 }
 
 /*Removes anchor border for Twenty Twenty One and Twenty*/


### PR DESCRIPTION
Made padding 0px. We have indicators at the sides of a container, 4px each. Had to make them absolutely positioned.
Also made indicators for the container 0px on all sides instead of -1px as we have it in general.

Fixes #3843 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Make sure there's no padding around the editor wrapper as it was before.
-   [ ] Make sure container indicators look good (lines around the container are visible and you can use the indicators).

**_ Pre-Code Testing _**

-   [ ] Make sure there's no padding around the editor wrapper as it was before.
-   [ ] Make sure container indicators look good (lines around the container are visible and you can use the indicators).
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
