### PR TITLE
Issue 4223 - Video exit ESC

### DIFF
--- a/js/maxi-video.js
+++ b/js/maxi-video.js
@@ -164,6 +164,14 @@ function popupEvents(video, popupContent, embedUrl, pauseVideo = null) {
 		}
 	};
 
+	document.addEventListener('keydown', e => {
+		if (popupContent.style.display === 'flex') {
+			if (e.key === 'Escape') {
+				closeVideo(e);
+			}
+		}
+	});
+
 	overlay.addEventListener('click', openVideo);
 	popupContent.addEventListener('click', closeVideo);
 }


### PR DESCRIPTION
New function to close a pop-up video by pressing ESC. 

_Note: It works until the video is started. Once started, the platform video site (ie YT) shortcuts take over._

Fixes #4223 


**_ Front/Back Testing _**

-   [x] Test that you can close a pop-up video with the ESC keyboard button.

**_ Pre-Code Testing _**

-   [x] Test that you can close a pop-up video with the ESC keyboard button.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
