### PR TITLE
Issue 3960 - Max-width error on full-width blocks

### DIFF
--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -72,10 +72,10 @@ const getBlockStyle = (attributes, breakpoint) => {
 		marginRight: `calc(${marginRight}${marginRightUnit} - ${marginValue}px)`,
 		marginLeft: `calc(${marginLeft}${marginLeftUnit} - ${marginValue}px)`,
 		width: `calc(${
-			isFullWidth && isNil(width) ? '100%' : `${width}${widthUnit}`
+			isFullWidth || isNil(width) ? '100%' : `${width}${widthUnit}`
 		} + ${marginValue * 2}px)`,
 		maxWidth: `calc(${
-			isFullWidth && isNil(maxWidth)
+			isFullWidth || isNil(maxWidth)
 				? '100%'
 				: `${maxWidth}${maxWidthUnit}`
 		} + ${marginValue * 2}px)`,


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes the FullWidth error on some blocks and some themes as commented on the issue.

Fixes #3960

# How Has This Been Tested?

Tested different full-width patterns on different WP themes 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test different full-width patterns on different WP themes 👍 

**_ Pre-Code Testing _**

-   [ ] Test different full-width patterns on different WP themes 👍 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
