### PR TITLE
Issue3888 - selected blocks z-index

### DIFF
--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -1,8 +1,3 @@
-body.maxi-blocks--active .maxi-block__resizer .is-selected,
-.maxi-svg-icon-block.is-selected {
-	z-index: 10;
-}
-
 body.maxi-blocks--active .maxi-block__resizer {
 	.maxi-resizable {
 		&__handle {


### PR DESCRIPTION
# Description
Removed `z-index` style for selected blocks with resizer. Will need to make something with resizer's `z-index`, but with current resizer I don't see how to make it, without affecting the blocks.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3888 

# How Has This Been Tested?
Checked that the issue is fixed.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that the issue is fixed.

**_ Pre-Code Testing _**

-   [ ] Check that the issue is fixed.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
