### PR TITLE
Popover advanced settings buttons

### DIFF
--- a/src/components/toolbar/components/svg-color/index.js
+++ b/src/components/toolbar/components/svg-color/index.js
@@ -47,7 +47,7 @@ function SvgColorToolbar(props) {
 						: toolbarShapeLineColor}
 				</div>
 			}
-			advancedOptions='colour'
+			advancedOptions='icon colour'
 		>
 			<div className='toolbar-item__svg-color__popover'>
 				<SvgColor


### PR DESCRIPTION
This popover advanced button wasn't working for the line fill and line colour. 
![Screenshot_1](https://user-images.githubusercontent.com/19425503/201177920-31cc778b-3bf0-444f-84f0-162d9b872f63.jpg)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that the Icon popover advanced buttons all work.
-   [ ] Test other blocks' same buttons too.

**_ Pre-Code Testing _**

-   [x] Test that the Icon popover advanced buttons all work.
-   [x] Test other blocks' same buttons too.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
