### PR TITLE
Issue 3360 Responsive Tooltips

### DIFF
--- a/src/editor/responsive-selector/editor.scss
+++ b/src/editor/responsive-selector/editor.scss
@@ -13,6 +13,12 @@
 	padding: 0 25px 0 0;
 	box-shadow: 0 5px 15px 0 rgba(119, 119, 119, 0.1);
 
+	.maxi-responsive-selector__base:hover {
+		.maxi-tabs-control__notification {
+			opacity: 1 !important;
+		}
+	}
+
 	.action-buttons {
 		display: inline-block;
 		&__button {
@@ -38,16 +44,18 @@
 				position: absolute;
 				display: block;
 				background-color: #081219;
-				transition: 0.3s;
-				bottom: -1px;
+				transition: 0.2s;
+				bottom: 0px;
 				left: 0;
 				width: 100%;
-				height: 0;
+				height: 2px;
+				pointer-events: none;
+				opacity: 0;
 			}
 			&:hover {
 				background-color: #f9f9f9;
 				&::after {
-					height: 2px;
+					opacity: 1;
 				}
 			}
 		}
@@ -175,11 +183,13 @@
 				position: absolute;
 				display: block;
 				background-color: #081219;
-				transition: 0.3s;
-				bottom: -1px;
+				transition: 0.2s;
+				bottom: 0px;
 				left: 0;
 				width: 100%;
-				height: 0;
+				height: 2px;
+				opacity: 0;
+				pointer-events: none;
 			}
 			&[aria-pressed='true'] {
 				background-color: #eaf2f6 !important;
@@ -198,7 +208,7 @@
 			&:hover {
 				background-color: #f9f9f9;
 				&::after {
-					height: 2px;
+					opacity: 1;
 				}
 			}
 			&:focus {

--- a/src/editor/responsive-selector/editor.scss
+++ b/src/editor/responsive-selector/editor.scss
@@ -136,12 +136,34 @@
 			justify-content: center;
 			align-items: center;
 
+			.responsive-button-tooltip {
+				opacity: 0;
+				transition: all 0.2s;
+				position: absolute;
+				height: 100%;
+				width: 100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				left: 0;
+				top: 0;
+			}
+
 			svg {
 				display: block;
 				margin: 0 auto;
+				transition: all 0.2s;
 			}
 			&:hover {
 				color: #000;
+
+				.maxi-responsive-selector__button-current-size,
+				svg {
+					opacity: 0;
+				}
+				.responsive-button-tooltip {
+					opacity: 1;
+				}
 			}
 			&:first-of-type {
 				margin-left: 0;

--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { select, useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -37,7 +37,13 @@ import {
 /**
  * Components
  */
-const ResponsiveButton = ({ baseBreakpoint, icon, breakpoint, target }) => {
+const ResponsiveButton = ({
+	baseBreakpoint,
+	icon,
+	tooltipValue,
+	breakpoint,
+	target,
+}) => {
 	const isBaseBreakpoint = baseBreakpoint === target;
 
 	const classes = classnames(
@@ -61,6 +67,9 @@ const ResponsiveButton = ({ baseBreakpoint, icon, breakpoint, target }) => {
 				aria-pressed={getIsPressed()}
 			>
 				<div>
+					<div className='responsive-button-tooltip'>
+						{tooltipValue}
+					</div>
 					{icon}
 					{isBaseBreakpoint && (
 						<>
@@ -111,7 +120,7 @@ const ResponsiveSelector = props => {
 	};
 
 	const classes = classnames('maxi-responsive-selector', className);
-
+	const SizeXXL = select('maxiBlocks').receiveXXLSize();
 	return (
 		<div className={classes} style={{ display: isOpen ? 'flex' : 'none' }}>
 			<span className='maxi-responsive-selector__close' onClick={onClose}>
@@ -123,6 +132,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={SizeXXL}
 			/>
 			<ResponsiveButton
 				icon={xlMode}
@@ -130,6 +140,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={breakpoints.xl}
 			/>
 			<ResponsiveButton
 				icon={largeMode}
@@ -137,6 +148,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={breakpoints.l}
 			/>
 			<ResponsiveButton
 				icon={mediumMode}
@@ -144,6 +156,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={breakpoints.m}
 			/>
 			<ResponsiveButton
 				icon={smallMode}
@@ -151,6 +164,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={breakpoints.s}
 			/>
 			<ResponsiveButton
 				icon={xsMode}
@@ -158,6 +172,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
+				tooltipValue={breakpoints.xs}
 			/>
 			<div className='action-buttons'>
 				<Button

--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -67,9 +67,11 @@ const ResponsiveButton = ({
 				aria-pressed={getIsPressed()}
 			>
 				<div>
-					<div className='responsive-button-tooltip'>
-						{tooltipValue}
-					</div>
+					{tooltipValue && (
+						<div className='responsive-button-tooltip'>
+							{tooltipValue}
+						</div>
+					)}
 					{icon}
 					{isBaseBreakpoint && (
 						<>

--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { select, useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -122,7 +122,7 @@ const ResponsiveSelector = props => {
 	};
 
 	const classes = classnames('maxi-responsive-selector', className);
-	const SizeXXL = select('maxiBlocks').receiveXXLSize();
+
 	return (
 		<div className={classes} style={{ display: isOpen ? 'flex' : 'none' }}>
 			<span className='maxi-responsive-selector__close' onClick={onClose}>
@@ -134,7 +134,7 @@ const ResponsiveSelector = props => {
 				breakpoint={deviceType}
 				baseBreakpoint={baseBreakpoint}
 				breakpoints={breakpoints}
-				tooltipValue={SizeXXL}
+				tooltipValue={`>${breakpoints.xl}`}
 			/>
 			<ResponsiveButton
 				icon={xlMode}


### PR DESCRIPTION
Added screen size value on button hover:
![Screenshot_5](https://user-images.githubusercontent.com/19425503/203815485-5141f41a-a0c2-4a3f-9d7d-05d4bed092f0.jpg)

Fixes #3360 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that the values work on hover and that values are correct.
-   [ ] Try changing the values in the backend and see if the new changes are displayed.

**_ Pre-Code Testing _**

-   [ ] Test that the values work on hover and that values are correct.
-   [ ] Try changing the values in the backend and see if the new changes are displayed.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
