### PR TITLE
Issue 3906 - IB bad UX when changing hovered trigger element fast

### DIFF
--- a/js/maxi-relations.js
+++ b/js/maxi-relations.js
@@ -376,7 +376,22 @@ class Relation {
 	}
 
 	setDataAttrToBlock(value) {
-		this.blockTargetEl.setAttribute('data-maxi-relations', value);
+		// On setting the 'false' value, is necessary to check the 'data-maxi-relations-trigger'
+		// to ensure the last trigger is not removed. It happens when moving from some trigger to
+		// other really fast between while `transitionTimeout` is still running.
+		if (value === 'false') {
+			const currentTrigger = this.blockTargetEl.getAttribute(
+				'data-maxi-relations-trigger'
+			);
+
+			if (currentTrigger === this.trigger || !currentTrigger)
+				this.blockTargetEl.setAttribute('data-maxi-relations', value);
+		} else this.blockTargetEl.setAttribute('data-maxi-relations', value);
+
+		this.blockTargetEl.setAttribute(
+			'data-maxi-relations-trigger',
+			this.trigger
+		);
 	}
 
 	addDataAttrToBlock() {


### PR DESCRIPTION
# Description

Fixes the frontend glitch explained on #3906 when changing from some trigger element to other so fast 👍 (hard to explain, check the video of the issue lol)

Fixes #3906 

# How Has This Been Tested?

Use this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/9983679/ibfastchange.txt) and check in frontend that the effect is correct when hovering the different words so fast 👍 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
