### PR TITLE
Issue 4099 - Typography attributes incorrect inherit on responsive if only xl(base), xxl are set

### DIFF
--- a/src/extensions/text/formats/getTypographyValue.js
+++ b/src/extensions/text/formats/getTypographyValue.js
@@ -69,6 +69,8 @@ const getTypographyValue = ({
 		textLevel,
 		styleCard,
 		styleCardPrefix,
+		avoidXXL,
+		avoidSC,
 	});
 
 	if (hoverValue || isBoolean(hoverValue) || isNumber(hoverValue))

--- a/src/extensions/text/formats/getTypographyValue.js
+++ b/src/extensions/text/formats/getTypographyValue.js
@@ -15,7 +15,6 @@ const getTypographyValue = ({
 	breakpoint,
 	typography,
 	isHover,
-	avoidXXL = true,
 	formatValue,
 	textLevel,
 	styleCard,
@@ -29,7 +28,6 @@ const getTypographyValue = ({
 			breakpoint,
 			attributes: typography,
 			isHover,
-			avoidXXL,
 		});
 
 	const nonHoverValue =
@@ -41,7 +39,7 @@ const getTypographyValue = ({
 			textLevel,
 			styleCard,
 			styleCardPrefix,
-			avoidXXL,
+			avoidXXL: true,
 			avoidSC,
 		}) ??
 		// In cases like HoverEffectControl, where we want the SC 'p' value
@@ -54,7 +52,7 @@ const getTypographyValue = ({
 			textLevel,
 			styleCard,
 			styleCardPrefix,
-			avoidXXL,
+			avoidXXL: true,
 			avoidSC,
 		});
 
@@ -69,7 +67,7 @@ const getTypographyValue = ({
 		textLevel,
 		styleCard,
 		styleCardPrefix,
-		avoidXXL,
+		avoidXXL: true,
 		avoidSC,
 	});
 

--- a/src/extensions/text/formats/getTypographyValue.js
+++ b/src/extensions/text/formats/getTypographyValue.js
@@ -15,7 +15,7 @@ const getTypographyValue = ({
 	breakpoint,
 	typography,
 	isHover,
-	avoidXXL,
+	avoidXXL = true,
 	formatValue,
 	textLevel,
 	styleCard,


### PR DESCRIPTION
# Description

Changes:
- removed `avoidXXL` param from `getTypographyValue`(checked, it's not used anywhere in arguments)
- added `avoidXXL: true, avoidSC` from `getTypographyValue` `hoverValue`

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4099

# How Has This Been Tested?
Ensure that my base breakpoint - `xl`, reproduced the video from the issue.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Reproduce the video and check if you have a correct result
-   [x] Reproduce the video, but in hover state, and check if you have a correct result
-   [x] Check XXL and other attributes interaction stays right

**_ Pre-Code Testing _**

-   [ ] Reproduce the video and check if you have a correct result
-   [ ] Reproduce the video, but in hover state, and check if you have a correct result
-   [ ] Check XXL and other attributes interaction stays right
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
