### PR TITLE
Issue 4248 - Button's icon padding label

### DIFF
--- a/src/components/toolbar/components/padding-margin/index.js
+++ b/src/components/toolbar/components/padding-margin/index.js
@@ -36,7 +36,7 @@ const PaddingMargin = props => {
 	return (
 		<ToolbarPopover
 			className='toolbar-item__padding-margin'
-			tooltip={__('Padding & Margin', 'maxi-blocks')}
+			tooltip={__('Padding', 'maxi-blocks')}
 			position='bottom center'
 			icon={toolbarPadding}
 			advancedOptions={isIconToolbar ? 'icon' : 'margin / padding'}


### PR DESCRIPTION
I noticed this option only in the toolbar for the button's icon so I just changed the original label, didn't add any conditional logic.

Fixes #4248 

**_ Front/Back Testing _**

-   [ ] Check that the button icon's padding option in the toolbar says "padding" and not "padding & margin".
-   [ ] Make sure if we have the same option anywhere else and if needs the label changed.

**_ Pre-Code Testing _**

-   [ ] Check that the button icon's padding option in the toolbar says "padding" and not "padding & margin".
-   [ ] Make sure if we have the same option anywhere else and if needs the label changed.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
