### PR TITLE
Issue 4234 - SelectControl default values

### DIFF
--- a/src/blocks/accordion-maxi/components/accordion-line-control/index.js
+++ b/src/blocks/accordion-maxi/components/accordion-line-control/index.js
@@ -29,6 +29,9 @@ const AccordionLineControl = props => {
 					breakpoint,
 					attributes: props,
 				})}
+				defaultValue={getDefaultAttribute(
+					`${prefix}line-horizontal-${breakpoint}`
+				)}
 				options={[
 					{
 						label: __('Left', 'maxi-blocks'),

--- a/src/blocks/column-maxi/components/column-size-control/index.js
+++ b/src/blocks/column-maxi/components/column-size-control/index.js
@@ -92,6 +92,9 @@ const ColumnSizeControl = props => {
 					breakpoint,
 					attributes: props,
 				})}
+				defaultValue={getDefaultAttribute(
+					getAttributeKey('justify-content', false, '', breakpoint)
+				)}
 				options={[
 					{
 						label: __('Top', 'maxi-blocks'),

--- a/src/blocks/divider-maxi/inspector.js
+++ b/src/blocks/divider-maxi/inspector.js
@@ -77,6 +77,9 @@ const Inspector = props => {
 																attributes,
 															}
 														)}
+														defaultValue={getDefaultAttribute(
+															`line-orientation-${deviceType}`
+														)}
 														options={[
 															{
 																label: __(
@@ -121,6 +124,9 @@ const Inspector = props => {
 																	deviceType,
 																attributes,
 															}
+														)}
+														defaultValue={getDefaultAttribute(
+															`line-vertical-${deviceType}`
 														)}
 														options={[
 															{
@@ -173,6 +179,9 @@ const Inspector = props => {
 																	deviceType,
 																attributes,
 															}
+														)}
+														defaultValue={getDefaultAttribute(
+															`line-horizontal-${deviceType}`
 														)}
 														options={[
 															{

--- a/src/blocks/image-maxi/components/dimension-tab/index.js
+++ b/src/blocks/image-maxi/components/dimension-tab/index.js
@@ -102,6 +102,7 @@ const DimensionTab = props => {
 								? imageSize
 								: 'full'
 						} // is still necessary?
+						defaultValue={getDefaultAttribute('imageSize')}
 						onReset={() =>
 							maxiSetAttributes({
 								imageSize: getDefaultAttribute('imageSize'),

--- a/src/blocks/image-maxi/components/hover-effect-control/index.js
+++ b/src/blocks/image-maxi/components/hover-effect-control/index.js
@@ -141,6 +141,9 @@ const HoverEffectControl = props => {
 					<SelectControl
 						label={__('Easing', 'maxi-blocks')}
 						value={props['hover-transition-easing']}
+						defaultValue={getDefaultAttribute(
+							'hover-transition-easing'
+						)}
 						onReset={() =>
 							onChange({
 								'hover-transition-easing': getDefaultAttribute(
@@ -195,6 +198,9 @@ const HoverEffectControl = props => {
 					<SelectControl
 						label={__('Effect type', 'maxi-blocks')}
 						value={props['hover-basic-effect-type']}
+						defaultValue={getDefaultAttribute(
+							'hover-basic-effect-type'
+						)}
 						onReset={() =>
 							onChange({
 								'hover-basic-effect-type': getDefaultAttribute(
@@ -299,6 +305,9 @@ const HoverEffectControl = props => {
 					<SelectControl
 						label={__('Animation type', 'maxi-blocks')}
 						value={props['hover-text-effect-type']}
+						defaultValue={getDefaultAttribute(
+							'hover-text-effect-type'
+						)}
 						onReset={() =>
 							onChange({
 								'hover-text-effect-type': getDefaultAttribute(

--- a/src/blocks/text-maxi/components/list-options-control/index.js
+++ b/src/blocks/text-maxi/components/list-options-control/index.js
@@ -141,6 +141,9 @@ const ListOptionsControl = props => {
 					breakpoint: deviceType,
 					attributes,
 				})}
+				defaultValue={getDefaultAttribute(
+					`list-style-position-${deviceType}`
+				)}
 				onReset={() =>
 					maxiSetAttributes({
 						[`list-style-position-${deviceType}`]:
@@ -588,6 +591,9 @@ const ListOptionsControl = props => {
 					breakpoint: deviceType,
 					attributes,
 				})}
+				defaultValue={getDefaultAttribute(
+					`list-text-position-${deviceType}`
+				)}
 				onReset={() =>
 					maxiSetAttributes({
 						[`list-text-position-${deviceType}`]:
@@ -636,6 +642,7 @@ const ListOptionsControl = props => {
 					label={__('Type of list', 'maxi-blocks')}
 					className='maxi-text-inspector__list-type'
 					value={typeOfList}
+					defaultValue={getDefaultAttribute('typeOfList')}
 					onReset={() =>
 						maxiSetAttributes({
 							typeOfList: getDefaultAttribute('typeOfList'),
@@ -669,6 +676,7 @@ const ListOptionsControl = props => {
 						label={__('Style', 'maxi-blocks')}
 						className='maxi-text-inspector__list-style'
 						value={listStyle || 'disc'}
+						defaultValue={getDefaultAttribute('listStyle')}
 						onReset={() =>
 							maxiSetAttributes({
 								listStyle: getDefaultAttribute('listStyle'),
@@ -739,9 +747,10 @@ const ListOptionsControl = props => {
 								label={__('Source', 'maxi-blocks')}
 								className='maxi-text-inspector__list-source-selector'
 								value={listStyleSource}
+								defaultValue={defaultListStyleSource}
 								onReset={() =>
 									maxiSetAttributes({
-										defaultListStyleSource,
+										listStyleCustom: defaultListStyleSource,
 										isReset: true,
 									})
 								}

--- a/src/blocks/video-maxi/components/video-icon-control/index.js
+++ b/src/blocks/video-maxi/components/video-icon-control/index.js
@@ -188,6 +188,9 @@ const IconSettings = props => {
 							label={__('Icon position', 'maxi-blocks')}
 							className='maxi-video-icon-control__icon-position'
 							value={props[`${prefix}icon-position`]}
+							defaultValue={getDefaultAttribute(
+								`${prefix}icon-position`
+							)}
 							onReset={() =>
 								onChange({
 									[`${prefix}icon-position`]:

--- a/src/components/background-control/imageLayer.js
+++ b/src/components/background-control/imageLayer.js
@@ -81,6 +81,7 @@ const ImageLayerSettings = props => {
 					attributes: imageOptions,
 					isHover,
 				})}
+				defaultValue={getDefaultAttr('background-image-size')}
 				options={[
 					{
 						label: __('Auto', 'maxi-blocks'),
@@ -226,6 +227,7 @@ const ImageLayerSettings = props => {
 							)]: val,
 						})
 					}
+					defaultValue={getDefaultAttr('background-image-repeat')}
 					onReset={() =>
 						onChange({
 							[getAttributeKey(
@@ -247,6 +249,7 @@ const ImageLayerSettings = props => {
 					attributes: imageOptions,
 					isHover,
 				})}
+				defaultValue={getDefaultAttr('background-image-position')}
 				options={[
 					{
 						label: __('Left top', 'maxi-blocks'),
@@ -444,6 +447,9 @@ const ImageLayerSettings = props => {
 							attributes: imageOptions,
 							isHover,
 						})}
+						defaultValue={getDefaultAttr(
+							'background-image-attachment'
+						)}
 						options={[
 							{
 								label: __('Scroll', 'maxi-blocks'),
@@ -500,6 +506,9 @@ const ImageLayerSettings = props => {
 									attributes: imageOptions,
 									isHover,
 								})}
+								defaultValue={getDefaultAttr(
+									'background-image-origin'
+								)}
 								options={[
 									{
 										label: __('Padding', 'maxi-blocks'),
@@ -546,6 +555,9 @@ const ImageLayerSettings = props => {
 									attributes: imageOptions,
 									isHover,
 								})}
+								defaultValue={getDefaultAttr(
+									'background-image-clip'
+								)}
 								options={[
 									{
 										label: __('Border', 'maxi-blocks'),

--- a/src/components/background-control/imageLayer.js
+++ b/src/components/background-control/imageLayer.js
@@ -191,6 +191,7 @@ const ImageLayerSettings = props => {
 						attributes: imageOptions,
 						isHover,
 					})}
+					defaultValue={getDefaultAttr('background-image-repeat')}
 					options={[
 						{
 							label: __('No repeat', 'maxi-blocks'),
@@ -227,7 +228,6 @@ const ImageLayerSettings = props => {
 							)]: val,
 						})
 					}
-					defaultValue={getDefaultAttr('background-image-repeat')}
 					onReset={() =>
 						onChange({
 							[getAttributeKey(

--- a/src/components/border-control/index.js
+++ b/src/components/border-control/index.js
@@ -315,6 +315,14 @@ const BorderControl = props => {
 					label={__('Add border line', 'maxi-blocks')}
 					className='maxi-border-control__type'
 					value={borderStyleValue || 'none'}
+					defaultValue={getDefaultAttribute(
+						getAttributeKey(
+							'border-style',
+							isHover,
+							prefix,
+							breakpoint
+						)
+					)}
 					onReset={() =>
 						onChange({
 							[getAttributeKey(

--- a/src/components/divider-control/index.js
+++ b/src/components/divider-control/index.js
@@ -181,6 +181,9 @@ const DividerControl = props => {
 							isHover,
 						}) || 'none'
 					}
+					defaultValue={getDefaultAttribute(
+						`${prefix}divider-border-style-${breakpoint}`
+					)}
 					onReset={() =>
 						onChange({
 							[`${prefix}divider-border-style-${breakpoint}`]:

--- a/src/components/flex-settings-control/index.js
+++ b/src/components/flex-settings-control/index.js
@@ -192,6 +192,9 @@ const FlexSettingsControl = props => {
 													attributes: props,
 											  }) ?? ''
 									}
+									defaultValue={getDefaultAttribute(
+										`flex-basis-${breakpoint}`
+									)}
 									onReset={() =>
 										onChange({
 											[`flex-basis-${breakpoint}`]:

--- a/src/components/font-weight-control/index.js
+++ b/src/components/font-weight-control/index.js
@@ -7,13 +7,21 @@ import { getWeightOptions } from '../typography-control/utils';
 import { loadFontsInEditor } from '../../extensions/text/fonts';
 
 const FontWeightControl = props => {
-	const { onChange, fontName, fontStyle, fontWeight, onReset } = props;
+	const {
+		onChange,
+		fontName,
+		fontStyle,
+		fontWeight,
+		defaultFontWeight,
+		onReset,
+	} = props;
 
 	return (
 		<SelectControl
 			label={__('Font weight', 'maxi-blocks')}
 			className='maxi-typography-control__weight'
 			value={fontWeight}
+			defaultValue={defaultFontWeight}
 			options={getWeightOptions(fontName)}
 			onChange={val => {
 				onChange(val);

--- a/src/components/overflow-control/index.js
+++ b/src/components/overflow-control/index.js
@@ -122,6 +122,9 @@ const OverflowControl = props => {
 							attributes: props,
 						}) || ''
 					}
+					defaultValue={getDefaultAttribute(
+						`overflow-${axis}-${breakpoint}`
+					)}
 					onChange={val => onChangeValue(val, axis)}
 					onReset={() =>
 						onChangeValue(

--- a/src/components/position-control/index.js
+++ b/src/components/position-control/index.js
@@ -126,6 +126,14 @@ const PositionControl = props => {
 								attributes: props,
 							}) || ''
 						}
+						defaultValue={getDefaultAttribute(
+							getAttributeKey(
+								'position',
+								isHover,
+								prefix,
+								breakpoint
+							)
+						)}
 						onReset={() =>
 							onChange({
 								[getAttributeKey(

--- a/src/components/select-control/index.js
+++ b/src/components/select-control/index.js
@@ -74,10 +74,10 @@ export default function SelectControl({
 				<select
 					id={id}
 					className='maxi-select-control__input'
+					value={value ?? defaultValue ?? options[0].value}
 					onChange={onChangeValue}
 					aria-describedby={help ? `${id}__help` : undefined}
 					multiple={multiple}
-					value={value ?? defaultValue ?? options[0].value}
 					{...props}
 				>
 					{isPlainObject(options)

--- a/src/components/select-control/index.js
+++ b/src/components/select-control/index.js
@@ -29,6 +29,8 @@ export default function SelectControl({
 	options = [],
 	className,
 	hideLabelFromVision,
+	defaultValue,
+	value,
 	...props
 }) {
 	const instanceId = useInstanceId(SelectControl);
@@ -75,6 +77,7 @@ export default function SelectControl({
 					onChange={onChangeValue}
 					aria-describedby={help ? `${id}__help` : undefined}
 					multiple={multiple}
+					value={value ?? defaultValue ?? options[0].value}
 					{...props}
 				>
 					{isPlainObject(options)

--- a/src/components/toolbar/components/icon-position/index.js
+++ b/src/components/toolbar/components/icon-position/index.js
@@ -36,6 +36,7 @@ const IconPosition = props => {
 					label={__('Icon position', 'maxi-block')}
 					className='maxi-icon__position'
 					value={props['icon-position']}
+					defaultValue={getDefaultAttribute('icon-position')}
 					onReset={() =>
 						onChange({
 							'icon-position':

--- a/src/components/toolbar/components/vertical-align/index.js
+++ b/src/components/toolbar/components/vertical-align/index.js
@@ -35,6 +35,9 @@ const VerticalAlign = props => {
 				<SelectControl
 					label={__('Vertical align', 'maxi-blocks')}
 					value={verticalAlign}
+					defaultValue={getDefaultAttribute(
+						`justify-content-${breakpoint}`
+					)}
 					onReset={() =>
 						onChange({
 							[`justify-content-${breakpoint}`]:

--- a/src/components/transition-control/index.js
+++ b/src/components/transition-control/index.js
@@ -121,6 +121,7 @@ const TransitionControl = props => {
 							breakpoint,
 							attributes: transition,
 						})}
+						defaultValue={getDefaultTransitionAttribute('easing')}
 						options={[
 							{ label: __('Ease', 'maxi-blocks'), value: 'ease' },
 							{

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -383,11 +383,14 @@ const TypographyControl = props => {
 			avoidSC,
 		});
 
-	const getDefault = target => {
+	const getDefault = (target, keepBreakpoint = false) => {
 		const prop = `${prefix}${target}`;
 
 		const currentBreakpoint =
-			(isStyleCards && breakpoint === 'general' && baseBreakpoint) ||
+			(isStyleCards &&
+				breakpoint === 'general' &&
+				!keepBreakpoint &&
+				baseBreakpoint) ||
 			breakpoint;
 
 		const defaultAttribute = !isStyleCards
@@ -650,7 +653,10 @@ const TypographyControl = props => {
 						);
 					}}
 					fontWeight={getValue('font-weight')}
-					defaultFontWeight={getDefault('font-weight') || '400'}
+					defaultFontWeight={
+						getDefault('font-weight', true) ??
+						getDefault('font-weight')
+					}
 					fontName={getValue('font-family')}
 					fontStyle={getValue('font-style')}
 					breakpoint={breakpoint}
@@ -659,7 +665,7 @@ const TypographyControl = props => {
 					label={__('Text transform', 'maxi-blocks')}
 					className='maxi-typography-control__transform'
 					value={getValue('text-transform')}
-					defaultValue={getDefault('text-transform')}
+					defaultValue={getDefault('text-transform', true)}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -697,7 +703,7 @@ const TypographyControl = props => {
 					label={__('Style', 'maxi-blocks')}
 					className='maxi-typography-control__font-style'
 					value={getValue('font-style')}
-					defaultValue={getDefault('font-style')}
+					defaultValue={getDefault('font-style', true)}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -731,7 +737,7 @@ const TypographyControl = props => {
 					label={__('Text decoration', 'maxi-blocks')}
 					className='maxi-typography-control__decoration'
 					value={getValue('text-decoration')}
-					defaultValue={getDefault('text-decoration')}
+					defaultValue={getDefault('text-decoration', true)}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -775,7 +781,7 @@ const TypographyControl = props => {
 							label={__('Text orientation', 'maxi-blocks')}
 							className='maxi-typography-control__orientation'
 							value={getValue('text-orientation')}
-							defaultValue={getDefault('text-orientation')}
+							defaultValue={getDefault('text-orientation', true)}
 							options={[
 								{
 									label: __('None', 'maxi-blocks'),
@@ -816,7 +822,7 @@ const TypographyControl = props => {
 							label={__('Text direction', 'maxi-blocks')}
 							className='maxi-typography-control__direction'
 							value={getValue('text-direction')}
-							defaultValue={getDefault('text-direction')}
+							defaultValue={getDefault('text-direction', true)}
 							options={[
 								{
 									label: __('Left to right', 'maxi-blocks'),
@@ -904,7 +910,7 @@ const TypographyControl = props => {
 					label={__('White space', 'maxi-blocks')}
 					className='maxi-typography-control__white-space'
 					value={getValue('white-space')}
-					defaultValue={getDefault('white-space')}
+					defaultValue={getDefault('white-space', true)}
 					options={[
 						{
 							label: __('Normal', 'maxi-blocks'),

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -650,6 +650,7 @@ const TypographyControl = props => {
 						);
 					}}
 					fontWeight={getValue('font-weight')}
+					defaultfontWeight={getDefault('font-weight')}
 					fontName={getValue('font-family')}
 					fontStyle={getValue('font-style')}
 					breakpoint={breakpoint}

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -949,9 +949,13 @@ const TypographyControl = props => {
 						});
 					}}
 					onReset={() => {
-						onChangeFormat({
-							[`${prefix}white-space`]: getDefault('white-space'),
-						});
+						onChangeFormat(
+							{
+								[`${prefix}white-space`]:
+									getDefault('white-space'),
+							},
+							{ isReset: true }
+						);
 					}}
 				/>
 				<AdvancedNumberControl

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -935,6 +935,11 @@ const TypographyControl = props => {
 							[`${prefix}white-space`]: val,
 						});
 					}}
+					onReset={() => {
+						onChangeFormat({
+							[`${prefix}white-space`]: getDefault('white-space'),
+						});
+					}}
 				/>
 				<AdvancedNumberControl
 					className='maxi-typography-control__word-spacing'

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -35,7 +35,7 @@ import { getDefaultSCValue } from '../../extensions/style-cards';
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty } from 'lodash';
+import { isEmpty, isNil } from 'lodash';
 
 /**
  * Styles
@@ -393,7 +393,7 @@ const TypographyControl = props => {
 				baseBreakpoint) ||
 			breakpoint;
 
-		const defaultAttribute = !isStyleCards
+		let defaultAttribute = !isStyleCards
 			? getDefaultAttribute(`${prop}-${currentBreakpoint}`, clientId)
 			: getDefaultSCValue({
 					target: `${prop}-${currentBreakpoint}`,
@@ -401,6 +401,15 @@ const TypographyControl = props => {
 					SCStyle: blockStyle,
 					groupAttr: textLevel,
 			  });
+
+		if (isStyleCards && isNil(defaultAttribute)) {
+			defaultAttribute = getDefaultSCValue({
+				target: `${prop}-${breakpoint}`,
+				SC: styleCard,
+				SCStyle: blockStyle,
+				groupAttr: textLevel,
+			});
+		}
 
 		return defaultAttribute;
 	};
@@ -653,10 +662,7 @@ const TypographyControl = props => {
 						);
 					}}
 					fontWeight={getValue('font-weight')}
-					defaultFontWeight={
-						getDefault('font-weight', true) ??
-						getDefault('font-weight')
-					}
+					defaultFontWeight={getDefault('font-weight')}
 					fontName={getValue('font-family')}
 					fontStyle={getValue('font-style')}
 					breakpoint={breakpoint}
@@ -665,7 +671,7 @@ const TypographyControl = props => {
 					label={__('Text transform', 'maxi-blocks')}
 					className='maxi-typography-control__transform'
 					value={getValue('text-transform')}
-					defaultValue={getDefault('text-transform', true)}
+					defaultValue={getDefault('text-transform')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -703,7 +709,7 @@ const TypographyControl = props => {
 					label={__('Style', 'maxi-blocks')}
 					className='maxi-typography-control__font-style'
 					value={getValue('font-style')}
-					defaultValue={getDefault('font-style', true)}
+					defaultValue={getDefault('font-style')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -737,7 +743,7 @@ const TypographyControl = props => {
 					label={__('Text decoration', 'maxi-blocks')}
 					className='maxi-typography-control__decoration'
 					value={getValue('text-decoration')}
-					defaultValue={getDefault('text-decoration', true)}
+					defaultValue={getDefault('text-decoration')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -781,7 +787,7 @@ const TypographyControl = props => {
 							label={__('Text orientation', 'maxi-blocks')}
 							className='maxi-typography-control__orientation'
 							value={getValue('text-orientation')}
-							defaultValue={getDefault('text-orientation', true)}
+							defaultValue={getDefault('text-orientation')}
 							options={[
 								{
 									label: __('None', 'maxi-blocks'),
@@ -822,7 +828,7 @@ const TypographyControl = props => {
 							label={__('Text direction', 'maxi-blocks')}
 							className='maxi-typography-control__direction'
 							value={getValue('text-direction')}
-							defaultValue={getDefault('text-direction', true)}
+							defaultValue={getDefault('text-direction')}
 							options={[
 								{
 									label: __('Left to right', 'maxi-blocks'),
@@ -910,7 +916,7 @@ const TypographyControl = props => {
 					label={__('White space', 'maxi-blocks')}
 					className='maxi-typography-control__white-space'
 					value={getValue('white-space')}
-					defaultValue={getDefault('white-space', true)}
+					defaultValue={getDefault('white-space')}
 					options={[
 						{
 							label: __('Normal', 'maxi-blocks'),

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -658,6 +658,7 @@ const TypographyControl = props => {
 					label={__('Text transform', 'maxi-blocks')}
 					className='maxi-typography-control__transform'
 					value={getValue('text-transform')}
+					defaultValue={getDefault('text-transform')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -695,6 +696,7 @@ const TypographyControl = props => {
 					label={__('Style', 'maxi-blocks')}
 					className='maxi-typography-control__font-style'
 					value={getValue('font-style')}
+					defaultValue={getDefault('font-style')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -728,6 +730,7 @@ const TypographyControl = props => {
 					label={__('Text decoration', 'maxi-blocks')}
 					className='maxi-typography-control__decoration'
 					value={getValue('text-decoration')}
+					defaultValue={getDefault('text-decoration')}
 					options={[
 						{
 							label: __('Default', 'maxi-blocks'),
@@ -771,6 +774,7 @@ const TypographyControl = props => {
 							label={__('Text orientation', 'maxi-blocks')}
 							className='maxi-typography-control__orientation'
 							value={getValue('text-orientation')}
+							defaultValue={getDefault('text-orientation')}
 							options={[
 								{
 									label: __('None', 'maxi-blocks'),
@@ -811,6 +815,7 @@ const TypographyControl = props => {
 							label={__('Text direction', 'maxi-blocks')}
 							className='maxi-typography-control__direction'
 							value={getValue('text-direction')}
+							defaultValue={getDefault('text-direction')}
 							options={[
 								{
 									label: __('Left to right', 'maxi-blocks'),
@@ -898,6 +903,7 @@ const TypographyControl = props => {
 					label={__('White space', 'maxi-blocks')}
 					className='maxi-typography-control__white-space'
 					value={getValue('white-space')}
+					defaultValue={getDefault('white-space')}
 					options={[
 						{
 							label: __('Normal', 'maxi-blocks'),

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -650,7 +650,7 @@ const TypographyControl = props => {
 						);
 					}}
 					fontWeight={getValue('font-weight')}
-					defaultfontWeight={getDefault('font-weight')}
+					defaultFontWeight={getDefault('font-weight') || '400'}
 					fontName={getValue('font-family')}
 					fontStyle={getValue('font-style')}
 					breakpoint={breakpoint}


### PR DESCRIPTION
# Description
When the reset button was clicked, the value on `SelectControl` reset to `undefined` and instead of changing value to default `select`'s value remained the same, now it will fall back to new `defaultValue` prop or to first element if `defaultValue` is not passed.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4234 

# How Has This Been Tested?
Checked that dropdown changes its value on reset.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that dropdown changes its value on reset.

**_ Pre-Code Testing _**

-   [ ] Check that dropdown changes its value on reset.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
