### PR TITLE
Issue 4085 - fix background size migrator

### DIFF
--- a/src/extensions/styles/migrators/backgroundSizeMigrator.js
+++ b/src/extensions/styles/migrators/backgroundSizeMigrator.js
@@ -2,7 +2,9 @@ const name = 'Background Size';
 
 const isEligible = blockAttributes =>
 	blockAttributes['background-layers']?.some(layer =>
-		Object.keys(layer).some(key => key.includes('size'))
+		Object.keys(layer).some(
+			key => key.includes('wrapper-size') || key.includes('svg-size')
+		)
 	);
 
 const migrate = newAttributes => {


### PR DESCRIPTION
# Description
Fixed background size migrator applying to blocks created on master
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4085

# How Has This Been Tested?
Checked that migrator doesn't apply to blocks created on master. Also checked that the migrator still works.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Add background image layer to any block on master and check that migrator doesn't apply (with the message in console).
-   [x] Check that migrator still works (group [here](https://github.com/maxi-blocks/maxi-blocks/files/9992884/code_editor.txt) should have 62% width of background).

**_ Pre-Code Testing _**

-   [ ] Add background image layer to any block on master and check that migrator doesn't apply (with the message in console).
-   [ ] Check that migrator still works (group [here](https://github.com/maxi-blocks/maxi-blocks/files/9992884/code_editor.txt) should have 62% width of background).
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
