### PR TITLE
Issue 4125 - Fix `OpacityControl` reset on responsive

### DIFF
--- a/src/blocks/container-maxi/components/shape-divider-control/index.js
+++ b/src/blocks/container-maxi/components/shape-divider-control/index.js
@@ -288,12 +288,10 @@ const ShapeDividerControl = props => {
 															attributes: props,
 														}
 													)}
-													onChange={opacity =>
-														onChange({
-															[`shape-divider-top-opacity-${breakpoint}`]:
-																opacity,
-														})
-													}
+													breakpoint={breakpoint}
+													prefix='shape-divider-top-'
+													onChange={onChange}
+													disableRTC
 												/>
 												<ColorControl
 													label={__(
@@ -497,12 +495,10 @@ const ShapeDividerControl = props => {
 															attributes: props,
 														}
 													)}
-													onChange={opacity =>
-														onChange({
-															[`shape-divider-bottom-opacity-${breakpoint}`]:
-																opacity,
-														})
-													}
+													breakpoint={breakpoint}
+													prefix='shape-divider-bottom-'
+													onChange={onChange}
+													disableRTC
 												/>
 												<ColorControl
 													label={__(

--- a/src/components/background-control/gradientLayer.js
+++ b/src/components/background-control/gradientLayer.js
@@ -10,13 +10,7 @@ import ClipPath from '../clip-path-control';
 import GradientControl from '../gradient-control';
 import ResponsiveTabsControl from '../responsive-tabs-control';
 import SizeAndPositionLayerControl from './sizeAndPositionLayerControl';
-import {
-	getDefaultAttribute,
-	getAttributeKey,
-	getLastBreakpointAttribute,
-	getGroupAttributes,
-} from '../../extensions/styles';
-import { getDefaultLayerAttr } from './utils';
+import { getGroupAttributes } from '../../extensions/styles';
 
 /**
  * External dependencies
@@ -38,52 +32,15 @@ const GradientLayerContent = props => {
 
 	const gradientOptions = cloneDeep(props.gradientOptions);
 
-	const getDefaultAttr = target => {
-		if (isLayer)
-			return getDefaultLayerAttr('colorOptions', `${prefix}${target}`);
-
-		return getDefaultAttribute(
-			getAttributeKey(target, isHover, prefix, breakpoint)
-		);
-	};
-
 	return (
 		<>
 			<GradientControl
+				{...gradientOptions}
 				label={__('Background gradient', 'maxi-blocks')}
-				gradient={getLastBreakpointAttribute({
-					target: `${prefix}background-gradient`,
-					breakpoint,
-					attributes: gradientOptions,
-					isHover,
-				})}
-				gradientOpacity={getLastBreakpointAttribute({
-					target: `${prefix}background-gradient-opacity`,
-					breakpoint,
-					attributes: gradientOptions,
-					isHover,
-				})}
-				defaultGradient={getDefaultAttr('background-gradient')}
-				onChange={val =>
-					onChange({
-						[getAttributeKey(
-							'background-gradient',
-							isHover,
-							prefix,
-							breakpoint
-						)]: val,
-					})
-				}
-				onChangeOpacity={val =>
-					onChange({
-						[getAttributeKey(
-							'background-gradient-opacity',
-							isHover,
-							prefix,
-							breakpoint
-						)]: val,
-					})
-				}
+				breakpoint={breakpoint}
+				prefix={`${prefix}background-`}
+				isHover={isHover}
+				onChange={onChange}
 			/>
 			{!disableClipPath && (
 				<ClipPath

--- a/src/components/background-control/imageLayer.js
+++ b/src/components/background-control/imageLayer.js
@@ -67,16 +67,9 @@ const ImageLayerSettings = props => {
 					attributes: imageOptions,
 					isHover,
 				})}
-				onChange={val =>
-					onChange({
-						[getAttributeKey(
-							'background-image-opacity',
-							isHover,
-							prefix,
-							breakpoint
-						)]: val,
-					})
-				}
+				prefix={`${prefix}background-image-`}
+				isHover={isHover}
+				onChange={onChange}
 				disableRTC
 			/>
 			<SelectControl

--- a/src/components/background-control/imageLayer.js
+++ b/src/components/background-control/imageLayer.js
@@ -67,6 +67,7 @@ const ImageLayerSettings = props => {
 					attributes: imageOptions,
 					isHover,
 				})}
+				breakpoint={breakpoint}
 				prefix={`${prefix}background-image-`}
 				isHover={isHover}
 				onChange={onChange}

--- a/src/components/background-control/videoLayer.js
+++ b/src/components/background-control/videoLayer.js
@@ -45,18 +45,10 @@ const VideoLayerContent = props => {
 					attributes: videoOptions,
 					isHover,
 				})}
-				onChange={opacity => {
-					videoOptions[
-						getAttributeKey(
-							'background-video-opacity',
-							isHover,
-							prefix,
-							breakpoint
-						)
-					] = opacity;
-
-					onChange(videoOptions);
-				}}
+				breakpoint={breakpoint}
+				prefix={`${prefix}background-video-`}
+				isHover={isHover}
+				onChange={onChange}
 				disableRTC
 			/>
 			<MediaUploaderControl

--- a/src/components/color-control/customColorControl.js
+++ b/src/components/color-control/customColorControl.js
@@ -81,7 +81,7 @@ const CustomColorControl = props => {
 						<OpacityControl
 							label={__('Colour opacity', 'maxi-blocks')}
 							opacity={color.a}
-							onChange={val => {
+							onChangeOpacity={val => {
 								if (!isEmpty(color)) {
 									color.a = val;
 
@@ -113,7 +113,7 @@ const CustomColorControl = props => {
 					<Icon icon={colorOpacity} />
 					<OpacityControl
 						opacity={color.a}
-						onChange={val => {
+						onChangeOpacity={val => {
 							if (!isEmpty(color)) {
 								color.a = val;
 

--- a/src/components/color-control/paletteControl.js
+++ b/src/components/color-control/paletteControl.js
@@ -134,7 +134,7 @@ const ColorPaletteControl = props => {
 				<OpacityControl
 					label={__('Colour opacity', 'maxi-blocks')}
 					opacity={globalStatus ? globalPaletteOpacity : opacity}
-					onChange={val =>
+					onChangeOpacity={val =>
 						onChange({
 							paletteOpacity: val,
 						})

--- a/src/components/gradient-control/index.js
+++ b/src/components/gradient-control/index.js
@@ -9,6 +9,10 @@ import { GradientPicker } from '@wordpress/components';
  */
 import BaseControl from '../base-control';
 import OpacityControl from '../opacity-control';
+import {
+	getAttributeKey,
+	getLastBreakpointAttribute,
+} from '../../extensions/styles';
 
 /**
  * External dependencies
@@ -27,11 +31,25 @@ const GradientControl = props => {
 	const {
 		label,
 		className,
-		gradient,
+		breakpoint,
+		prefix = '',
+		isHover = false,
 		onChange,
-		gradientOpacity,
-		onChangeOpacity,
 	} = props;
+
+	const gradient = getLastBreakpointAttribute({
+		target: `${prefix}gradient`,
+		breakpoint,
+		attributes: props,
+		isHover,
+	});
+
+	const gradientOpacity = getLastBreakpointAttribute({
+		target: `${prefix}gradient-opacity`,
+		breakpoint,
+		attributes: props,
+		isHover,
+	});
 
 	const classes = classnames('maxi-gradient-control', className);
 
@@ -48,15 +66,25 @@ const GradientControl = props => {
 			<OpacityControl
 				label={__('Gradient opacity', 'maxi-blocks')}
 				opacity={gradientOpacity}
-				onChange={val => onChangeOpacity(val)}
+				onChange={onChange}
+				breakpoint={breakpoint}
+				prefix={`${prefix}gradient-`}
+				isHover={isHover}
 				disableRTC
 			/>
 			<div className='maxi-gradient-control__gradient'>
 				<GradientPicker
 					value={gradient}
-					onChange={gradient => {
-						onChange(gradient);
-					}}
+					onChange={gradient =>
+						onChange({
+							[getAttributeKey(
+								'gradient',
+								isHover,
+								prefix,
+								breakpoint
+							)]: gradient,
+						})
+					}
 					// Should be removed after deprecation period will end, approximately in WP 6.4
 					__nextHasNoMargin
 				/>

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -663,53 +663,20 @@ const IconControl = props => {
 								))}
 							{iconBgActive === 'gradient' && (
 								<GradientControl
+									{...getGroupAttributes(
+										props,
+										'iconBackgroundGradient',
+										isHover,
+										prefix
+									)}
 									label={__(
 										'Icon Background gradient',
 										'maxi-blocks'
 									)}
-									gradient={getLastBreakpointAttribute({
-										target: `${prefix}icon-background-gradient`,
-										breakpoint,
-										attributes: props,
-										isHover,
-									})}
-									gradientOpacity={getLastBreakpointAttribute(
-										{
-											target: `${prefix}icon-background-gradient-opacity`,
-											breakpoint,
-											attributes: props,
-											isHover,
-										}
-									)}
-									defaultGradient={getDefaultAttribute(
-										getAttributeKey(
-											'background-gradient',
-											isHover,
-											`${prefix}icon-`,
-											breakpoint
-										)
-									)}
-									onChange={val =>
-										onChange({
-											[getAttributeKey(
-												'background-gradient',
-												isHover,
-												`${prefix}icon-`,
-												breakpoint
-											)]: val,
-										})
-									}
-									onChangeOpacity={val =>
-										onChange({
-											[getAttributeKey(
-												'background-gradient-opacity',
-												isHover,
-												`${prefix}icon-`,
-												breakpoint
-											)]: val,
-										})
-									}
+									breakpoint={breakpoint}
+									prefix={`${prefix}icon-background-`}
 									isHover={isHover}
+									onChange={onChange}
 								/>
 							)}
 						</>

--- a/src/components/inspector-tabs/inspector-opacity.js
+++ b/src/components/inspector-tabs/inspector-opacity.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  */
 import OpacityControl from '../opacity-control';
 import {
-	getAttributeKey,
 	getGroupAttributes,
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
@@ -16,7 +15,6 @@ import { opacity as opacityAttr } from '../../extensions/styles/defaults';
 import SettingTabsControl from '../setting-tabs-control';
 import ToggleSwitch from '../toggle-switch';
 import ManageHoverTransitions from '../manage-hover-transitions';
-import { handleOnReset } from '../../extensions/attributes';
 
 /**
  * Component
@@ -42,16 +40,8 @@ const opacity = ({ props, depth = 2 }) => {
 						content: (
 							<OpacityControl
 								opacity={normalOpacity}
-								onChange={val =>
-									maxiSetAttributes({
-										[getAttributeKey(
-											'opacity',
-											false,
-											'',
-											deviceType
-										)]: val,
-									})
-								}
+								onChange={maxiSetAttributes}
+								breakpoint={deviceType}
 							/>
 						),
 					},
@@ -85,39 +75,9 @@ const opacity = ({ props, depth = 2 }) => {
 												isHover: true,
 											}) ?? normalOpacity
 										}
-										onChange={val =>
-											maxiSetAttributes({
-												[getAttributeKey(
-													'opacity',
-													true,
-													'',
-													deviceType
-												)]: val,
-											})
-										}
-										onReset={() => {
-											maxiSetAttributes(
-												handleOnReset({
-													[getAttributeKey(
-														'opacity',
-														true,
-														'',
-														deviceType
-													)]: getLastBreakpointAttribute(
-														{
-															target: 'opacity',
-															breakpoint:
-																deviceType,
-															attributes:
-																getGroupAttributes(
-																	attributes,
-																	'opacity'
-																),
-														}
-													),
-												})
-											);
-										}}
+										onChange={maxiSetAttributes}
+										breakpoint={deviceType}
+										isHover
 									/>
 								)}
 							</>

--- a/src/components/opacity-control/index.js
+++ b/src/components/opacity-control/index.js
@@ -64,9 +64,10 @@ const OpacityControl = props => {
 			onReset={() => {
 				if (isFunction(onReset)) return onReset();
 
-				if (isNil(breakpoint)) return onChange(getDefaultAttribute());
-
 				const opacityAttributeKey = getOpacityAttributeKey();
+
+				if (isNil(breakpoint))
+					return onChange(getDefaultAttribute(opacityAttributeKey));
 				return onChange(
 					handleOnReset({
 						[opacityAttributeKey]:

--- a/src/components/opacity-control/index.js
+++ b/src/components/opacity-control/index.js
@@ -33,6 +33,7 @@ const OpacityControl = props => {
 		prefix = '',
 		isHover = false,
 		onChange,
+		onChangeOpacity,
 		onReset,
 		disableLabel = false,
 	} = props;
@@ -53,11 +54,9 @@ const OpacityControl = props => {
 			value={getIsValid(opacity, true) ? round(opacity * 100, 2) : 100}
 			onChangeValue={rawVal => {
 				const val = !isNil(rawVal) ? round(rawVal / 100, 2) : 0;
-				onChange(
-					!isNil(breakpoint)
-						? { [getOpacityAttributeKey()]: val }
-						: val
-				);
+
+				if (isFunction(onChangeOpacity)) return onChangeOpacity(val);
+				return onChange({ [getOpacityAttributeKey()]: val });
 			}}
 			min={0}
 			max={100}
@@ -66,8 +65,10 @@ const OpacityControl = props => {
 
 				const opacityAttributeKey = getOpacityAttributeKey();
 
-				if (isNil(breakpoint))
-					return onChange(getDefaultAttribute(opacityAttributeKey));
+				if (isFunction(onChangeOpacity))
+					return onChangeOpacity(
+						getDefaultAttribute(opacityAttributeKey)
+					);
 				return onChange(
 					handleOnReset({
 						[opacityAttributeKey]:

--- a/src/components/opacity-control/index.js
+++ b/src/components/opacity-control/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import withRTC from '../../extensions/maxi-block/withRTC';
  */
 import classnames from 'classnames';
 import { isEmpty, round, isNil } from 'lodash';
-import { getIsValid } from '../../extensions/styles';
+import { getDefaultAttribute, getIsValid } from '../../extensions/styles';
 
 /**
  * Component
@@ -28,6 +29,10 @@ const OpacityControl = props => {
 		onReset,
 		disableLabel = false,
 	} = props;
+
+	const { breakpoint } = useSelect(select => ({
+		breakpoint: select('maxiBlocks').receiveMaxiDeviceType(),
+	}));
 
 	const classes = classnames('maxi-opacity-control', className);
 
@@ -45,7 +50,11 @@ const OpacityControl = props => {
 			}}
 			min={0}
 			max={100}
-			onReset={() => (onReset ? onReset() : onChange(1))}
+			onReset={() =>
+				onReset
+					? onReset()
+					: onChange(getDefaultAttribute(`opacity-${breakpoint}`))
+			}
 		/>
 	);
 };

--- a/src/extensions/relations/getCanvasSettings.js
+++ b/src/extensions/relations/getCanvasSettings.js
@@ -157,9 +157,6 @@ const getCanvasSettings = ({ name, customCss }) => [
 					breakpoint: props.breakpoint,
 					attributes: getGroupAttributes(props, 'opacity'),
 				})}
-				onChange={val =>
-					props.onChange({ [`opacity-${props.breakpoint}`]: val })
-				}
 			/>
 		),
 		helper: props => getOpacityStyles(props.obj),

--- a/src/extensions/styles/defaults/iconHover.js
+++ b/src/extensions/styles/defaults/iconHover.js
@@ -1,5 +1,10 @@
 import hoverAttributesCreator from '../hoverAttributesCreator';
-import { icon, iconBackground, iconBackgroundColor } from './icon';
+import {
+	icon,
+	iconBackground,
+	iconBackgroundColor,
+	iconBackgroundGradient,
+} from './icon';
 
 export const iconHover = hoverAttributesCreator({
 	obj: icon,
@@ -38,7 +43,7 @@ export const iconBackgroundColorHover = hoverAttributesCreator({
 });
 
 export const iconBackgroundGradientHover = hoverAttributesCreator({
-	obj: iconBackgroundColor,
+	obj: iconBackgroundGradient,
 	diffValAttr: {
 		'icon-background-gradient-opacity-general-hover': 1,
 	},

--- a/src/extensions/styles/helpers/getButtonIconStyles.js
+++ b/src/extensions/styles/helpers/getButtonIconStyles.js
@@ -55,6 +55,7 @@ const getIconObject = (props, target, prefix = '', isIB) => {
 					prefix
 				),
 				prefix: `${prefix}icon-`,
+				blockStyle: props.blockStyle,
 				isIcon: true,
 			}),
 		},
@@ -185,12 +186,13 @@ const getIconHoverObject = (props, target, prefix = '', iconType = '') => {
 				...getGradientBackgroundObject({
 					...getGroupAttributes(
 						props,
-						['icon', 'iconBackgroundGradient'],
+						['icon', 'iconBackground', 'iconBackgroundGradient'],
 						true,
 						prefix
 					),
 					prefix: `${prefix}icon-`,
 					isHover: true,
+					blockStyle: props.blockStyle,
 					isIcon: true,
 				}),
 			},


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4125 

# How Has This Been Tested?
Tested `OpacityControl` responsive reset.

Places with `OpacityControl`:
- different background layers
- container-maxi shape divider
- colour control
- gradient control(made some refactor to him as well, check its work please in button-maxi icon settings(fixed hover icon gradient) and gradient bg layer normal and hover)
- opacity settings
- ib opacity

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar

**_ Pre-Code Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

