### PR TITLE
Issue 4076 - Clip path

### DIFF
--- a/src/components/clip-path-control/index.js
+++ b/src/components/clip-path-control/index.js
@@ -132,15 +132,15 @@ const ClipPathControl = props => {
 
 	const classes = classnames('maxi-clip-path-control', className);
 
+	const gradientPrefix =
+		props.prefix === 'background-gradient-' ? 'header-' : '';
+
 	const clipPath = getLastBreakpointAttribute({
-		target: `${prefix}clip-path`,
+		target: `${gradientPrefix}${prefix}clip-path`,
 		breakpoint,
 		attributes: props,
 		isHover,
 	});
-
-	const gradientPrefix =
-		props.prefix === 'background-gradient-' ? 'header-' : '';
 
 	const hasClipPath =
 		isLayer || !isHover

--- a/src/components/clip-path-control/index.js
+++ b/src/components/clip-path-control/index.js
@@ -151,10 +151,11 @@ const ClipPathControl = props => {
 					isHover,
 			  })
 			: props[
-					`${gradientPrefix}${getAttributeKey(
+					getAttributeKey(
 						'clip-path-status',
-						true
-					)}`
+						true,
+						`${gradientPrefix}${prefix}`
+					)
 			  ];
 
 	const deconstructCP = (clipPathToDeconstruct = clipPath) => {
@@ -263,12 +264,12 @@ const ClipPathControl = props => {
 
 	const onChangeValue = val => {
 		onChange({
-			[`${gradientPrefix}${getAttributeKey(
+			[getAttributeKey(
 				'clip-path',
 				isHover,
-				prefix,
+				`${gradientPrefix}${prefix}`,
 				breakpoint
-			)}`]: val,
+			)]: val,
 		});
 	};
 
@@ -335,12 +336,12 @@ const ClipPathControl = props => {
 
 	const onToggleClipPath = val => {
 		onChange({
-			[`${gradientPrefix}${getAttributeKey(
+			[getAttributeKey(
 				'clip-path-status',
 				isHover,
-				prefix,
+				`${gradientPrefix}${prefix}`,
 				breakpoint
-			)}`]: val,
+			)]: val,
 		});
 	};
 

--- a/src/components/clip-path-control/index.js
+++ b/src/components/clip-path-control/index.js
@@ -139,15 +139,23 @@ const ClipPathControl = props => {
 		isHover,
 	});
 
+	const gradientPrefix =
+		props.prefix === 'background-gradient-' ? 'header-' : '';
+
 	const hasClipPath =
 		isLayer || !isHover
 			? getLastBreakpointAttribute({
-					target: `${prefix}clip-path-status`,
+					target: `${gradientPrefix}${prefix}clip-path-status`,
 					breakpoint,
 					attributes: props,
 					isHover,
 			  })
-			: props[getAttributeKey('clip-path-status', true)];
+			: props[
+					`${gradientPrefix}${getAttributeKey(
+						'clip-path-status',
+						true
+					)}`
+			  ];
 
 	const deconstructCP = (clipPathToDeconstruct = clipPath) => {
 		if (isEmpty(clipPathToDeconstruct) || clipPath === 'none')
@@ -255,7 +263,12 @@ const ClipPathControl = props => {
 
 	const onChangeValue = val => {
 		onChange({
-			[getAttributeKey('clip-path', isHover, prefix, breakpoint)]: val,
+			[`${gradientPrefix}${getAttributeKey(
+				'clip-path',
+				isHover,
+				prefix,
+				breakpoint
+			)}`]: val,
 		});
 	};
 
@@ -322,8 +335,12 @@ const ClipPathControl = props => {
 
 	const onToggleClipPath = val => {
 		onChange({
-			[getAttributeKey('clip-path-status', isHover, prefix, breakpoint)]:
-				val,
+			[`${gradientPrefix}${getAttributeKey(
+				'clip-path-status',
+				isHover,
+				prefix,
+				breakpoint
+			)}`]: val,
 		});
 	};
 


### PR DESCRIPTION
Fixed pane header bg clip-path. It was not working for the gradient before, only for colour.

Fixes #4076 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Add accordion and open pane settings. Check that you can enable and use clip-path in the header background. Make sure that clip-path works for both colour and gradient options.

**_ Pre-Code Testing _**

-   [ ] Add accordion and open pane settings. Check that you can enable and use clip-path in the header background. Make sure that clip-path works for both colour and gradient options.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
