### PR TITLE
Issue 4075 - Empty column height

### DIFF
--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -11,7 +11,7 @@
 	.block-editor-inserter {
 		display: flex;
 		width: 100%;
-		min-height: 100px;
+		min-height: 40px;
 	}
 	&__text {
 		&:empty {


### PR DESCRIPTION
Changed block inserter min height from 100px to 40px. This doesn't fix the issue completely but there might not be much we can do about this. [See the issue and comments there](https://github.com/maxi-blocks/maxi-blocks/issues/4075#issuecomment-1353027171).

If you have any ideas, share 🙏 

Fixes #4075 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that min-height for block inserted is 40px.

**_ Pre-Code Testing _**


-   [ ] Check that min-height for block inserted is 40px.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
