### PR TITLE
Issue 3950 - Transform control inputs ignore placeholder values on arrow value change

### DIFF
--- a/src/components/transform-control/index.js
+++ b/src/components/transform-control/index.js
@@ -285,8 +285,6 @@ const TransformControl = props => {
 						<>
 							{transformStatus === 'scale' && (
 								<SquareControl
-									defaultX='100'
-									defaultY='100'
 									x={
 										getLastBreakpointAttribute({
 											target: 'transform-scale',

--- a/src/components/transform-control/index.js
+++ b/src/components/transform-control/index.js
@@ -285,6 +285,8 @@ const TransformControl = props => {
 						<>
 							{transformStatus === 'scale' && (
 								<SquareControl
+									defaultX='100'
+									defaultY='100'
 									x={
 										getLastBreakpointAttribute({
 											target: 'transform-scale',

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -135,18 +135,17 @@ const SquareControl = props => {
 			nativeEvent: { inputType },
 		} = e;
 
-		const newValue = !isEmpty(e.target.value)
-			? validateOriginValue(e.target.value)
-			: '';
+		const newValue = !isEmpty(e.target.value) ? Number(e.target.value) : '';
 
-		if (isNumber(currentValue)) return newValue;
+		if (isNumber(currentValue) && Number.isFinite(currentValue))
+			return newValue;
 
 		const typeofEvent = getIsValid(inputType, true) ? 'type' : 'click';
 
 		switch (typeofEvent) {
 			case 'click':
 				return (
-					(isNumber(+placeholder) && isEmpty(currentValue)
+					(!isNaN(Number(placeholder)) && isEmpty(currentValue)
 						? +placeholder
 						: 0) + +newValue
 				);

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -458,7 +458,7 @@ const SquareControl = props => {
 							className='maxi-transform-control__square-control__y-control__range'
 							value={
 								!isNumber(validateOriginValue(yAxis))
-									? getPlaceholder(yAxis, true)
+									? ''
 									: validateOriginValue(yAxis)
 							}
 							onChange={e => {
@@ -503,16 +503,15 @@ const SquareControl = props => {
 							<input
 								type='number'
 								placeholder={
-									!isNumber(validateOriginValue(yAxis)) &&
-									!isEmpty(validateOriginValue(yAxis))
-										? validateOriginValue(yAxis)
-										: getPlaceholder(yAxis, true)
+									validateOriginValue(yAxis) === false
+										? getPlaceholder(yAxis, true)
+										: validateOriginValue(yAxis)
 								}
 								className='maxi-transform-control__square-control__y-control__value__input'
 								value={
-									validateOriginValue(yAxis) === false
-										? ''
-										: validateOriginValue(yAxis)
+									isNumber(validateOriginValue(yAxis))
+										? validateOriginValue(yAxis)
+										: ''
 								}
 								onChange={e => {
 									const newValue = getNewValueFromEmpty(
@@ -581,7 +580,7 @@ const SquareControl = props => {
 							className='maxi-transform-control__square-control__x-control__range'
 							value={
 								!isNumber(validateOriginValue(xAxis))
-									? getPlaceholder(xAxis)
+									? ''
 									: validateOriginValue(xAxis)
 							}
 							placeholder={getPlaceholder(xAxis)}
@@ -627,16 +626,15 @@ const SquareControl = props => {
 							<input
 								type='number'
 								placeholder={
-									!isNumber(validateOriginValue(xAxis)) &&
-									!isEmpty(validateOriginValue(xAxis))
-										? validateOriginValue(xAxis)
-										: getPlaceholder(xAxis, true)
+									validateOriginValue(xAxis) === false
+										? getPlaceholder(xAxis, true)
+										: validateOriginValue(xAxis)
 								}
 								className='maxi-transform-control__square-control__x-control__value__input'
 								value={
-									validateOriginValue(xAxis) === false
-										? ''
-										: validateOriginValue(xAxis)
+									isNumber(validateOriginValue(xAxis))
+										? validateOriginValue(xAxis)
+										: ''
 								}
 								onChange={e => {
 									const newValue = getNewValueFromEmpty(

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -456,7 +456,11 @@ const SquareControl = props => {
 						<input
 							type='range'
 							className='maxi-transform-control__square-control__y-control__range'
-							value={yAxis || ''}
+							value={
+								!isNumber(validateOriginValue(yAxis))
+									? getPlaceholder(yAxis, true)
+									: validateOriginValue(yAxis)
+							}
 							onChange={e => {
 								const value = Number(e.target.value);
 
@@ -543,6 +547,8 @@ const SquareControl = props => {
 										);
 									}
 								}}
+								min={getMinMax()?.min}
+								max={getMinMax()?.max}
 							/>
 							{isShowUnit(y) && (
 								<SelectControl
@@ -568,7 +574,12 @@ const SquareControl = props => {
 						<input
 							type='range'
 							className='maxi-transform-control__square-control__x-control__range'
-							value={xAxis || ''}
+							value={
+								!isNumber(validateOriginValue(xAxis))
+									? getPlaceholder(xAxis)
+									: validateOriginValue(xAxis)
+							}
+							placeholder={getPlaceholder(xAxis)}
 							onChange={e => {
 								const value = Number(e.target.value);
 
@@ -655,6 +666,8 @@ const SquareControl = props => {
 										);
 									}
 								}}
+								min={getMinMax()?.min}
+								max={getMinMax()?.max}
 							/>
 							{isShowUnit(x) && (
 								<SelectControl
@@ -684,7 +697,11 @@ const SquareControl = props => {
 						<input
 							type='range'
 							className='maxi-transform-control__square-control__y-control__range'
-							value={yAxis || ''}
+							value={
+								!isNumber(yAxis)
+									? getPlaceholder(yAxis, true)
+									: yAxis
+							}
 							onChange={e => {
 								const value = Number(e.target.value);
 
@@ -737,6 +754,8 @@ const SquareControl = props => {
 										);
 									}
 								}}
+								min={getMinMax()?.min}
+								max={getMinMax()?.max}
 							/>
 							{!!yUnit && (
 								<SelectControl
@@ -762,7 +781,9 @@ const SquareControl = props => {
 						<input
 							type='range'
 							className='maxi-transform-control__square-control__x-control__range'
-							value={xAxis || ''}
+							value={
+								!isNumber(xAxis) ? getPlaceholder(xAxis) : xAxis
+							}
 							onChange={e => {
 								const value = Number(e.target.value);
 
@@ -815,6 +836,8 @@ const SquareControl = props => {
 										);
 									}
 								}}
+								min={getMinMax()?.min}
+								max={getMinMax()?.max}
 							/>
 							{!!xUnit && (
 								<SelectControl

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -476,7 +476,7 @@ const SquareControl = props => {
 								className='maxi-transform-control__square-control__y-control__value__input'
 								value={
 									!isNumber(validateOriginValue(yAxis))
-										? ''
+										? defaultY
 										: validateOriginValue(yAxis)
 								}
 								onChange={e => {
@@ -586,7 +586,7 @@ const SquareControl = props => {
 								className='maxi-transform-control__square-control__x-control__value__input'
 								value={
 									!isNumber(validateOriginValue(xAxis))
-										? ''
+										? defaultX
 										: validateOriginValue(xAxis)
 								}
 								onChange={e => {
@@ -678,7 +678,7 @@ const SquareControl = props => {
 								type='number'
 								placeholder={getPlaceholder(yAxis)}
 								className='maxi-transform-control__square-control__y-control__value__input'
-								value={!isNumber(yAxis) ? '' : yAxis}
+								value={!isNumber(yAxis) ? defaultY : yAxis}
 								onChange={e => {
 									const newValue = !isEmpty(e.target.value)
 										? Number(e.target.value)
@@ -754,7 +754,7 @@ const SquareControl = props => {
 								type='number'
 								placeholder={getPlaceholder(xAxis)}
 								className='maxi-transform-control__square-control__x-control__value__input'
-								value={!isNumber(xAxis) ? '' : xAxis}
+								value={!isNumber(xAxis) ? defaultX : xAxis}
 								onChange={e => {
 									const newValue = !isEmpty(e.target.value)
 										? Number(e.target.value)

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -11,7 +11,7 @@ import { Tooltip } from '@wordpress/components';
 import Button from '../button';
 import SelectControl from '../select-control';
 import BlockResizer from '../block-resizer';
-import { validateOriginValue } from '../../extensions/styles';
+import { validateOriginValue, getIsValid } from '../../extensions/styles';
 import ResetButton from '../reset-control';
 
 /**
@@ -129,6 +129,33 @@ const SquareControl = props => {
 		}
 		return false;
 	};
+
+	const getNewValueFromEmpty = (e, currentValue, placeholder) => {
+		const {
+			nativeEvent: { inputType },
+		} = e;
+
+		const newValue = !isEmpty(e.target.value)
+			? validateOriginValue(e.target.value)
+			: '';
+
+		if (isNumber(currentValue)) return newValue;
+
+		const typeofEvent = getIsValid(inputType, true) ? 'type' : 'click';
+
+		switch (typeofEvent) {
+			case 'click':
+				return (
+					(isNumber(+placeholder) && isEmpty(currentValue)
+						? +placeholder
+						: 0) + +newValue
+				);
+			case 'type':
+			default:
+				return newValue;
+		}
+	};
+
 	const transformStr = useCallback(() => {
 		return `translateX(${xAxis}${xUnit}) translateY(${yAxis}${yUnit})`;
 	}, [xAxis, xUnit, yAxis, yUnit]);
@@ -476,13 +503,15 @@ const SquareControl = props => {
 								className='maxi-transform-control__square-control__y-control__value__input'
 								value={
 									!isNumber(validateOriginValue(yAxis))
-										? defaultY
+										? ''
 										: validateOriginValue(yAxis)
 								}
 								onChange={e => {
-									const newValue = !isEmpty(e.target.value)
-										? validateOriginValue(e.target.value)
-										: '';
+									const newValue = getNewValueFromEmpty(
+										e,
+										validateOriginValue(yAxis),
+										getPlaceholder(yAxis)
+									);
 
 									if (!sync) {
 										changeYAxis(newValue);
@@ -586,13 +615,15 @@ const SquareControl = props => {
 								className='maxi-transform-control__square-control__x-control__value__input'
 								value={
 									!isNumber(validateOriginValue(xAxis))
-										? defaultX
+										? ''
 										: validateOriginValue(xAxis)
 								}
 								onChange={e => {
-									const newValue = !isEmpty(e.target.value)
-										? validateOriginValue(e.target.value)
-										: '';
+									const newValue = getNewValueFromEmpty(
+										e,
+										validateOriginValue(xAxis),
+										getPlaceholder(xAxis)
+									);
 
 									if (!sync) {
 										changeXAxis(newValue);
@@ -678,11 +709,13 @@ const SquareControl = props => {
 								type='number'
 								placeholder={getPlaceholder(yAxis)}
 								className='maxi-transform-control__square-control__y-control__value__input'
-								value={!isNumber(yAxis) ? defaultY : yAxis}
+								value={!isNumber(yAxis) ? '' : yAxis}
 								onChange={e => {
-									const newValue = !isEmpty(e.target.value)
-										? Number(e.target.value)
-										: '';
+									const newValue = getNewValueFromEmpty(
+										e,
+										yAxis,
+										getPlaceholder(yAxis)
+									);
 
 									if (!sync) {
 										changeYAxis(newValue);
@@ -754,11 +787,13 @@ const SquareControl = props => {
 								type='number'
 								placeholder={getPlaceholder(xAxis)}
 								className='maxi-transform-control__square-control__x-control__value__input'
-								value={!isNumber(xAxis) ? defaultX : xAxis}
+								value={!isNumber(xAxis) ? '' : xAxis}
 								onChange={e => {
-									const newValue = !isEmpty(e.target.value)
-										? Number(e.target.value)
-										: '';
+									const newValue = getNewValueFromEmpty(
+										e,
+										xAxis,
+										getPlaceholder(xAxis)
+									);
 
 									if (!sync) {
 										changeXAxis(newValue);

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -502,10 +502,15 @@ const SquareControl = props => {
 						<div className='maxi-transform-control__square-control__y-control__value'>
 							<input
 								type='number'
-								placeholder={getPlaceholder(yAxis, true)}
+								placeholder={
+									!isNumber(validateOriginValue(yAxis)) &&
+									!isEmpty(validateOriginValue(yAxis))
+										? validateOriginValue(yAxis)
+										: getPlaceholder(yAxis, true)
+								}
 								className='maxi-transform-control__square-control__y-control__value__input'
 								value={
-									!isNumber(validateOriginValue(yAxis))
+									validateOriginValue(yAxis) === false
 										? ''
 										: validateOriginValue(yAxis)
 								}
@@ -621,10 +626,15 @@ const SquareControl = props => {
 						<div className='maxi-transform-control__square-control__x-control__value'>
 							<input
 								type='number'
-								placeholder={getPlaceholder(xAxis)}
+								placeholder={
+									!isNumber(validateOriginValue(xAxis)) &&
+									!isEmpty(validateOriginValue(xAxis))
+										? validateOriginValue(xAxis)
+										: getPlaceholder(xAxis, true)
+								}
 								className='maxi-transform-control__square-control__x-control__value__input'
 								value={
-									!isNumber(validateOriginValue(xAxis))
+									validateOriginValue(xAxis) === false
 										? ''
 										: validateOriginValue(xAxis)
 								}


### PR DESCRIPTION

# Description

Added default values for x and y and set the default value on square control to defaultX + defaultY instead of empty

Fixes #3950 

# How Has This Been Tested?

1. Add an icon maxi to any editor and test the transform scale X and Y.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
