### PR TITLE
Visibility of tags for another category 

### DIFF
--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -181,6 +181,19 @@ const Accordion = ({ children, title, openByDefault = false }) => {
 	);
 };
 
+// hack to fix issue #3930: top level tags resetting when we choose a second-level tag
+const removeMenuBugFix = () => {
+	const lists = document.querySelectorAll('.maxi__hide-top-tags');
+
+	for (const list of lists) {
+		list.classList.remove('maxi__hide-top-tags');
+		const listElements = list.childNodes;
+		for (const element of listElements) {
+			element.classList.remove('maxi__show-top-tag');
+		}
+	}
+};
+
 const resultsCount = {
 	stats(nbHits) {
 		const resultsString = nbHits.toLocaleString();
@@ -253,6 +266,7 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 					value={item.value}
 					onClick={event => {
 						event.preventDefault();
+						removeMenuBugFix();
 						refine(item.value);
 						item.isRefined = true;
 					}}
@@ -337,19 +351,6 @@ const HierarchicalMenu = ({ items, refine, type = 'firstLevel' }) => {
 };
 
 const ClearRefinements = ({ items, refine }) => {
-	// hack to fix issue #3930: top level tags resetting when we choose a second-level tag
-	const removeMenuBugFix = () => {
-		const lists = document.querySelectorAll('.maxi__hide-top-tags');
-
-		for (const list of lists) {
-			list.classList.remove('maxi__hide-top-tags');
-			const listElements = list.childNodes;
-			for (const element of listElements) {
-				element.classList.remove('maxi__show-top-tag');
-			}
-		}
-	};
-
 	return (
 		<button
 			type='button'


### PR DESCRIPTION
# Description

Added resetting svg tags on category change

Fixes #3939

# How Has This Been Tested?

Do the same as in the video here https://github.com/maxi-blocks/maxi-blocks/issues/3939

You should see all the tags in the left sidebar.

# Test checklist

**_ Front/Back Testing _**

-   [ ] Test the tags / categories in Modal sidebar 

**_ Pre-Code Testing _**

-   [ ] Test the tags / categories in Modal sidebar 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
