### PR TITLE
Implement ESLint rules for `e2e-tests` folder

### DIFF
--- a/e2e-tests/.eslintrc.json
+++ b/e2e-tests/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+	"extends": ["plugin:jest/recommended"],
+	"env": {
+		"browser": true
+	},
+	"globals": {
+		"browser": "readonly",
+		"page": "readonly",
+		"wp": "readonly"
+	}
+}

--- a/e2e-tests/utils/openPreviewPage.js
+++ b/e2e-tests/utils/openPreviewPage.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undef */
+/* eslint-disable no-await-in-loop */
 /**
  * External dependencies
  */


### PR DESCRIPTION
# Description

After checking the new tool we are testing for reviewings, one of the issues is most commenting is the lack of some variables that are coming from Jest and Puppeteer which are global variables. This PR aims to tell ESLint that global variables are there and there's no need to trace them as a bug 👍 

<img width="929" alt="Captura de Pantalla 2022-12-01 a las 11 03 07" src="https://user-images.githubusercontent.com/50477222/205024387-5f4eda0e-3a03-4566-91d7-dbb5a0e61170.png">

# How Has This Been Tested?

Files like `e2e-tests/utils/openPreviewPage.js` can use the global variable `browser` without a ESLint error 👍 

# Test checklist

Just code review 👍 
