### PR TITLE
Issue 3634 - load column template for general when inserting columns on responsive

### DIFF
--- a/src/extensions/column-templates/loadColumnsTemplate.js
+++ b/src/extensions/column-templates/loadColumnsTemplate.js
@@ -78,7 +78,7 @@ const loadColumnsTemplate = (templateName, clientId, breakpoint) => {
 	const isRowEmpty = !columnsBlockObjects.length;
 
 	if (isRowEmpty) {
-		// When inserting column, template should be loaded on general as well as on breakpoint the user is on
+		// When inserting column, template should be loaded for general as well as for breakpoint the user is on
 		if (breakpoint !== 'general') {
 			loadColumnsTemplate(templateName, clientId, 'general');
 			const columnsBlockObjects = wp.data

--- a/src/extensions/column-templates/loadColumnsTemplate.js
+++ b/src/extensions/column-templates/loadColumnsTemplate.js
@@ -71,22 +71,18 @@ const updateTemplate = (template, columnsBlockObjects, clientId) => {
 };
 
 const loadColumnsTemplate = (templateName, clientId, breakpoint) => {
-	const template = cloneDeep(getColumnTemplate(templateName, breakpoint));
 	const columnsBlockObjects = wp.data
 		.select('core/block-editor')
 		.getBlock(clientId).innerBlocks;
 	const isRowEmpty = !columnsBlockObjects.length;
+	// When inserting column, template should be loaded for general
+	const template = cloneDeep(
+		getColumnTemplate(templateName, isRowEmpty ? 'general' : breakpoint)
+	);
 
-	if (isRowEmpty) {
-		// When inserting column, template should be loaded for general as well as for breakpoint the user is on
-		if (breakpoint !== 'general') {
-			loadColumnsTemplate(templateName, clientId, 'general');
-			const columnsBlockObjects = wp.data
-				.select('core/block-editor')
-				.getBlock(clientId).innerBlocks;
-			updateTemplate(template, columnsBlockObjects, clientId);
-		} else loadTemplate(template, clientId);
-	} else updateTemplate(template, columnsBlockObjects, clientId);
+	isRowEmpty
+		? loadTemplate(template, clientId)
+		: updateTemplate(template, columnsBlockObjects, clientId);
 };
 
 export default loadColumnsTemplate;

--- a/src/extensions/column-templates/loadColumnsTemplate.js
+++ b/src/extensions/column-templates/loadColumnsTemplate.js
@@ -77,9 +77,16 @@ const loadColumnsTemplate = (templateName, clientId, breakpoint) => {
 		.getBlock(clientId).innerBlocks;
 	const isRowEmpty = !columnsBlockObjects.length;
 
-	isRowEmpty
-		? loadTemplate(template, clientId)
-		: updateTemplate(template, columnsBlockObjects, clientId);
+	if (isRowEmpty) {
+		// When inserting column, template should be loaded on general as well as on breakpoint the user is on
+		if (breakpoint !== 'general') {
+			loadColumnsTemplate(templateName, clientId, 'general');
+			const columnsBlockObjects = wp.data
+				.select('core/block-editor')
+				.getBlock(clientId).innerBlocks;
+			updateTemplate(template, columnsBlockObjects, clientId);
+		} else loadTemplate(template, clientId);
+	} else updateTemplate(template, columnsBlockObjects, clientId);
 };
 
 export default loadColumnsTemplate;


### PR DESCRIPTION
# Description
This fixes the last comment from the issue. When inserting columns on responsive, their sizes were only loaded for that responsive stage, so I made them load on general as well as on responsive.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3634 

# How Has This Been Tested?
Inserted columns on non-general breakpoint and checked that they look good on other breakpoints
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Insert columns on different breakpoints and check that they look right

**_ Pre-Code Testing _**

-   [ ] Insert columns on different breakpoints and check that they look right
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
