### PR TITLE
Issue 3294 - Removed duplicate fit content from column

### DIFF
--- a/src/blocks/column-maxi/inspector.js
+++ b/src/blocks/column-maxi/inspector.js
@@ -79,6 +79,7 @@ const Inspector = props => {
 										block: true,
 										hideWidth: true,
 										hideMaxWidth: true,
+										hideFit: true,
 									}),
 									...inspectorTabs.marginPadding({
 										props,

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -36,6 +36,7 @@ const FullSizeControl = props => {
 		hideHeight,
 		hideWidth,
 		hideMaxWidth,
+		hideFit,
 		prefix = '',
 		isBlockFullWidth,
 		allowForceAspectRatio = false,
@@ -116,7 +117,7 @@ const FullSizeControl = props => {
 						}
 					/>
 				))}
-			{!isBlockFullWidth && (
+			{!isBlockFullWidth && !hideFit && (
 				<ToggleSwitch
 					label={__('Set width to fit content', 'maxi-blocks')}
 					className='maxi-full-size-control__width-fit-content'

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -22,6 +22,7 @@ const size = ({
 	hideHeight = false,
 	hideWidth = false,
 	hideMaxWidth = false,
+	hideFit,
 	hideFullWidth = false,
 	isImage = false,
 }) => {
@@ -50,6 +51,7 @@ const size = ({
 				hideHeight={hideHeight}
 				hideWidth={hideWidth || isBlockFullWidth}
 				hideMaxWidth={hideMaxWidth || isBlockFullWidth}
+				hideFit={hideFit}
 				isBlockFullWidth={isBlockFullWidth}
 				allowForceAspectRatio={block}
 				showFullWidth={showFullWidth}


### PR DESCRIPTION
Removed the duplicate `fit content` option for columns.

Our only concern here was if the removed option was used in patterns. Checked with @Olekrut, and he said that we used the other option in most cases because the one we removed wasn't even working. 

Fixes #3294 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Make sure that the fit content option under height/width is removed for column, but that it's still there for row and container.

**_ Pre-Code Testing _**


-   [ ] Make sure that the fit content option under height/width is removed for column, but that it's still there for row and container.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
