### PR TITLE
Fix CssSyntaxError for empty css

### DIFF
--- a/src/extensions/styles/store/controls.js
+++ b/src/extensions/styles/store/controls.js
@@ -17,7 +17,11 @@ import postcss from 'postcss';
 import frontendStyleGenerator from '../frontendStyleGenerator';
 
 async function processCss(code) {
+	if (!code) return null;
+
 	const { css } = postcss([autoprefixer]).process(code);
+	if (!css) return null;
+
 	const minifiedCss = minifyCssString(css);
 
 	return minifiedCss;


### PR DESCRIPTION
# Description

Fixes the annoying ```Uncaught (in promise) CssSyntaxError: <css input>:1:1: Unknown word``` error in the console (usually you can see it on a post saving, especially with a debugger on):

[screencast-nimbus-capture-2022.11.23-12_08_44.webm](https://user-images.githubusercontent.com/2401618/203520539-86217ec4-a03a-47c1-948c-ca9fc7edc7f7.webm)

Fixes #3819

# How Has This Been Tested?

It was occurring on all blocks, but to re-create for sure, you can add a Template Library Maxi.  But don't choose any patterns, just close the modal, leaving it "empty". Save the page / post. You can do the same with Icon Maxi Block too.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test with an "empty" Template Library (you need to save the post and check the console)
-   [x] Test with an "empty" Icon Block (you need to save the post and check the console)
-   [x] Check that the Custom CSS works on backend - on as many blocks you can
-   [x] Check that the Custom CSS works on frontend - on as many blocks you can
-   [x] Check that backend saves the CSS settings after the editor reload
-   [x] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [ ] Test with an "empty" Template Library (you need to save the post and check the console)
-   [ ] Test with an "empty" Icon Block (you need to save the post and check the console)
-   [ ] Check that the Custom CSS works on backend - on as many blocks you can
-   [ ] Check that the Custom CSS works on frontend - on as many blocks you can
-   [ ] Check that backend saves the CSS settings after the editor reload
-   [ ] Same 1-4 points on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
