### PR TITLE
Issue 4059 Search block icon reveal button

### DIFF
--- a/src/blocks/search-maxi/components/skin-control/index.js
+++ b/src/blocks/search-maxi/components/skin-control/index.js
@@ -37,7 +37,7 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 	return (
 		<>
 			<SelectControl
-				label={__('Skin', 'maxi-blocks')}
+				label={__('Choose', 'maxi-blocks')}
 				value={skin}
 				options={[
 					{

--- a/src/blocks/search-maxi/edit.js
+++ b/src/blocks/search-maxi/edit.js
@@ -60,7 +60,9 @@ const SearchBlock = props => {
 
 	const inputClasses = classnames(
 		'maxi-search-block__input',
-		!isInputOpen && 'maxi-search-block__input--hidden'
+		skin === 'icon-reveal' &&
+			!isInputOpen &&
+			'maxi-search-block__input--hidden'
 	);
 
 	const buttonIconClasses = classnames(

--- a/src/blocks/search-maxi/style.scss
+++ b/src/blocks/search-maxi/style.scss
@@ -53,6 +53,9 @@ body.maxi-blocks--active .maxi-search-block {
 		align-items: center;
 		z-index: 1;
 		cursor: pointer;
+		height: 100%;
+		aspect-ratio: 1 / 1;
+		justify-content: center;
 
 		&__icon {
 			box-sizing: content-box;


### PR DESCRIPTION
Added CSS `aspect-ratio` to the button to keep the width the same as the height.

An alternative, and a harder, and possibly not needed solution, would be to add width settings for the button.

Fixes #4059 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add a search block and test icon to reveal skin. Make sure the button doesn't look distorted.
-   [ ] Test the other two skins as well.

**_ Pre-Code Testing _**

-   [ ] Add a search block and test icon to reveal skin. Make sure the button doesn't look distorted.
-   [ ] Test the other two skins as well.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
