### PR TITLE
Issue 4123 - Divider Maxi force canvas equal...

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -62,6 +62,12 @@ class edit extends MaxiBlockComponent {
 				attributes: this.props.attributes,
 			})}`;
 
+			const forceAspectRatio = getLastBreakpointAttribute({
+				target: 'force-aspect-ratio',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+
 			const { width: resizerWidth, height: resizerHeight } =
 				this.resizableObject.current.state;
 
@@ -71,7 +77,7 @@ class edit extends MaxiBlockComponent {
 			) {
 				this.resizableObject.current.updateSize({
 					width: width ? `${width}${widthUnit}` : '100%',
-					height,
+					height: forceAspectRatio ? 'auto' : height,
 				});
 			}
 		}
@@ -81,6 +87,12 @@ class edit extends MaxiBlockComponent {
 		const { attributes, deviceType, isSelected, maxiSetAttributes } =
 			this.props;
 		const { uniqueID, lineOrientation } = attributes;
+
+		const forceAspectRatio = getLastBreakpointAttribute({
+			target: 'force-aspect-ratio',
+			breakpoint: deviceType,
+			attributes,
+		});
 
 		const classes = classnames(
 			lineOrientation === 'vertical'
@@ -161,7 +173,7 @@ class edit extends MaxiBlockComponent {
 				}}
 				showHandle={isSelected}
 				enable={{
-					bottom: true,
+					bottom: !forceAspectRatio,
 				}}
 				onResizeStart={handleOnResizeStart}
 				onResizeStop={handleOnResizeStop}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

[Disabled resizeable on force aspect ratio and set height to auto](https://github.com/maxi-blocks/maxi-blocks/commit/d60a8c896525b4ae6cf00c5a0b5a94e8703c02a3)

Fixes #4123 

# How Has This Been Tested?

- Created a divider maxi in a container and check that setting force aspect ratio is setting the height and width equal and that I am not able to resize
- Check that resizing still works after toggling off the force aspect ratio button and that it keeps the height that it had before

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
