### PR TITLE
Issue 3949 Conditional max width in toolbar

### DIFF
--- a/src/components/toolbar/components/size/index.js
+++ b/src/components/toolbar/components/size/index.js
@@ -111,44 +111,46 @@ const Size = props => {
 								})
 							}
 						/>
-						{BLOCKS_MAX_WIDTH.includes(blockName) && (
-							<AdvancedNumberControl
-								label={__('Max width', 'maxi-blocks')}
-								enableUnit
-								unit={getLastBreakpointAttribute({
-									target: 'max-width-unit',
-									breakpoint,
-									attributes: props,
-								})}
-								onChangeUnit={val =>
-									onChange({
-										[`max-width-unit-${breakpoint}`]: val,
-									})
-								}
-								onReset={() =>
-									onChange({
-										[`max-width-${breakpoint}`]:
-											getDefaultAttribute(
-												`max-width-${breakpoint}`
-											),
-										[`max-width-unit-${breakpoint}`]:
-											getDefaultAttribute(
-												`max-width-unit-${breakpoint}`
-											),
-									})
-								}
-								value={getLastBreakpointAttribute({
-									target: 'max-width',
-									breakpoint,
-									attributes: props,
-								})}
-								onChangeValue={val =>
-									onChange({
-										[`max-width-${breakpoint}`]: val,
-									})
-								}
-							/>
-						)}
+						{BLOCKS_MAX_WIDTH.includes(blockName) &&
+							props['size-advanced-options'] && (
+								<AdvancedNumberControl
+									label={__('Max width', 'maxi-blocks')}
+									enableUnit
+									unit={getLastBreakpointAttribute({
+										target: 'max-width-unit',
+										breakpoint,
+										attributes: props,
+									})}
+									onChangeUnit={val =>
+										onChange({
+											[`max-width-unit-${breakpoint}`]:
+												val,
+										})
+									}
+									onReset={() =>
+										onChange({
+											[`max-width-${breakpoint}`]:
+												getDefaultAttribute(
+													`max-width-${breakpoint}`
+												),
+											[`max-width-unit-${breakpoint}`]:
+												getDefaultAttribute(
+													`max-width-unit-${breakpoint}`
+												),
+										})
+									}
+									value={getLastBreakpointAttribute({
+										target: 'max-width',
+										breakpoint,
+										attributes: props,
+									})}
+									onChangeValue={val =>
+										onChange({
+											[`max-width-${breakpoint}`]: val,
+										})
+									}
+								/>
+							)}
 					</>
 				)}
 			</div>


### PR DESCRIPTION
Enables max width in the toolbar only when set min/maxi values in the sidebar is enabled
Fixes #3949 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add a block that has max-width in the toolbar, like map or group, and make sure that the option shows only if you enable min/max width it in the sidebar first.
- 
**_ Pre-Code Testing _**

-   [ ] Add a block that has max-width in the toolbar, like map or group, and make sure that the option shows only if you enable min/max width it in the sidebar first.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
