### PR TITLE
Issue 4104 - Button icon shape outline

### DIFF
--- a/src/editor/library/editor.scss
+++ b/src/editor/library/editor.scss
@@ -72,16 +72,6 @@
 			margin-right: 5px;
 			height: 66px;
 
-			&__icon {
-				svg {
-					stroke-width: 1;
-					stroke: #000;
-					* {
-						stroke-width: 1;
-						stroke: #000;
-					}
-				}
-			}
 			&__shape {
 				svg {
 					max-height: 100%;


### PR DESCRIPTION
Removed outline from the button icons preview.

Fixes #4104 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Add a button and insert an icon. Check that there is no black outline for the shapes. Check filled and line icons too.

**_ Pre-Code Testing _**
-   [ ] Add a button and insert an icon. Check that there is no black outline for the shapes. Check filled and line icons too.

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
