### PR TITLE
Issue 3977 Twenty Twenty icons max width

### DIFF
--- a/src/blocks/button-maxi/style.scss
+++ b/src/blocks/button-maxi/style.scss
@@ -14,6 +14,7 @@ body.maxi-blocks--active .maxi-button-block {
 		svg {
 			width: 100%;
 			height: 100%;
+			max-width: unset; //Twenty Twenty theme fix
 		}
 	}
 	&__content {


### PR DESCRIPTION
Fixed max width for icons in the Twenty Twenty theme.

Fixes #3977

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Insert a button and add an icon. Make sure the max width is unset and not 100%, and that it looks & works well.
-   [ ] Test the icon block too.

**_ Pre-Code Testing _**

-   [ ] Insert a button and add an icon. Make sure the max width is unset and not 100%, and that it looks & works well.
-   [ ] Test the icon block too.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings in console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
