### PR TITLE
Issue 3981 Popover position for small blocks

### DIFF
--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -187,6 +187,10 @@ class edit extends MaxiBlockComponent {
 						key={`popover-${uniqueID}`}
 						ref={this.blockRef}
 						isOpen={isOpen}
+						isSmall={
+							this.props.isChild ||
+							this.props.attributes['width-fit-content-general']
+						}
 						{...this.props}
 					>
 						<MaxiModal {...maxiModalProps} />

--- a/src/blocks/svg-icon-maxi/editor.scss
+++ b/src/blocks/svg-icon-maxi/editor.scss
@@ -54,3 +54,7 @@
 		margin-right: 0;
 	}
 }
+
+body.maxi-blocks--active .maxi-popover-button--small-block {
+	transform: translate(50px, 30px);
+}

--- a/src/blocks/svg-icon-maxi/editor.scss
+++ b/src/blocks/svg-icon-maxi/editor.scss
@@ -56,5 +56,5 @@
 }
 
 body.maxi-blocks--active .maxi-popover-button--small-block {
-	transform: translate(50px, 30px);
+	transform: translate(50px, 0px);
 }

--- a/src/components/maxi-popover-button/editor.scss
+++ b/src/components/maxi-popover-button/editor.scss
@@ -14,5 +14,5 @@ body.maxi-blocks--active .components-popover.maxi-popover-button {
 	}
 }
 body.maxi-blocks--active .small-block {
-	transform: translateX(36px);
+	transform: translate(50px, 30px);
 }

--- a/src/components/maxi-popover-button/editor.scss
+++ b/src/components/maxi-popover-button/editor.scss
@@ -13,6 +13,3 @@ body.maxi-blocks--active .components-popover.maxi-popover-button {
 		z-index: -1;
 	}
 }
-body.maxi-blocks--active .maxi-popover-button--small-block {
-	transform: translate(50px, 30px);
-}

--- a/src/components/maxi-popover-button/editor.scss
+++ b/src/components/maxi-popover-button/editor.scss
@@ -13,3 +13,6 @@ body.maxi-blocks--active .components-popover.maxi-popover-button {
 		z-index: -1;
 	}
 }
+body.maxi-blocks--active .small-block {
+	transform: translateX(36px);
+}

--- a/src/components/maxi-popover-button/editor.scss
+++ b/src/components/maxi-popover-button/editor.scss
@@ -13,6 +13,6 @@ body.maxi-blocks--active .components-popover.maxi-popover-button {
 		z-index: -1;
 	}
 }
-body.maxi-blocks--active .small-block {
+body.maxi-blocks--active .maxi-popover-button--small-block {
 	transform: translate(50px, 30px);
 }

--- a/src/components/maxi-popover-button/index.js
+++ b/src/components/maxi-popover-button/index.js
@@ -31,14 +31,12 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 
 	if (!isSelected || !ref.current) return null;
 
-	const smallBlock = props.isSmall ? 'maxi-popover-button--small-block' : '';
-
 	const classes = classnames(
 		'maxi-popover-button',
 		isOpen && 'maxi-popover-button--open',
 		version <= 13.0 && 'maxi-popover-button--old',
 		className,
-		smallBlock
+		props.isSmall && 'maxi-popover-button--small-block'
 	);
 
 	const boundaryElement =

--- a/src/components/maxi-popover-button/index.js
+++ b/src/components/maxi-popover-button/index.js
@@ -79,10 +79,16 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 			})),
 	};
 
+	const smallBlock =
+		props.name === 'maxi-blocks/svg-icon-maxi' &&
+		props.attributes['width-fit-content-general']
+			? 'small-block'
+			: '';
+
 	return (
 		<Popover
 			ref={popoverRef}
-			className={classes}
+			className={(classes, smallBlock)}
 			noArrow
 			animate={false}
 			focusOnMount={false}

--- a/src/components/maxi-popover-button/index.js
+++ b/src/components/maxi-popover-button/index.js
@@ -80,11 +80,13 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 	};
 
 	const smallBlock =
-		props.name === 'maxi-blocks/svg-icon-maxi' &&
-		props.attributes['width-fit-content-general']
+		(props.name === 'maxi-blocks/svg-icon-maxi' &&
+			props.attributes['width-fit-content-general']) ||
+		props.isChild
 			? 'small-block'
 			: '';
 
+	console.log(props);
 	return (
 		<Popover
 			ref={popoverRef}

--- a/src/components/maxi-popover-button/index.js
+++ b/src/components/maxi-popover-button/index.js
@@ -79,14 +79,8 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 			})),
 	};
 
-	const smallBlock =
-		(props.name === 'maxi-blocks/svg-icon-maxi' &&
-			props.attributes['width-fit-content-general']) ||
-		props.isChild
-			? 'small-block'
-			: '';
+	const smallBlock = props.isSmall ? 'maxi-popover-button--small-block' : '';
 
-	console.log(props);
 	return (
 		<Popover
 			ref={popoverRef}

--- a/src/components/maxi-popover-button/index.js
+++ b/src/components/maxi-popover-button/index.js
@@ -31,11 +31,14 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 
 	if (!isSelected || !ref.current) return null;
 
+	const smallBlock = props.isSmall ? 'maxi-popover-button--small-block' : '';
+
 	const classes = classnames(
 		'maxi-popover-button',
 		isOpen && 'maxi-popover-button--open',
 		version <= 13.0 && 'maxi-popover-button--old',
-		className
+		className,
+		smallBlock
 	);
 
 	const boundaryElement =
@@ -79,12 +82,10 @@ const MaxiPopoverButton = forwardRef((props, ref) => {
 			})),
 	};
 
-	const smallBlock = props.isSmall ? 'maxi-popover-button--small-block' : '';
-
 	return (
 		<Popover
 			ref={popoverRef}
-			className={(classes, smallBlock)}
+			className={classes}
 			noArrow
 			animate={false}
 			focusOnMount={false}


### PR DESCRIPTION
The goal is to position the popover button better for small blocks. One example is the icon block when you size it down completely. In that case, the popover button covers the icon and you can't see it.

Added a special class for the icon's popover only when the canvas width is set to fit the content.

Fixes #3981 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add an SVG and try to reproduce the issue when the popover button covers the icon.

**_ Pre-Code Testing _**

-   [ ] Add an SVG and try to reproduce the issue when the popover button covers the icon.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
