### PR TITLE
Issue 3772 - Seedlet theme: editor doesn't look the same than frontend

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -33,4 +33,8 @@
 	.maxi-text-block__content {
 		transition: color 0.3s ease;
 	}
+
+	> .maxi-block--has-link {
+		max-width: inherit;
+	}
 }


### PR DESCRIPTION
# Description

Fixes #3772 

# How To Test This?

Get the code editor from the issue and test it on master branch with Seedlet theme installed. On the frontend, it should occupy the whole screen. With this branch that shouldn't happen, and changing the width and the max-width should work correct 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Do the test commented

**_ Pre-Code Testing _**

-   [ ] Do the test commented
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
