### PR TITLE
Issue 4105 - `OverflowControl`: fix behaviour on sync change and editor reload

### DIFF
--- a/src/components/overflow-control/index.js
+++ b/src/components/overflow-control/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Tooltip } from '@wordpress/components';
 
 /**
@@ -38,13 +38,17 @@ const OverflowControl = props => {
 	const axes = ['x', 'y'];
 	const [sync, changeSync] = useState(true);
 
-	const [AxisVal, setAxisVal] = useState();
+	const [axisVal, setAxisVal] = useState();
 
-	const syncOverflow = () => {
-		if (!sync) {
+	useEffect(() => {
+		setAxisVal(props[`overflow-x-${breakpoint}`]);
+	}, [breakpoint]);
+
+	const syncOverflow = newSync => {
+		if (newSync) {
 			onChange({
-				[`overflow-x-${breakpoint}`]: AxisVal,
-				[`overflow-y-${breakpoint}`]: AxisVal,
+				[`overflow-x-${breakpoint}`]: axisVal,
+				[`overflow-y-${breakpoint}`]: axisVal,
 			});
 		}
 	};
@@ -110,8 +114,9 @@ const OverflowControl = props => {
 						isPrimary={sync}
 						aria-pressed={sync}
 						onClick={() => {
-							changeSync(!sync);
-							syncOverflow();
+							const newSync = !sync;
+							changeSync(newSync);
+							syncOverflow(newSync);
 						}}
 					>
 						{syncIcon}

--- a/src/components/overflow-control/index.js
+++ b/src/components/overflow-control/index.js
@@ -53,18 +53,18 @@ const OverflowControl = props => {
 		changeSync(x === y);
 	};
 
-	const updateAxisVal = (val, changedAttributes = null) => {
-		if (!isEmpty(val)) return setAxisVal(val);
-		return setAxisVal(
-			getLastBreakpointAttribute({
-				target: 'overflow-x',
-				breakpoint,
-				attributes: changedAttributes
-					? { ...props, ...changedAttributes }
-					: props,
-			})
+	const updateAxisVal = (val, changedAttributes = null) =>
+		setAxisVal(
+			!isEmpty(val)
+				? val
+				: getLastBreakpointAttribute({
+						target: 'overflow-x',
+						breakpoint,
+						attributes: changedAttributes
+							? { ...props, ...changedAttributes }
+							: props,
+				  })
 		);
-	};
 
 	useEffect(() => {
 		updateSync();

--- a/src/components/overflow-control/index.js
+++ b/src/components/overflow-control/index.js
@@ -53,6 +53,10 @@ const OverflowControl = props => {
 		changeSync(x === y);
 	};
 
+	/**
+	 * If `val` is `null`(has been reset), get the last breakpoint attribute
+	 * from last version of `attributes`.
+	 */
 	const updateAxisVal = (val, changedAttributes = null) =>
 		setAxisVal(
 			!isEmpty(val)

--- a/src/components/overflow-control/index.js
+++ b/src/components/overflow-control/index.js
@@ -75,28 +75,29 @@ const OverflowControl = props => {
 		updateAxisVal();
 	}, [breakpoint]);
 
+	const getChangedAttributes = ({
+		val,
+		axis = null,
+		sync: currentSync = sync,
+	}) =>
+		(currentSync ? axes : [axis]).reduce((acc, axis) => {
+			acc[`overflow-${axis}-${breakpoint}`] = val;
+			return acc;
+		}, {});
+
 	const onChangeSync = val => {
 		changeSync(val);
 
-		if (val) {
-			onChange({
-				[`overflow-x-${breakpoint}`]: axisVal,
-				[`overflow-y-${breakpoint}`]: axisVal,
-			});
-		}
+		if (val) onChange(getChangedAttributes({ val: axisVal, sync: true }));
 	};
 
 	const onChangeValue = (rawValue, axis) => {
 		const isValEmpty = isEmpty(rawValue);
 		const val = !isValEmpty ? rawValue : null;
 
-		const changedAttributes = (sync ? axes : [axis]).reduce((acc, axis) => {
-			acc[`overflow-${axis}-${breakpoint}`] = val;
-			return acc;
-		}, {});
+		const changedAttributes = getChangedAttributes({ val, axis });
 
 		onChange(changedAttributes);
-
 		updateAxisVal(val, changedAttributes);
 		if (isValEmpty && sync) updateSync(changedAttributes);
 	};


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4105 

# How Has This Been Tested?
Tested how `sync` change, values, reset behave in different combinations at different breakpoints and after editor reload

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Same 1-4 points on responsive

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Check that the settings work on frontend
-   [ ] Same 1-4 points on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
