### PR TITLE
Issue 4131 - Block inserter full width and height

### DIFF
--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -1,4 +1,7 @@
 .maxi-block-inserter {
+	width: 100%;
+	height: 100%;
+
 	&__text {
 		text-align: center;
 		white-space: nowrap;

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -100,6 +100,11 @@ body {
 		width: 100%;
 		height: 100%;
 		max-width: none;
+
+		.maxi-block-inserter {
+			width: 100%;
+			height: 100%;
+		}
 	}
 
 	.maxi-block .maxi-block-inserter {

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -100,11 +100,6 @@ body {
 		width: 100%;
 		height: 100%;
 		max-width: none;
-
-		.maxi-block-inserter {
-			width: 100%;
-			height: 100%;
-		}
 	}
 
 	.maxi-block .maxi-block-inserter {


### PR DESCRIPTION
Makes the inserter centred and full size of the container.

Fixes #4131 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that the inserter takes the entire area of its container in a group and columns.

**_ Pre-Code Testing _**

-   [x] Test that the inserter takes the entire area of its container in a group and columns.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
