### PR TITLE
Fix disabling auto value on AxisControl

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -172,7 +172,7 @@ const AdvancedNumberControl = props => {
 					label={autoLabel || __('Auto', 'maxi-blocks')}
 					className={classNameAutoInput}
 					selected={value === 'auto'}
-					onChange={val => onChangeValue(val ? 'auto' : '')}
+					onChange={val => (val ? onChangeValue('auto') : onReset())}
 				/>
 			)}
 			{value !== 'auto' && (


### PR DESCRIPTION
# Description

@Olekrut found out that, when setting a value on baseBreakpoint inside an AxisControl with `auto` support as is MarginControl, then going to smaller responsive stage, enabling `auto` and then disabling it, the value shown was incorrect. After checking, seems AdvancedNumberControl was returning directly `''` instead of resetting the value. Here's a video:


https://user-images.githubusercontent.com/50477222/209303242-99c2f561-e9a2-4223-aa17-39dd15da22ee.mp4



Fixes # (issue)

# How Has This Been Tested?

Did the same actions from the video on this implementation and the value is correct 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Follow the steps of the video and check there's a placeholder in the inputs value 👍 

**_ Pre-Code Testing _**

-   [x] Follow the steps of the video and check there's a placeholder in the inputs value 👍 
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
