### PR TITLE
Issue 3809 - Errors when winBase === XXL

### DIFF
--- a/src/components/axis-control/index.js
+++ b/src/components/axis-control/index.js
@@ -3,6 +3,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -69,7 +70,9 @@ const AxisInput = props => {
 
 	const value = getValue(target, breakpoint);
 	const lastValue = getLastBreakpointValue(target);
+
 	const unit = getLastBreakpointValue(`${target}-unit`, breakpoint);
+
 	return (
 		<AdvancedNumberControl
 			label={__(capitalize(label), 'maxi-blocks')}
@@ -513,15 +516,27 @@ const AxisControl = props => {
 	};
 
 	const getValue = (key, customBreakpoint) => {
-		const value =
-			props[
-				getAttributeKey(
-					getKey(key),
-					isHover,
-					false,
-					customBreakpoint ?? breakpoint
-				)
-			];
+		let value;
+
+		if (breakpoint === 'general' || customBreakpoint === 'general') {
+			const baseBreakpoint = select('maxiBlocks').receiveBaseBreakpoint();
+
+			value =
+				props[
+					getAttributeKey(getKey(key), isHover, false, baseBreakpoint)
+				];
+		}
+		if (isNil(value)) {
+			value =
+				props[
+					getAttributeKey(
+						getKey(key),
+						isHover,
+						false,
+						customBreakpoint ?? breakpoint
+					)
+				];
+		}
 
 		if (isNumber(value) || value) return value;
 
@@ -543,6 +558,30 @@ const AxisControl = props => {
 			);
 
 			return filteredResult;
+		};
+
+		const getDefaultValue = key => {
+			let value;
+
+			if (breakpoint === 'general' || customBreakpoint === 'general') {
+				const baseBreakpoint =
+					select('maxiBlocks').receiveBaseBreakpoint();
+
+				value = getDefaultAttribute(
+					getAttributeKey(getKey(key), isHover, false, baseBreakpoint)
+				);
+			}
+			if (isNil(value))
+				value = getDefaultAttribute(
+					getAttributeKey(
+						getKey(key),
+						isHover,
+						false,
+						customBreakpoint ?? breakpoint
+					)
+				);
+
+			return value;
 		};
 
 		const top = inputsArray[0];
@@ -573,14 +612,7 @@ const AxisControl = props => {
 					false,
 					customBreakpoint ?? breakpoint
 				)
-			] = getDefaultAttribute(
-				getAttributeKey(
-					getKey(key),
-					isHover,
-					false,
-					customBreakpoint ?? breakpoint
-				)
-			);
+			] = getDefaultValue(key);
 		});
 		onChange(response);
 	};

--- a/src/extensions/dom/getWinBreakpoint.js
+++ b/src/extensions/dom/getWinBreakpoint.js
@@ -1,20 +1,26 @@
 /**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
  * Returns the relative breakpoint to the content width of the editor canvas
  *
  * @param {number} contentWidth Editor canvas width
  * @param {obj}    breakpoints  Breakpoints object
  * @returns Breakpoint relative to the content width
  */
-const getWinBreakpoint = (
-	contentWidth,
-	breakpoints = {
-		xs: 480,
-		s: 767,
-		m: 1024,
-		l: 1366,
-		xl: 1920,
-	}
-) => {
+const getWinBreakpoint = (contentWidth, rawBreakpoints) => {
+	const breakpoints = !isEmpty(rawBreakpoints)
+		? rawBreakpoints
+		: {
+				xs: 480,
+				s: 767,
+				m: 1024,
+				l: 1366,
+				xl: 1920,
+		  };
+
 	if (contentWidth > breakpoints.xl) return 'xxl';
 
 	// Objects are unordered collection of properties, so as we can't rely on


### PR DESCRIPTION
# Description

This PR is a possible alternative to #3943 🤔 

Fixes the problems commented on the issue:
1. The value of padding on Button Maxi having XXL winSize wasn't correct.
2. The value of padding on Button Maxi having XXL winsize while resetting wasn't correct.

(the issue was referring to situatons where winBase === XXL and we've got different default attributes for XXL and for General; I'm talking directly about Button Maxi paddings as is the only place where I found this situation)

Fixes #3809

# How Has This Been Tested?

1. Open editor from an XXL winSize and add a Button Maxi. Try modifying the values of the padding and then resetting. Try the same on XL and then on other responsive stages: adding values, resetting, etc... (on resetting from XXL, is normal the general values become the same as XXL, as XXL is winBase and everything we modify there is saved as General)
2. Open editor from XL winSize and do the same as point one. Check XXL size also.
3. Open editor from any other winSize and do the same as point one and two, checking XXL and XL.

On each one of the tests is important to check the correspondence between what we are displaying on settings sidebar and what the block is rendering 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the steps commented above.

**_ Pre-Code Testing _**

-   [ ] Test the steps commented above.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
