### PR TITLE
Issue 4244 - Search icon palette colour reset

### DIFF
--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -409,7 +409,7 @@ const IconControlResponsiveSettings = withRTC(props => {
 							`${prefix}icon-fill-color${isHover ? '-hover' : ''}`
 						]
 					}
-					prefix={`${prefix}icon-fill`}
+					prefix={`${prefix}icon-fill-`}
 					paletteColor={
 						props[
 							`${prefix}icon-fill-palette-color${


### PR DESCRIPTION
Fixes palette colour reset for the search block.

Fixes #4244 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add a search block and try changing and resetting the palette colour.
-   [ ] Test all types of icons (line, shape, filled)
-   [ ] Test SVG and button icon too.

**_ Pre-Code Testing _**

-   [x] Add a search block and try changing and resetting the palette colour.
-   [x] Test all types of icons (line, shape, filled)
-   [x] Test SVG and button icon too.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
