### PR TITLE
Issue 4079 - Background layers position migrator

### DIFF
--- a/src/extensions/styles/migrators/backgroundPositionMigrator.js
+++ b/src/extensions/styles/migrators/backgroundPositionMigrator.js
@@ -1,0 +1,40 @@
+const axis = ['top', 'left', 'bottom', 'right'];
+
+const positionArray = axis.map(a => `position-${a}-unit-general`);
+
+const getLayerType = layer => {
+	let { type } = layer;
+
+	if (type === 'shape') type = 'svg';
+	else type = `${type}-wrapper`;
+
+	return type;
+};
+
+const name = 'Background Position';
+
+const isEligible = blockAttributes =>
+	blockAttributes['background-layers']?.some(
+		layer =>
+			!positionArray.every(
+				unit => `background-${getLayerType(layer)}-${unit}` in layer
+			)
+	);
+
+const migrate = newAttributes => {
+	const response = { ...newAttributes };
+
+	response['background-layers'].forEach((layer, i) => {
+		const type = getLayerType(layer);
+
+		positionArray.forEach(unit => {
+			if (!(`background-${type}-${unit}` in layer))
+				response['background-layers'][i][`background-${type}-${unit}`] =
+					'px';
+		});
+	});
+
+	return response;
+};
+
+export default { name, isEligible, migrate };

--- a/src/extensions/styles/migrators/blockMigrator.js
+++ b/src/extensions/styles/migrators/blockMigrator.js
@@ -18,6 +18,7 @@ import backgroundSizeMigrator from './backgroundSizeMigrator';
 import opacityTransitionMigrator from './opacityTransitionMigrator';
 import maxiAttributesMigrator from './maxiAttributesMigrator';
 import transformIBTargetMigrator from './transformIBTargetMigrator';
+import backgroundPositionMigrator from './backgroundPositionMigrator';
 
 /**
  * External dependencies
@@ -93,6 +94,7 @@ const blockMigrator = blockMigratorProps => {
 		opacityTransitionMigrator,
 		maxiAttributesMigrator,
 		transformIBTargetMigrator,
+		backgroundPositionMigrator,
 		...(blockMigratorProps.migrators ?? []),
 	];
 


### PR DESCRIPTION
# Description

This implementation adds a new migrator that ensures position unit attributes are added on each bg layer.

Fixes #4079

# How Has This Been Tested?

To test the error on master, follow the steps suggested on the main issue. Once done that, test this branch doing different experiments:
1. Paste the code editor of the issue; a console log should appear commenting `Background Position migrator has been successfully used to update [...]` for each column, and on modifying on the layer the position values, it should work perfectly.
2. Create, in another post, a new block with background. Then copy it and paste into a new post: there shouldn't be any console log commenting `Background Position migrator has been successfully used to update [...]`


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Reproduce the commented test above

**_ Pre-Code Testing _**

-   [ ] Reproduce the commented test above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
