### PR TITLE
Issue 3910 Undefined native WP block in breadcrumbs

### DIFF
--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -292,7 +292,7 @@ const MaxiToolbar = memo(
 									: customLabel}
 
 								<span className='toolbar-block-custom-label__block-style'>
-									{` | ${blockStyle}`}
+									{blockStyle ? ` | ${blockStyle}` : ''}
 								</span>
 								{!isFirstOnHierarchy && (
 									<span className='toolbar-more-indicator'>


### PR DESCRIPTION
When a Maxi block is inside a native WP block, the breadcrumbs show "undefined" for the native WP block.
Removed that so it doesn't show anything instead.

Fixes #3910

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Make sure "undefined" is not in the breadcrumbs when a Maxi block is inside a WP native block.

**_ Pre-Code Testing _**

-   [ ] Make sure "undefined" is not in the breadcrumbs when a Maxi block is inside a WP native block.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
