### PR TITLE
Issue 3880 - Update `GradientPicker` to remove deprecation warn

### DIFF
--- a/e2e-tests/setup-test-framework.js
+++ b/e2e-tests/setup-test-framework.js
@@ -143,15 +143,6 @@ function observeConsoleLogging() {
 			return;
 		}
 
-		// Since 6.1 GradientPicker is deprecated. Need to be update on #3880
-		if (
-			text.includes(
-				'Outer margin styles for wp.components.GradientPicker is deprecated'
-			)
-		) {
-			return;
-		}
-
 		// Sometimes favicon is not found
 		if (message?._stackTraceLocations?.[0]?.url.includes('favicon.ico'))
 			return;

--- a/src/components/gradient-control/index.js
+++ b/src/components/gradient-control/index.js
@@ -56,6 +56,8 @@ const GradientControl = props => {
 					onChange={gradient => {
 						onChange(gradient);
 					}}
+					// Should be removed after deprecation period will end, approximately in WP 6.4
+					__nextHasNoMargin
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #3880 

# How Has This Been Tested?
Checked [GradientPicker source code](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/gradient-picker/index.js), it changes nothing for us (check where `__nextHasNoMargin` is used, it changes only UI of the component and only when `GradientPicker` has multiply gradients if I'm not wrong)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test `GradientPicker`

**_ Pre-Code Testing _**

-   [ ] Test `GradientPicker`
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
