### PR TITLE
Issue 4093 - TextControl uncontrolled styles

### DIFF
--- a/src/blocks/map-maxi/components/search-box/index.js
+++ b/src/blocks/map-maxi/components/search-box/index.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { getNewMarker, getUpdatedMarkers } from '../../utils';
-import { Button, TextControl } from '../../../../components';
+import { Button, TextInput } from '../../../../components';
 
 /**
  * External dependencies
@@ -88,7 +88,7 @@ const SearchBox = ({ mapMarkers, maxiSetAttributes }) => {
 	return (
 		<>
 			<div className='maxi-map-block__search-box'>
-				<TextControl
+				<TextInput
 					value={keywords}
 					onChange={keyWords => setKeywords(keyWords)}
 					onKeyDown={event => handleKeyDown(event)}

--- a/src/components/text-control/editor.scss
+++ b/src/components/text-control/editor.scss
@@ -9,11 +9,11 @@ body.maxi-blocks--active .maxi-text-control {
 		padding: 2px 8px;
 		border-radius: 5px;
 		background-color: rgba(33, 141, 250, 0);
-		border: 2px solid var(--maxi-grey-1-color);
+		border: 1px solid var(--maxi-grey-1-color);
 		font-size: 13px;
 		color: #464a53;
 		font-weight: 500;
-		flex: 2;
+		flex: 1;
 
 		&:focus {
 			border-color: var(--maxi-grey-6-color);

--- a/src/components/text-control/editor.scss
+++ b/src/components/text-control/editor.scss
@@ -1,18 +1,23 @@
-.maxi-text-control {
+body.maxi-blocks--active .maxi-text-control {
 	.maxi-base-control__field {
 		flex-wrap: wrap;
 	}
 
-	&__input {
+	input.maxi-text-control__input {
 		min-height: unset;
 		max-height: unset !important;
+		padding: 2px 8px;
 		border-radius: 5px;
 		background-color: rgba(33, 141, 250, 0);
-		border: 2px solid #dddfe1;
+		border: 2px solid var(--maxi-grey-1-color);
 		font-size: 13px;
 		color: #464a53;
 		font-weight: 500;
-		flex: 1;
+		flex: 2;
+
+		&:focus {
+			border-color: var(--maxi-grey-6-color);
+		}
 	}
 
 	&__validation-text {

--- a/src/components/toolbar/components/reusable-blocks/editor.scss
+++ b/src/components/toolbar/components/reusable-blocks/editor.scss
@@ -64,6 +64,7 @@
 
 				height: 28px;
 				min-height: 0;
+				flex-basis: 100%;
 				border-radius: 0;
 				border-color: #dbdde6;
 				font-weight: 400;
@@ -90,8 +91,11 @@
 /*******************************
 * RTL
 *******************************/
-html[dir="rtl"]  {
-	.maxi-dropdown__content.maxi-dropdown__reusable-content .components-popover__content .maxi-base-control input {
+html[dir='rtl'] {
+	.maxi-dropdown__content.maxi-dropdown__reusable-content
+		.components-popover__content
+		.maxi-base-control
+		input {
 		text-indent: 53px;
 	}
 }


### PR DESCRIPTION
# Description
Increased specificity in `TextControl` styles to overwrite `TextInput` styles, but the styles shown in the issue still are the ones applied, which is right imo because they have high css specificity.
Also changed some styles on `TextControl` to make it look more like other inputs on maxi.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4093 

# How Has This Been Tested?
Checked all instances of `TextControl` look good.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check all instances of `TextControl` look good.

**_Pre-Code Testing_**

-   [x] Check all instances of `TextControl` look good.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
