### PR TITLE
Issue 4123 - Divider force canvas equal

### DIFF
--- a/src/blocks/divider-maxi/edit.js
+++ b/src/blocks/divider-maxi/edit.js
@@ -62,6 +62,12 @@ class edit extends MaxiBlockComponent {
 				attributes: this.props.attributes,
 			})}`;
 
+			const forceAspectRatio = getLastBreakpointAttribute({
+				target: 'force-aspect-ratio',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+
 			const { width: resizerWidth, height: resizerHeight } =
 				this.resizableObject.current.state;
 
@@ -71,9 +77,44 @@ class edit extends MaxiBlockComponent {
 			) {
 				this.resizableObject.current.updateSize({
 					width: width ? `${width}${widthUnit}` : '100%',
-					height,
+					height: forceAspectRatio ? 'auto' : height,
 				});
 			}
+		}
+	}
+
+	maxiBlockDidMount() {
+		if (this.resizableObject.current) {
+			const width = getLastBreakpointAttribute({
+				target: 'width',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+			const widthUnit = getLastBreakpointAttribute({
+				target: 'width-unit',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+			const height = `${getLastBreakpointAttribute({
+				target: 'height',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			})}${getLastBreakpointAttribute({
+				target: 'height-unit',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			})}`;
+
+			const forceAspectRatio = getLastBreakpointAttribute({
+				target: 'force-aspect-ratio',
+				breakpoint: this.props.deviceType,
+				attributes: this.props.attributes,
+			});
+
+			this.resizableObject.current.updateSize({
+				width: width ? `${width}${widthUnit}` : '100%',
+				height: forceAspectRatio ? 'auto' : height,
+			});
 		}
 	}
 


### PR DESCRIPTION
This issue was partially fixed here: https://github.com/maxi-blocks/maxi-blocks/pull/4153

This PR fixes the comment - divider canvas not keeping the aspect ratio after moving.

Fixes #4123 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test that divider canvas force equal works.
-   [x] Test that width and height remain the same after moving the divider to a different column.
- 
**_ Pre-Code Testing _**

-   [ ] Test that divider canvas force equal works.
-   [ ] Test that width and height remain the same after moving the divider to a different column.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
