### PR TITLE
Issue 4214 - Video placeholder URL

### DIFF
--- a/e2e-tests/components/video-options-control/__snapshots__/index.spec.js.snap
+++ b/e2e-tests/components/video-options-control/__snapshots__/index.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Video options control Check video options control 1`] = `"<iframe class=\\"maxi-video-block__video-player\\" id=\\"video-maxi-1-player\\" title=\\"Placeholder Video\\" allowfullscreen=\\"\\" allow=\\"autoplay\\" src=\\"https://www.youtube.com/embed/ScMzIvxBSi4?rel=0&amp;enablejsapi=1&amp;mute=1&amp;controls=0&amp;autoplay=1\\" frameborder=\\"0\\"></iframe>"`;
+exports[`Video options control Check video options control 1`] = `"<iframe class=\\"maxi-video-block__video-player\\" id=\\"video-maxi-1-player\\" title=\\"Placeholder Video\\" allowfullscreen=\\"\\" allow=\\"autoplay\\" src=\\"https://www.youtube.com/embed/ScMzIvxBSi4?rel=0&amp;enablejsapi=1&amp;mute=1&amp;controls=0&amp;autoplay=1\\"></iframe>"`;
 
 exports[`Video options control Check video options control 2`] = `
 "<!-- wp:maxi-blocks/video-maxi {\\"maxi-version-current\\":\\"0.0.1-SC4\\",\\"maxi-version-origin\\":\\"0.0.1-SC4\\",\\"blockStyle\\":\\"light\\",\\"isFirstOnHierarchy\\":true,\\"uniqueID\\":\\"video-maxi-1\\",\\"customLabel\\":\\"Video_1\\",\\"embedUrl\\":\\"https://www.youtube.com/embed/ScMzIvxBSi4?rel=0\\\\u0026enablejsapi=1\\\\u0026mute=1\\\\u0026controls=0\\\\u0026autoplay=1\\",\\"isLoop\\":true,\\"isMuted\\":true,\\"isAutoplay\\":true,\\"showPlayerControls\\":false} -->

--- a/src/blocks/video-maxi/components/video-control/index.js
+++ b/src/blocks/video-maxi/components/video-control/index.js
@@ -30,6 +30,8 @@ const VideoControl = props => {
 		playerType,
 	} = props;
 
+	const defaultURL = 'https://www.youtube.com/watch?v=ScMzIvxBSi4';
+
 	const [validationText, setValidationText] = useState(null);
 	return (
 		<>
@@ -61,7 +63,7 @@ const VideoControl = props => {
 				label={__('URL', 'maxi-blocks')}
 				type='url'
 				value={videoUrl}
-				placeholder='Youtube, Vimeo, or Direct Link'
+				placeholder={defaultURL}
 				onChange={val => {
 					if (val && !videoUrlRegex.test(val)) {
 						setValidationText(
@@ -72,10 +74,10 @@ const VideoControl = props => {
 					}
 
 					onChange({
-						url: val,
+						url: val !== '' ? val : defaultURL,
 						embedUrl: getParsedVideoUrl({
 							...props,
-							url: val,
+							url: val !== '' ? val : defaultURL,
 						}),
 						videoType: parseVideo(val).type,
 					});

--- a/src/blocks/video-maxi/edit.js
+++ b/src/blocks/video-maxi/edit.js
@@ -125,7 +125,6 @@ const VideoPlayer = props => {
 					allowFullScreen
 					allow='autoplay'
 					src={embedUrl}
-					frameBorder={0}
 				/>
 			)}
 			{!isSelected && (

--- a/src/blocks/video-maxi/style.scss
+++ b/src/blocks/video-maxi/style.scss
@@ -132,10 +132,7 @@
 		font-size: 12px;
 	}
 }
-.maxi-text-input[value="https://www.youtube.com/watch?v=ScMzIvxBSi4"]
-{
-	color: var(--maxi-grey-7-color) !important;
-}
+
 @keyframes popup-zoom-out {
 	0% {
 		transform: scale(1.2);

--- a/src/components/background-control/videoLayer.js
+++ b/src/components/background-control/videoLayer.js
@@ -106,6 +106,8 @@ const VideoLayer = props => {
 
 	const [validationText, setValidationText] = useState(null);
 
+	const defaultURL = 'https://www.youtube.com/watch?v=ScMzIvxBSi4';
+
 	return (
 		<div className='maxi-background-control__video'>
 			{(!isHover || (isHover && isLayerHover)) && (
@@ -118,7 +120,7 @@ const VideoLayer = props => {
 							props: videoOptions,
 							prefix,
 						})}
-						placeholder='Youtube, Vimeo, or Direct Link'
+						placeholder={defaultURL}
 						onChange={val => {
 							if (val && !videoUrlRegex.test(val)) {
 								setValidationText(
@@ -133,7 +135,7 @@ const VideoLayer = props => {
 									'background-video-mediaURL',
 									false,
 									prefix
-								)]: val,
+								)]: val !== '' ? val : defaultURL,
 							});
 						}}
 						validationText={validationText}

--- a/src/components/toolbar/components/video-url/index.js
+++ b/src/components/toolbar/components/video-url/index.js
@@ -24,6 +24,8 @@ const VideoUrl = props => {
 
 	const [validationText, setValidationText] = useState(null);
 
+	const defaultURL = 'https://www.youtube.com/watch?v=ScMzIvxBSi4';
+
 	return (
 		<ToolbarPopover
 			className='toolbar-item__video-url'
@@ -37,7 +39,7 @@ const VideoUrl = props => {
 				</label>
 				<TextInput
 					type='url'
-					placeholder='Youtube, Vimeo, or Direct Link'
+					placeholder={defaultURL}
 					value={url}
 					onChange={val => {
 						if (val && !videoUrlRegex.test(val)) {
@@ -49,10 +51,10 @@ const VideoUrl = props => {
 						}
 
 						onChange({
-							url: val,
+							url: val !== '' ? val : defaultURL,
 							embedUrl: getParsedVideoUrl({
 								...props,
-								url: val,
+								url: val !== '' ? val : defaultURL,
 							}),
 							videoType: parseVideo(val).type,
 						});


### PR DESCRIPTION
Added our default video URL to be the placeholder. Now if the input is empty it will get the default URL automatically.

Removed unneccessary placeholder text colour.

Deleted deprecated prop frameborder.

Fixes #4214 

**_ Front/Back Testing _**

-   [ ] Check that if the video URL input is empty, it gets the default video URL.
-   [ ] Test that the video URL input works normally in general.

**_ Pre-Code Testing _**

-   [x] Check that if the video URL input is empty, it gets the default video URL.
-   [x] Test that the video URL input works normally in general.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
