### PR TITLE
Issue 4171- Removed inset from divider

### DIFF
--- a/src/blocks/divider-maxi/inspector.js
+++ b/src/blocks/divider-maxi/inspector.js
@@ -262,6 +262,7 @@ const Inspector = props => {
 									...inspectorTabs.boxShadow({
 										props,
 										prefix: 'divider-',
+										disableInset: true,
 									}),
 								]}
 							/>

--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -2,6 +2,7 @@
  * Wordpress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -217,6 +218,11 @@ const BoxShadowControl = props => {
 		className
 	);
 
+	const { getSelectedBlockClientId, getBlockName } =
+		select('core/block-editor');
+
+	const currentBlockName = getBlockName(getSelectedBlockClientId());
+
 	return (
 		<div className={classes}>
 			<DefaultStylesControl
@@ -355,24 +361,25 @@ const BoxShadowControl = props => {
 			/>
 			{!isToolbar && (
 				<>
-					{!dropShadow && (
-						<ToggleSwitch
-							label={__('Inset', 'maxi-block')}
-							selected={getLastBreakpointAttribute({
-								target: `${prefix}box-shadow-inset`,
-								breakpoint,
-								attributes: props,
-								isHover,
-							})}
-							onChange={val =>
-								onChange({
-									[`${prefix}box-shadow-inset-${breakpoint}${
-										isHover ? '-hover' : ''
-									}`]: val,
-								})
-							}
-						/>
-					)}
+					{!dropShadow &&
+						currentBlockName !== 'maxi-blocks/divider-maxi' && (
+							<ToggleSwitch
+								label={__('Inset', 'maxi-block')}
+								selected={getLastBreakpointAttribute({
+									target: `${prefix}box-shadow-inset`,
+									breakpoint,
+									attributes: props,
+									isHover,
+								})}
+								onChange={val =>
+									onChange({
+										[`${prefix}box-shadow-inset-${breakpoint}${
+											isHover ? '-hover' : ''
+										}`]: val,
+									})
+								}
+							/>
+						)}
 					{boxShadowItems.map(type => (
 						<BoxShadowValueControl
 							type={type}

--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -2,7 +2,6 @@
  * Wordpress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,7 +21,6 @@ import {
 	getLastBreakpointAttribute,
 	getDefaultAttribute,
 } from '../../extensions/styles';
-import { getActiveTabName } from '../../extensions/inspector';
 
 /**
  * External dependencies
@@ -152,6 +150,7 @@ const BoxShadowControl = props => {
 		prefix = '',
 		clientId,
 		dropShadow = false,
+		disableInset = false,
 	} = props;
 
 	const boxShadowItems = ['horizontal', 'vertical', 'blur'];
@@ -218,11 +217,6 @@ const BoxShadowControl = props => {
 		isNone && 'maxi-shadow-control--disable',
 		className
 	);
-
-	const { getSelectedBlockClientId, getBlockName } =
-		select('core/block-editor');
-
-	const currentBlockName = getBlockName(getSelectedBlockClientId());
 
 	return (
 		<div className={classes}>
@@ -362,10 +356,7 @@ const BoxShadowControl = props => {
 			/>
 			{!isToolbar && (
 				<>
-					{((!dropShadow &&
-						currentBlockName !== 'maxi-blocks/divider-maxi') ||
-						(currentBlockName === 'maxi-blocks/divider-maxi' &&
-							getActiveTabName(0) !== 'Settings')) && (
+					{!dropShadow && !disableInset && (
 						<ToggleSwitch
 							label={__('Inset', 'maxi-block')}
 							selected={getLastBreakpointAttribute({

--- a/src/components/box-shadow-control/index.js
+++ b/src/components/box-shadow-control/index.js
@@ -22,6 +22,7 @@ import {
 	getLastBreakpointAttribute,
 	getDefaultAttribute,
 } from '../../extensions/styles';
+import { getActiveTabName } from '../../extensions/inspector';
 
 /**
  * External dependencies
@@ -361,25 +362,27 @@ const BoxShadowControl = props => {
 			/>
 			{!isToolbar && (
 				<>
-					{!dropShadow &&
-						currentBlockName !== 'maxi-blocks/divider-maxi' && (
-							<ToggleSwitch
-								label={__('Inset', 'maxi-block')}
-								selected={getLastBreakpointAttribute({
-									target: `${prefix}box-shadow-inset`,
-									breakpoint,
-									attributes: props,
-									isHover,
-								})}
-								onChange={val =>
-									onChange({
-										[`${prefix}box-shadow-inset-${breakpoint}${
-											isHover ? '-hover' : ''
-										}`]: val,
-									})
-								}
-							/>
-						)}
+					{((!dropShadow &&
+						currentBlockName !== 'maxi-blocks/divider-maxi') ||
+						(currentBlockName === 'maxi-blocks/divider-maxi' &&
+							getActiveTabName(0) !== 'Settings')) && (
+						<ToggleSwitch
+							label={__('Inset', 'maxi-block')}
+							selected={getLastBreakpointAttribute({
+								target: `${prefix}box-shadow-inset`,
+								breakpoint,
+								attributes: props,
+								isHover,
+							})}
+							onChange={val =>
+								onChange({
+									[`${prefix}box-shadow-inset-${breakpoint}${
+										isHover ? '-hover' : ''
+									}`]: val,
+								})
+							}
+						/>
+					)}
 					{boxShadowItems.map(type => (
 						<BoxShadowValueControl
 							type={type}

--- a/src/components/inspector-tabs/inspector-box-shadow.js
+++ b/src/components/inspector-tabs/inspector-box-shadow.js
@@ -25,6 +25,7 @@ const boxShadow = ({
 	inlineTarget = '',
 	dropShadow,
 	enableActiveState = false,
+	disableInset,
 }) => {
 	const {
 		attributes,
@@ -67,6 +68,7 @@ const boxShadow = ({
 								breakpoint={deviceType}
 								clientId={clientId}
 								dropShadow={dropShadow}
+								disableInset={disableInset}
 							/>
 						),
 					},
@@ -123,6 +125,7 @@ const boxShadow = ({
 										isHover
 										clientId={clientId}
 										dropShadow={dropShadow}
+										disableInset={disableInset}
 									/>
 								)}
 							</>
@@ -160,6 +163,7 @@ const boxShadow = ({
 										breakpoint={deviceType}
 										clientId={clientId}
 										dropShadow={dropShadow}
+										disableInset={disableInset}
 									/>
 								)}
 							</>

--- a/src/components/toolbar/components/box-shadow/index.js
+++ b/src/components/toolbar/components/box-shadow/index.js
@@ -34,6 +34,7 @@ const BoxShadow = props => {
 		clientId,
 		prefix = '',
 		dropShadow,
+		disableInset,
 	} = props;
 
 	if (!ALLOWED_BLOCKS.includes(blockName)) return null;
@@ -56,6 +57,7 @@ const BoxShadow = props => {
 					prefix={prefix}
 					isToolbar
 					dropShadow={dropShadow}
+					disableInset={disableInset}
 				/>
 			</div>
 		</ToolbarPopover>

--- a/src/components/toolbar/index.js
+++ b/src/components/toolbar/index.js
@@ -101,6 +101,7 @@ const MaxiToolbar = memo(
 			copyPasteMapping,
 			mediaPrefix,
 			dropShadow,
+			disableInset,
 		} = props;
 		const {
 			customLabel,
@@ -554,6 +555,7 @@ const MaxiToolbar = memo(
 							breakpoint={breakpoint}
 							prefix={prefix}
 							dropShadow={dropShadow}
+							disableInset={disableInset}
 						/>
 						<ToolbarColumnPattern
 							clientId={clientId}


### PR DESCRIPTION
Removed the `inset` box shadow option for the divider block.

Fixes #4171 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that there's no inset option under box-shadow for `divider`.
-   [ ] Test that the option is still there for other blocks.

**_ Pre-Code Testing _**

-   [ ] Test that there's no inset option under box-shadow for `divider`.
-   [ ] Test that the option is still there for other blocks.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
