### PR TITLE
Issue 3899 - Scrollbar on canvas with full-width blocks

### DIFF
--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -95,7 +95,7 @@ const BlockResizer = memo(
 				handleClassName,
 				showHandlesClassName,
 				!isCorner ? sideHandleClassName : cornerHandleClassName,
-				`maxi-resizable__handle--${axis}`
+				`maxi-resizable__handle-${axis}`
 			);
 
 		const handleClasses = {

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -119,7 +119,6 @@ const BlockResizer = memo(
 				enable={enable}
 				handleClasses={handleClasses}
 				handleWrapperClass={handlesWrapperClassName}
-				// handleStyles={handleStyles}
 				onResizeStop={(e, direction, refToElement, ...rest) => {
 					onResizeStop?.(e, direction, refToElement, ...rest);
 					if (cleanStyles) stylesCleaner(refToElement);

--- a/src/components/block-resizer/index.js
+++ b/src/components/block-resizer/index.js
@@ -11,10 +11,14 @@ import classnames from 'classnames';
 import { isEqual } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { memoChildrenComparator } from '../../extensions/maxi-block';
+
+/**
  * Styles and icons
  */
 import './editor.scss';
-import { memoChildrenComparator } from '../../extensions/maxi-block';
 
 /**
  * Component
@@ -59,11 +63,23 @@ const BlockResizer = memo(
 			...props.enable,
 		};
 
+		const stylesCleaner = el =>
+			[
+				'position',
+				'user-select',
+				'box-sizing',
+				'flex-shrink',
+				'min-width',
+				'max-width',
+			].forEach(style => {
+				el.style.setProperty(style, '');
+			});
+
 		const handleRef = newRef => {
 			if (newRef) {
 				// Needed to clean styles before first onResizeStop, so that blocks don't jump after resizing
 				if (cleanStyles && !hasCleanedStyles.current) {
-					newRef.resizable.style = null;
+					stylesCleaner(newRef.resizable);
 					hasCleanedStyles.current = true;
 				}
 				if (resizableObject) resizableObject.current = newRef;
@@ -74,82 +90,39 @@ const BlockResizer = memo(
 			}
 		};
 
+		const getHandleClasses = (axis, isCorner = false) =>
+			classnames(
+				handleClassName,
+				showHandlesClassName,
+				!isCorner ? sideHandleClassName : cornerHandleClassName,
+				`maxi-resizable__handle--${axis}`
+			);
+
+		const handleClasses = {
+			top: enable.top && getHandleClasses('top'),
+			right: enable.right && getHandleClasses('right'),
+			bottom: enable.bottom && getHandleClasses('bottom'),
+			left: enable.left && getHandleClasses('left'),
+			topLeft: enable.topLeft && getHandleClasses('topleft', true),
+			topRight: enable.topRight && getHandleClasses('topright', true),
+			bottomRight:
+				enable.bottomRight && getHandleClasses('bottomright', true),
+			bottomLeft:
+				enable.bottomLeft && getHandleClasses('bottomleft', true),
+		};
+
 		return (
 			<Resizable
 				{...rest}
 				ref={handleRef}
 				className={classes}
 				enable={enable}
-				handleClasses={{
-					top:
-						enable.top &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							sideHandleClassName,
-							'maxi-resizable__handle-top'
-						),
-					right:
-						enable.right &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							sideHandleClassName,
-							'maxi-resizable__handle-right'
-						),
-					bottom:
-						enable.bottom &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							sideHandleClassName,
-							'maxi-resizable__handle-bottom'
-						),
-					left:
-						enable.left &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							sideHandleClassName,
-							'maxi-resizable__handle-left'
-						),
-					topLeft:
-						enable.topLeft &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							cornerHandleClassName,
-							'maxi-resizable__handle-topleft'
-						),
-					topRight:
-						enable.topRight &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							cornerHandleClassName,
-							'maxi-resizable__handle-topright'
-						),
-					bottomRight:
-						enable.bottomRight &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							cornerHandleClassName,
-							'maxi-resizable__handle-bottomright'
-						),
-					bottomLeft:
-						enable.bottomLeft &&
-						classnames(
-							handleClassName,
-							showHandlesClassName,
-							cornerHandleClassName,
-							'maxi-resizable__handle-bottomleft'
-						),
-				}}
+				handleClasses={handleClasses}
 				handleWrapperClass={handlesWrapperClassName}
+				// handleStyles={handleStyles}
 				onResizeStop={(e, direction, refToElement, ...rest) => {
 					onResizeStop?.(e, direction, refToElement, ...rest);
-					if (cleanStyles) refToElement.style = null;
+					if (cleanStyles) stylesCleaner(refToElement);
 				}}
 			>
 				{children}

--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -54,6 +54,8 @@ const getBlockStyle = (attributes, breakpoint) => {
 
 	if (!isFullWidth) return {};
 
+	const marginValue = 8;
+
 	// Margin
 	const marginRight = getValue('margin-right') || 0;
 	const marginRightUnit = getValue('margin-right-unit') || 'px';
@@ -67,16 +69,16 @@ const getBlockStyle = (attributes, breakpoint) => {
 	const maxWidthUnit = getValue('max-width-unit');
 
 	return {
-		marginRight: `calc(${marginRight}${marginRightUnit} - 8px)`,
-		marginLeft: `calc(${marginLeft}${marginLeftUnit} - 8px)`,
+		marginRight: `calc(${marginRight}${marginRightUnit} - ${marginValue}px)`,
+		marginLeft: `calc(${marginLeft}${marginLeftUnit} - ${marginValue}px)`,
 		width: `calc(${
 			isFullWidth && isNil(width) ? '100%' : `${width}${widthUnit}`
-		} + 16px)`,
+		} + ${marginValue * 2}px)`,
 		maxWidth: `calc(${
 			isFullWidth && isNil(maxWidth)
 				? '100%'
 				: `${maxWidth}${maxWidthUnit}`
-		} + 16px)`,
+		} + ${marginValue * 2}px)`,
 	};
 };
 

--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -16,7 +16,10 @@ import { dispatch, select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getHasParallax } from '../../extensions/styles';
+import {
+	getHasParallax,
+	getLastBreakpointAttribute,
+} from '../../extensions/styles';
 import InnerBlocksBlock from './innerBlocksBlock';
 import MainMaxiBlock from './mainMaxiBlock';
 
@@ -24,7 +27,7 @@ import MainMaxiBlock from './mainMaxiBlock';
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, isNil } from 'lodash';
 
 /**
  * Styles
@@ -37,6 +40,44 @@ const getBlockClassName = blockName => {
 	return `maxi-${blockName
 		.replace('maxi-blocks/', '')
 		.replace('-maxi', '')}-block`;
+};
+
+const getBlockStyle = (attributes, breakpoint) => {
+	const getValue = target =>
+		getLastBreakpointAttribute({
+			target,
+			breakpoint,
+			attributes,
+		});
+
+	const isFullWidth = getValue('full-width') === 'full';
+
+	if (!isFullWidth) return {};
+
+	// Margin
+	const marginRight = getValue('margin-right') || 0;
+	const marginRightUnit = getValue('margin-right-unit') || 'px';
+	const marginLeft = getValue('margin-left') || 0;
+	const marginLeftUnit = getValue('margin-left-unit') || 'px';
+
+	// Width
+	const width = getValue('width');
+	const widthUnit = getValue('width-unit');
+	const maxWidth = getValue('max-width');
+	const maxWidthUnit = getValue('max-width-unit');
+
+	return {
+		marginRight: `calc(${marginRight}${marginRightUnit} - 8px)`,
+		marginLeft: `calc(${marginLeft}${marginLeftUnit} - 8px)`,
+		width: `calc(${
+			isFullWidth && isNil(width) ? '100%' : `${width}${widthUnit}`
+		} + 16px)`,
+		maxWidth: `calc(${
+			isFullWidth && isNil(maxWidth)
+				? '100%'
+				: `${maxWidth}${maxWidthUnit}`
+		} + 16px)`,
+	};
 };
 
 const MaxiBlockContent = forwardRef((props, ref) => {
@@ -103,6 +144,20 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 			});
 		}
 	}
+
+	// In order to keep the structure that Gutenberg uses for the block,
+	// is necessary to add some inline styles to the first hierarchy blocks.
+	const { isFirstOnHierarchy } = extraProps.attributes;
+	const style = getBlockStyle(extraProps.attributes, extraProps.deviceType);
+
+	// Gets if the block is full-width
+	const isFullWidth =
+		getLastBreakpointAttribute({
+			target: 'full-width',
+			breakpoint: extraProps.deviceType,
+			attributes: extraProps.attributes,
+		}) === 'full';
+
 	// Are just necessary for the memo() part
 	delete extraProps.attributes;
 	delete extraProps.isChild;
@@ -160,7 +215,8 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 		paletteClasses,
 		hasLink && 'maxi-block--has-link',
 		isDragging && isDragOverBlock && 'maxi-block--is-drag-over',
-		isHovered && 'maxi-block--is-hovered'
+		isHovered && 'maxi-block--is-hovered',
+		!isSave && isFullWidth && 'maxi-block--full-width'
 	);
 
 	const onDragLeave = isSave
@@ -211,6 +267,7 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 		background,
 		disableBackground: !disableBackground,
 		isSave,
+		...(!isSave && isFirstOnHierarchy && { style }),
 		...(!isSave &&
 			INNER_BLOCKS.includes(blockName) && {
 				onDragLeave,

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -348,14 +348,18 @@ svg path#styleCardBoat_b {
 
 .maxi-block {
 	&::after {
-		border: 2px solid var(--maxi-light-blue-3-color);
-		border-radius: 0;
-		box-shadow: none !important;
-		opacity: 0;
 		top: -1px !important;
 		right: -1px !important;
 		bottom: -1px !important;
 		left: -1px !important;
+		border: 2px solid var(--maxi-light-blue-3-color);
+		border-radius: 0;
+		box-shadow: none !important;
+		opacity: 0;
+	}
+
+	&.maxi-block--full-width::after {
+		width: calc(100% - 4px);
 	}
 
 	&:not(.is-selected) {

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -105,14 +105,6 @@ body.maxi-blocks--active .maxi-button-block button:focus {
 	outline: none !important;
 }
 
-/*Fixes container alignment for Twenty Twenty Two*/
-body.maxi-blocks--active #wpcontent .is-root-container {
-	padding: 0;
-}
-body.maxi-blocks--active #wpcontent .editor-styles-wrapper {
-	padding: 0px;
-}
-
 /*Removes anchor border for Twenty Twenty One and Twenty*/
 body.maxi-blocks--active .maxi-link-wrapper {
 	text-decoration: none;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Removes padding issues on Maxi blocks. To understand the situation we need some context: Gutenberg editor adds some padding on the canvas (8px on both X axis sides), and then blocks have 2 subsequent styles:
1. Margin-left and margin-right === -8px
2. Width === calc(100% + 16px)

We can celebrate such a good practices like those, but anyway we need to adapt to it. The fix we've implemented was to modify the padding of the canvas of the Gutenberg editor, which affected the editor itself. The problem has been on setting that padding to 0: a scrollbar appeared on the bottom, and some native Gutenberg blocks were affected by that change we did. So, basically, we needed a solution that just affects Maxi blocks.

Considering that as a difference with native WP blocks, Maxi blocks has dynamic styles that affect margin and width, we can't rely as they do on static CSS. Also, our style mechanisms doesn't have support for having some styles on back and some on front, so wasn't a good solution. So, finally, I decided to take the same procedure done on #3853 to implement it; basically, added that styles as element inline-styles from the `MaxiBlock` component and just affect backend. 

Fixes #3899 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

Create different blocks and set them on full-size. Not just Maxi, also native WP blocks. No scrollbar should appear on the bottom (unless we select a block with resizer handlers, that is an exception!)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test different blocks, Maxi ones and native WP ones, on full-width
- [ ] Test different responsive stages
- [ ] Test different themes

**_ Pre-Code Testing _**

-   [ ] Test different blocks, Maxi ones and native WP ones, on full-width
- [ ] Test different responsive stages
- [ ] Test different themes
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
