### PR TITLE
Isse 4212 - Fix SC import / export

### DIFF
--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -457,7 +457,10 @@ const MaxiStyleCardsEditor = ({ styleCards, setIsVisible }) => {
 							<MediaUpload
 								onSelect={media => {
 									fetch(media.url)
+										// Need to parse the response 2 times,
+										// because it was stringified twice in the export function
 										.then(response => response.json())
+										.then(response => JSON.parse(response))
 										.then(jsonData => {
 											saveImportedStyleCard(jsonData);
 										})

--- a/src/editor/style-cards/utils.js
+++ b/src/editor/style-cards/utils.js
@@ -77,7 +77,8 @@ export const exportStyleCard = (data, fileName) => {
 	a.style = 'display: none';
 
 	const reducedSC = updatedDiff(standardSC?.sc_maxi, data);
-	const json = JSON.stringify(reducedSC);
+	// Need stringify twice to get 'text/plain' mime type
+	const json = JSON.stringify(JSON.stringify(reducedSC));
 	const blob = new Blob([json], { type: 'text/plain' });
 	const url = window.URL.createObjectURL(blob);
 

--- a/src/editor/style-cards/utils.js
+++ b/src/editor/style-cards/utils.js
@@ -13,7 +13,7 @@ import standardSC from '../../../core/utils/defaultSC.json';
  * External dependencies
  */
 import { isEmpty, isNil, isString } from 'lodash';
-import { updatedDiff } from 'deep-object-diff';
+import { diff } from 'deep-object-diff';
 
 /**
  * Utils
@@ -76,7 +76,7 @@ export const exportStyleCard = (data, fileName) => {
 	document.body.appendChild(a);
 	a.style = 'display: none';
 
-	const reducedSC = updatedDiff(standardSC?.sc_maxi, data);
+	const reducedSC = diff(standardSC?.sc_maxi, data);
 	// Need stringify twice to get 'text/plain' mime type
 	const json = JSON.stringify(JSON.stringify(reducedSC));
 	const blob = new Blob([json], { type: 'text/plain' });


### PR DESCRIPTION
# Description

The extension of the exported SC file remains `.txt`. The problem was in the way we exported it. Thanks to the idea of double `JSON.stringify` from @Naaaaiix 👍, now we get the correct mime type and the `txt` file is available for import. Previously exported SCs may not work, check with a new exported files.

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4212 

# How Has This Been Tested?
Exported different style cards, checked if it's possible to import and use.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Export different SC settings
-   [ ] Import exported different SC settings

**_ Pre-Code Testing _**

-   [x] Export different SC settings
-   [x] Import exported different SC settings
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
