### PR TITLE
Issue 4072 - Fix box shadow reset on responsive

### DIFF
--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -105,6 +105,13 @@ const BoxShadowValueControl = props => {
 								isHover ? '-hover' : ''
 							}`
 						),
+						[`${prefix}box-shadow-${type}-unit-${breakpoint}${
+							isHover ? '-hover' : ''
+						}`]: getDefaultAttribute(
+							`${prefix}box-shadow-${type}-unit-${breakpoint}${
+								isHover ? '-hover' : ''
+							}`
+						),
 					})
 				)
 			}

--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -79,6 +79,12 @@ const BoxShadowValueControl = props => {
 				attributes: props,
 				isHover,
 			})}
+			defaultValue={getLastBreakpointAttribute({
+				target: `${prefix}box-shadow-${type}`,
+				breakpoint,
+				attributes: props,
+				isHover,
+			})}
 			onChangeValue={val => {
 				onChange({
 					[`${prefix}box-shadow-${type}-${breakpoint}${
@@ -94,7 +100,11 @@ const BoxShadowValueControl = props => {
 					handleOnReset({
 						[`${prefix}box-shadow-${type}-${breakpoint}${
 							isHover ? '-hover' : ''
-						}`]: 0,
+						}`]: getDefaultAttribute(
+							`${prefix}box-shadow-${type}-${breakpoint}${
+								isHover ? '-hover' : ''
+							}`
+						),
 					})
 				)
 			}


### PR DESCRIPTION
# Description
Fixed reset on box-shadow on responsive
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4072 

# How Has This Been Tested?
Checked box-shadow reset on responsive.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check box-shadow resets on responsive

**_ Pre-Code Testing _**

-   [ ] Check box-shadow resets on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
