### PR TITLE
Issue 4235 - Button white space

### DIFF
--- a/src/blocks/button-maxi/edit.js
+++ b/src/blocks/button-maxi/edit.js
@@ -67,6 +67,13 @@ class edit extends MaxiBlockComponent {
 		return getStyles(attributes, scValues);
 	}
 
+	maxiBlockDidUpdate() {
+		// Ensures white-space is applied from Maxi and not with inline styles
+		Array.from(this.blockRef.current.children[0].children).forEach(el => {
+			if (el.style.whiteSpace) el.style.whiteSpace = null;
+		});
+	}
+
 	render() {
 		const { attributes, maxiSetAttributes } = this.props;
 		const { uniqueID } = attributes;


### PR DESCRIPTION
Button had inline styles for white space which were overriding settings. Now those inline styles are ignored.

Fixes #4235

**_ Front/Back Testing _**

-   [ ] Add a button block and test that white space settings are applied. Test backend and frontend.

**_ Pre-Code Testing _**

-   [ ] Add a button block and test that white space settings are applied. Test backend and frontend.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
