### PR TITLE
Inner blocks get wrapper's `min-height`

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -20,7 +20,7 @@ body.maxi-blocks--active .maxi-block {
 	min-width: initial;
 	max-height: none;
 	height: initial;
-	min-height: inherit;
+	min-height: initial;
 	border: none;
 	border-width: 0;
 	border-radius: 0;


### PR DESCRIPTION
# Description

As the default `min-height` for `.maxi-block` is `inherit`, is getting the value of the wrapper block. Modified to be `initial`. Bug found be @Olekrut :


https://user-images.githubusercontent.com/50477222/212648563-1a423323-7139-4544-8e76-fc7114f1f80b.mp4


# How Has This Been Tested?

1. Reproduce the video content and see the min-height doesn't affect the inner blocks 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the commented above

**_ Pre-Code Testing _**

-   [x] Test the commented above
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
