### PR TITLE
Issue 3863 - Disallow pane block inside a group

### DIFF
--- a/src/blocks/group-maxi/edit.js
+++ b/src/blocks/group-maxi/edit.js
@@ -32,6 +32,7 @@ class edit extends MaxiBlockComponent {
 					[
 						'maxi-blocks/container-maxi',
 						'maxi-blocks/column-maxi',
+						'maxi-blocks/pane-maxi',
 					].indexOf(blockName) === -1
 			);
 


### PR DESCRIPTION
Disallowed pane-maxi block in the group block.

Fixes #3863 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add a group block and try to insert the pane block inside it. 

**_ Pre-Code Testing _**

-   [ ] Add a group block and try to insert the pane block inside it. 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
