### PR TITLE
Issue 4171 - Image overflow target

### DIFF
--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -213,6 +213,15 @@ const getHoverEffectContentTextObject = props => {
 	return response;
 };
 
+const getImageOverflow = props => {
+	const response = {
+		overflow: getOverflowStyles({
+			...getGroupAttributes(props, 'overflow'),
+		}),
+	};
+
+	return response;
+};
 const getImageWrapperObject = props => {
 	const response = {
 		alignment: getAlignmentFlexStyles({
@@ -505,7 +514,7 @@ const getStyles = props => {
 	const response = {
 		[uniqueID]: styleProcessor(
 			{
-				'': getWrapperObject(props),
+				'': { ...getWrapperObject(props), ...getImageOverflow(props) },
 				':hover': getHoverWrapperObject(props),
 				' .maxi-image-block-wrapper': {
 					...getImageWrapperObject(props),

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -514,7 +514,16 @@ const getStyles = props => {
 	const response = {
 		[uniqueID]: styleProcessor(
 			{
-				'': { ...getWrapperObject(props), ...getImageOverflow(props) },
+				'': { ...getWrapperObject(props) },
+				' .maxi-block__resizer--overflow': {
+					...getImageOverflow(props),
+					border: getBorderStyles({
+						obj: {
+							...getGroupAttributes(props, ['borderRadius']),
+						},
+						blockStyle: props.blockStyle,
+					}),
+				},
 				':hover': getHoverWrapperObject(props),
 				' .maxi-image-block-wrapper': {
 					...getImageWrapperObject(props),


### PR DESCRIPTION
I'm not sure if this is a good solution.

Added `getImageOverflow `and applied it to the root target of the block. Does what we want, but with the overflow hidden, you can't see handlers anymore. 
This should be fixed in the popover component issue, I think? Should be related with other popover issues we had.

Fixes #4173

**_ Front/Back Testing _**

-   [ ] Test that overflow hidden applies to the canvas too, not just the image.

**_ Pre-Code Testing _**

-   [ ] Test that overflow hidden applies to the canvas too, not just the image.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
