### PR TITLE
Issue 4128 - accordion with transform

### DIFF
--- a/src/blocks/accordion-maxi/data.js
+++ b/src/blocks/accordion-maxi/data.js
@@ -47,6 +47,10 @@ const copyPasteMapping = {
 		template: 'advanced',
 	},
 };
+
+const normalPaneTarget = '.maxi-pane-block[aria-expanded]';
+const activePaneTarget = '.maxi-pane-block[aria-expanded=true]';
+
 const customCss = {
 	selectors: {
 		...createSelectors({
@@ -55,117 +59,117 @@ const customCss = {
 		'pane header': {
 			normal: {
 				label: 'pane header',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header`,
 			},
 			hover: {
 				label: 'pane header on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header:hover`,
 			},
 			active: {
 				label: 'pane header on active state',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__header',
+				target: ` ${activePaneTarget} .maxi-pane-block__header`,
 			},
 		},
 		'pane header content': {
 			normal: {
 				label: 'header content',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header-content',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header-content`,
 			},
 			hover: {
 				label: 'header content on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header-content:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header-content:hover`,
 			},
 			active: {
 				label: 'header content on active state',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__header-content',
+				target: ` ${activePaneTarget} .maxi-pane-block__header-content`,
 			},
 		},
 		'pane header line': {
 			normal: {
 				label: 'header line',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header-line',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header-line`,
 			},
 			hover: {
 				label: 'header line on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__header-line:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__header-line:hover`,
 			},
 			active: {
 				label: 'header line on active state',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__header-line',
+				target: ` ${activePaneTarget} .maxi-pane-block__header-line`,
 			},
 		},
 		'pane content line': {
 			normal: {
 				label: 'content line',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__content-line',
+				target: ` ${normalPaneTarget} .maxi-pane-block__content-line`,
 			},
 			hover: {
 				label: 'content line on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__content-line:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__content-line:hover`,
 			},
 			active: {
 				label: 'content line on active state',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__content-line',
+				target: ` ${activePaneTarget} .maxi-pane-block__content-line`,
 			},
 		},
 		'pane icon': {
 			normal: {
 				label: 'icon',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon`,
 			},
 			svg: {
 				label: "icon's svg",
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon svg`,
 			},
 			insideSvg: {
 				label: 'everything inside svg (svg > *)',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg > *',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon svg > *`,
 			},
 			path: {
 				label: "svg's path",
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg path',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon svg path`,
 			},
 			hover: {
 				label: 'icon on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon:hover`,
 			},
 			hoverSvg: {
 				label: "icon's svg on hover",
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon:hover svg`,
 			},
 			hoverInsideSvg: {
 				label: 'everything inside svg on hover (:hover svg > *)',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg > *',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon:hover svg > *`,
 			},
 			hoverPath: {
 				label: "svg's path on hover",
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg path',
+				target: ` ${normalPaneTarget} .maxi-pane-block__icon:hover svg path`,
 			},
 			active: {
 				label: 'active icon',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon',
+				target: ` ${activePaneTarget} .maxi-pane-block__icon`,
 			},
 			activeSvg: {
 				label: "active icon's svg",
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg',
+				target: ` ${activePaneTarget} .maxi-pane-block__icon svg`,
 			},
 			activeInsideSvg: {
 				label: 'everything inside active svg (svg > *)',
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg > *',
+				target: ` ${activePaneTarget} .maxi-pane-block__icon svg > *`,
 			},
 			activePath: {
 				label: "active svg's path",
-				target: ' .maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg path',
+				target: ` ${activePaneTarget} .maxi-pane-block__icon svg path`,
 			},
 		},
 		'pane content': {
 			normal: {
 				label: 'pane content',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__content',
+				target: ` ${normalPaneTarget} .maxi-pane-block__content`,
 			},
 			hover: {
 				label: 'pane content on hover',
-				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__content:hover',
+				target: ` ${normalPaneTarget} .maxi-pane-block__content:hover`,
 			},
 		},
 	},

--- a/src/blocks/accordion-maxi/data.js
+++ b/src/blocks/accordion-maxi/data.js
@@ -5,6 +5,7 @@ import { createSelectors } from '../../extensions/styles/custom-css';
 import { createIconTransitions } from '../../extensions/styles';
 import { getCanvasSettings } from '../../extensions/relations';
 import transitionDefault from '../../extensions/styles/transitions/transitionDefault';
+import { targets as paneTargets } from '../pane-maxi/data';
 
 /**
  * Data object
@@ -48,8 +49,7 @@ const copyPasteMapping = {
 	},
 };
 
-const normalPaneTarget = '.maxi-pane-block[aria-expanded]';
-const activePaneTarget = '.maxi-pane-block[aria-expanded=true]';
+const { normalPaneTarget, activePaneTarget } = paneTargets;
 
 const customCss = {
 	selectors: {

--- a/src/blocks/accordion-maxi/data.js
+++ b/src/blocks/accordion-maxi/data.js
@@ -111,19 +111,19 @@ const customCss = {
 		'pane icon': {
 			normal: {
 				label: 'icon',
-				target: ' .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon',
+				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon',
 			},
 			svg: {
 				label: "icon's svg",
-				target: ' .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg',
+				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg',
 			},
 			insideSvg: {
 				label: 'everything inside svg (svg > *)',
-				target: ' .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg > *',
+				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg > *',
 			},
 			path: {
 				label: "svg's path",
-				target: ' .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg path',
+				target: ' .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg path',
 			},
 			hover: {
 				label: 'icon on hover',

--- a/src/blocks/pane-maxi/data.js
+++ b/src/blocks/pane-maxi/data.js
@@ -153,19 +153,19 @@ const customCss = {
 		icon: {
 			normal: {
 				label: 'icon',
-				target: '[aria-expanded=false] .maxi-pane-block__icon',
+				target: '[aria-expanded] .maxi-pane-block__icon',
 			},
 			svg: {
 				label: "icon's svg",
-				target: '[aria-expanded=false] .maxi-pane-block__icon svg',
+				target: '[aria-expanded] .maxi-pane-block__icon svg',
 			},
 			insideSvg: {
 				label: 'everything inside svg (svg > *)',
-				target: '[aria-expanded=false] .maxi-pane-block__icon svg > *',
+				target: '[aria-expanded] .maxi-pane-block__icon svg > *',
 			},
 			path: {
 				label: "svg's path",
-				target: '[aria-expanded=false] .maxi-pane-block__icon svg path',
+				target: '[aria-expanded] .maxi-pane-block__icon svg path',
 			},
 			hover: {
 				label: 'icon on hover',

--- a/src/blocks/pane-maxi/data.js
+++ b/src/blocks/pane-maxi/data.js
@@ -54,6 +54,11 @@ const copyPasteMapping = {
 const normalPaneTarget = '.maxi-pane-block[aria-expanded]';
 const activePaneTarget = '.maxi-pane-block[aria-expanded=true]';
 
+const targets = {
+	normalPaneTarget,
+	activePaneTarget,
+};
+
 const customCss = {
 	selectors: {
 		pane: {
@@ -304,5 +309,11 @@ const data = {
 	interactionBuilderSettings,
 };
 
-export { copyPasteMapping, customCss, transition, interactionBuilderSettings };
+export {
+	copyPasteMapping,
+	customCss,
+	transition,
+	interactionBuilderSettings,
+	targets,
+};
 export default data;

--- a/src/blocks/pane-maxi/data.js
+++ b/src/blocks/pane-maxi/data.js
@@ -50,6 +50,10 @@ const copyPasteMapping = {
 		template: 'advanced',
 	},
 };
+
+const normalPaneTarget = '.maxi-pane-block[aria-expanded]';
+const activePaneTarget = '.maxi-pane-block[aria-expanded=true]';
+
 const customCss = {
 	selectors: {
 		pane: {
@@ -63,7 +67,7 @@ const customCss = {
 			},
 			active: {
 				label: 'pane on active state',
-				target: '[aria-expanded="true"]',
+				target: activePaneTarget,
 			},
 		},
 		'before pane': {
@@ -77,7 +81,7 @@ const customCss = {
 			},
 			active: {
 				label: 'pane ::before on active state',
-				target: '[aria-expanded="true"]::before',
+				target: `${activePaneTarget}::before`,
 			},
 		},
 		'after pane': {
@@ -91,123 +95,123 @@ const customCss = {
 			},
 			active: {
 				label: 'pane ::after on active state',
-				target: '[aria-expanded="true"]::after',
+				target: `${activePaneTarget}::after`,
 			},
 		},
 		header: {
 			normal: {
 				label: 'pane header',
-				target: '[aria-expanded] .maxi-pane-block__header',
+				target: `${normalPaneTarget} .maxi-pane-block__header`,
 			},
 			hover: {
 				label: 'pane header on hover',
-				target: '[aria-expanded] .maxi-pane-block__header:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__header:hover`,
 			},
 			active: {
 				label: 'pane header on active state',
-				target: '[aria-expanded=true] .maxi-pane-block__header',
+				target: `${activePaneTarget} .maxi-pane-block__header`,
 			},
 		},
 		'header content': {
 			normal: {
 				label: 'header content',
-				target: '[aria-expanded] .maxi-pane-block__header-content',
+				target: `${normalPaneTarget} .maxi-pane-block__header-content`,
 			},
 			hover: {
 				label: 'header content on hover',
-				target: '[aria-expanded] .maxi-pane-block__header-content:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__header-content:hover`,
 			},
 			active: {
 				label: 'header content on active state',
-				target: '[aria-expanded=true] .maxi-pane-block__header-content',
+				target: `${activePaneTarget} .maxi-pane-block__header-content`,
 			},
 		},
 		'header line': {
 			normal: {
 				label: 'header line',
-				target: '[aria-expanded] .maxi-pane-block__header-line',
+				target: `${normalPaneTarget} .maxi-pane-block__header-line`,
 			},
 			hover: {
 				label: 'header line on hover',
-				target: '[aria-expanded] .maxi-pane-block__header-line:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__header-line:hover`,
 			},
 			active: {
 				label: 'header line on active state',
-				target: '[aria-expanded=true] .maxi-pane-block__header-line',
+				target: `${activePaneTarget} .maxi-pane-block__header-line`,
 			},
 		},
 		'content line': {
 			normal: {
 				label: 'content line',
-				target: '[aria-expanded] .maxi-pane-block__content-line',
+				target: `${normalPaneTarget} .maxi-pane-block__content-line`,
 			},
 			hover: {
 				label: 'content line on hover',
-				target: '[aria-expanded] .maxi-pane-block__content-line:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__content-line:hover`,
 			},
 			active: {
 				label: 'content line on active state',
-				target: '[aria-expanded=true] .maxi-pane-block__content-line',
+				target: `${activePaneTarget} .maxi-pane-block__content-line`,
 			},
 		},
 		icon: {
 			normal: {
 				label: 'icon',
-				target: '[aria-expanded] .maxi-pane-block__icon',
+				target: `${normalPaneTarget} .maxi-pane-block__icon`,
 			},
 			svg: {
 				label: "icon's svg",
-				target: '[aria-expanded] .maxi-pane-block__icon svg',
+				target: `${normalPaneTarget} .maxi-pane-block__icon svg`,
 			},
 			insideSvg: {
 				label: 'everything inside svg (svg > *)',
-				target: '[aria-expanded] .maxi-pane-block__icon svg > *',
+				target: `${normalPaneTarget} .maxi-pane-block__icon svg > *`,
 			},
 			path: {
 				label: "svg's path",
-				target: '[aria-expanded] .maxi-pane-block__icon svg path',
+				target: `${normalPaneTarget} .maxi-pane-block__icon svg path`,
 			},
 			hover: {
 				label: 'icon on hover',
-				target: '[aria-expanded] .maxi-pane-block__icon:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__icon:hover`,
 			},
 			hoverSvg: {
 				label: "icon's svg on hover",
-				target: '[aria-expanded] .maxi-pane-block__icon:hover svg',
+				target: `${normalPaneTarget} .maxi-pane-block__icon:hover svg`,
 			},
 			hoverInsideSvg: {
 				label: 'everything inside svg on hover (:hover svg > *)',
-				target: '[aria-expanded] .maxi-pane-block__icon:hover svg > *',
+				target: `${normalPaneTarget} .maxi-pane-block__icon:hover svg > *`,
 			},
 			hoverPath: {
 				label: "svg's path on hover",
-				target: '[aria-expanded] .maxi-pane-block__icon:hover svg path',
+				target: `${normalPaneTarget} .maxi-pane-block__icon:hover svg path`,
 			},
 			active: {
 				label: 'active icon',
-				target: '[aria-expanded=true] .maxi-pane-block__icon',
+				target: `${activePaneTarget} .maxi-pane-block__icon`,
 			},
 			activeSvg: {
 				label: "active icon's svg",
-				target: '[aria-expanded=true] .maxi-pane-block__icon svg',
+				target: `${activePaneTarget} .maxi-pane-block__icon svg`,
 			},
 			activeInsideSvg: {
 				label: 'everything inside active svg (svg > *)',
-				target: '[aria-expanded=true] .maxi-pane-block__icon svg > *',
+				target: `${activePaneTarget} .maxi-pane-block__icon svg > *`,
 			},
 			activePath: {
 				label: "active svg's path",
-				target: '[aria-expanded=true] .maxi-pane-block__icon svg path',
+				target: `${activePaneTarget} .maxi-pane-block__icon svg path`,
 			},
 		},
 		content: {
 			normal: {
 				label: 'pane content',
-				target: '[aria-expanded] .maxi-pane-block__content',
+				target: `${normalPaneTarget} .maxi-pane-block__content`,
 			},
 			hover: {
 				label: 'pane content on hover',
-				target: '[aria-expanded] .maxi-pane-block__content:hover',
+				target: `${normalPaneTarget} .maxi-pane-block__content:hover`,
 			},
 		},
 	},

--- a/src/extensions/styles/migrators/test/__snapshots__/utils.js.snap
+++ b/src/extensions/styles/migrators/test/__snapshots__/utils.js.snap
@@ -137,19 +137,19 @@ Object {
     },
     "insideSvg": Object {
       "label": "everything inside svg (svg > *)",
-      "target": " .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg > *",
+      "target": " .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg > *",
     },
     "normal": Object {
       "label": "icon",
-      "target": " .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon",
+      "target": " .maxi-pane-block[aria-expanded] .maxi-pane-block__icon",
     },
     "path": Object {
       "label": "svg's path",
-      "target": " .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg path",
+      "target": " .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg path",
     },
     "svg": Object {
       "label": "icon's svg",
-      "target": " .maxi-pane-block[aria-expanded=false] .maxi-pane-block__icon svg",
+      "target": " .maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg",
     },
   },
 }
@@ -714,7 +714,7 @@ Object {
   "after pane": Object {
     "active": Object {
       "label": "pane ::after on active state",
-      "target": "[aria-expanded=\\"true\\"]::after",
+      "target": ".maxi-pane-block[aria-expanded=true]::after",
     },
     "hover": Object {
       "label": "pane ::after on hover",
@@ -728,7 +728,7 @@ Object {
   "before pane": Object {
     "active": Object {
       "label": "pane ::before on active state",
-      "target": "[aria-expanded=\\"true\\"]::before",
+      "target": ".maxi-pane-block[aria-expanded=true]::before",
     },
     "hover": Object {
       "label": "pane ::before on hover",
@@ -742,123 +742,123 @@ Object {
   "content": Object {
     "hover": Object {
       "label": "pane content on hover",
-      "target": "[aria-expanded] .maxi-pane-block__content:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__content:hover",
     },
     "normal": Object {
       "label": "pane content",
-      "target": "[aria-expanded] .maxi-pane-block__content",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__content",
     },
   },
   "content line": Object {
     "active": Object {
       "label": "content line on active state",
-      "target": "[aria-expanded=true] .maxi-pane-block__content-line",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__content-line",
     },
     "hover": Object {
       "label": "content line on hover",
-      "target": "[aria-expanded] .maxi-pane-block__content-line:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__content-line:hover",
     },
     "normal": Object {
       "label": "content line",
-      "target": "[aria-expanded] .maxi-pane-block__content-line",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__content-line",
     },
   },
   "header": Object {
     "active": Object {
       "label": "pane header on active state",
-      "target": "[aria-expanded=true] .maxi-pane-block__header",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__header",
     },
     "hover": Object {
       "label": "pane header on hover",
-      "target": "[aria-expanded] .maxi-pane-block__header:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header:hover",
     },
     "normal": Object {
       "label": "pane header",
-      "target": "[aria-expanded] .maxi-pane-block__header",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header",
     },
   },
   "header content": Object {
     "active": Object {
       "label": "header content on active state",
-      "target": "[aria-expanded=true] .maxi-pane-block__header-content",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__header-content",
     },
     "hover": Object {
       "label": "header content on hover",
-      "target": "[aria-expanded] .maxi-pane-block__header-content:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header-content:hover",
     },
     "normal": Object {
       "label": "header content",
-      "target": "[aria-expanded] .maxi-pane-block__header-content",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header-content",
     },
   },
   "header line": Object {
     "active": Object {
       "label": "header line on active state",
-      "target": "[aria-expanded=true] .maxi-pane-block__header-line",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__header-line",
     },
     "hover": Object {
       "label": "header line on hover",
-      "target": "[aria-expanded] .maxi-pane-block__header-line:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header-line:hover",
     },
     "normal": Object {
       "label": "header line",
-      "target": "[aria-expanded] .maxi-pane-block__header-line",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__header-line",
     },
   },
   "icon": Object {
     "active": Object {
       "label": "active icon",
-      "target": "[aria-expanded=true] .maxi-pane-block__icon",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon",
     },
     "activeInsideSvg": Object {
       "label": "everything inside active svg (svg > *)",
-      "target": "[aria-expanded=true] .maxi-pane-block__icon svg > *",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg > *",
     },
     "activePath": Object {
       "label": "active svg's path",
-      "target": "[aria-expanded=true] .maxi-pane-block__icon svg path",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg path",
     },
     "activeSvg": Object {
       "label": "active icon's svg",
-      "target": "[aria-expanded=true] .maxi-pane-block__icon svg",
+      "target": ".maxi-pane-block[aria-expanded=true] .maxi-pane-block__icon svg",
     },
     "hover": Object {
       "label": "icon on hover",
-      "target": "[aria-expanded] .maxi-pane-block__icon:hover",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover",
     },
     "hoverInsideSvg": Object {
       "label": "everything inside svg on hover (:hover svg > *)",
-      "target": "[aria-expanded] .maxi-pane-block__icon:hover svg > *",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg > *",
     },
     "hoverPath": Object {
       "label": "svg's path on hover",
-      "target": "[aria-expanded] .maxi-pane-block__icon:hover svg path",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg path",
     },
     "hoverSvg": Object {
       "label": "icon's svg on hover",
-      "target": "[aria-expanded] .maxi-pane-block__icon:hover svg",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon:hover svg",
     },
     "insideSvg": Object {
       "label": "everything inside svg (svg > *)",
-      "target": "[aria-expanded=false] .maxi-pane-block__icon svg > *",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg > *",
     },
     "normal": Object {
       "label": "icon",
-      "target": "[aria-expanded=false] .maxi-pane-block__icon",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon",
     },
     "path": Object {
       "label": "svg's path",
-      "target": "[aria-expanded=false] .maxi-pane-block__icon svg path",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg path",
     },
     "svg": Object {
       "label": "icon's svg",
-      "target": "[aria-expanded=false] .maxi-pane-block__icon svg",
+      "target": ".maxi-pane-block[aria-expanded] .maxi-pane-block__icon svg",
     },
   },
   "pane": Object {
     "active": Object {
       "label": "pane on active state",
-      "target": "[aria-expanded=\\"true\\"]",
+      "target": ".maxi-pane-block[aria-expanded=true]",
     },
     "hover": Object {
       "label": "pane on hover",


### PR DESCRIPTION
# Description
 - Made normal icon transform styles apply on active icon.
 - Made pane's `customCss` targets more specific so that styles from pane apply over styles from accordion.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4128 

# How Has This Been Tested?
Checked that transform styles for icon apply for active state, and checked that pane transform styles apply over the accordion ones.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that transform styles for icon apply for active state
-   [x] Check that pane transform styles apply over the accordion ones.

**_ Pre-Code Testing _**

-   [ ] Check that transform styles for icon apply for active state
-   [ ] Check that pane transform styles apply over the accordion ones.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
