### PR TITLE
Text Maxi list mode fix on SC5

### DIFF
--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -188,7 +188,7 @@ const getListObject = props => {
 			},
 		},
 		...(() => {
-			const response = { listGap: {} };
+			const response = { listGap: {}, bottomGap: {} };
 
 			breakpoints.forEach(breakpoint => {
 				const isRTL =
@@ -258,6 +258,24 @@ const getListObject = props => {
 				if (!isNil(gapNum) && !isNil(gapUnit)) {
 					response.listGap[breakpoint] = {
 						[`padding-${isRTL ? 'right' : 'left'}`]: padding,
+					};
+				}
+
+				// Bottom gap
+				const bottomGapNum = getLastBreakpointAttribute({
+					target: 'bottom-gap',
+					breakpoint,
+					attributes: props,
+				});
+				const bottomGapUnit = getLastBreakpointAttribute({
+					target: 'bottom-gap-unit',
+					breakpoint,
+					attributes: props,
+				});
+
+				if (!isNil(bottomGapNum) && !isNil(bottomGapUnit)) {
+					response.bottomGap[breakpoint] = {
+						'margin-bottom': bottomGapNum + bottomGapUnit,
 					};
 				}
 			});
@@ -544,13 +562,10 @@ const getStyles = props => {
 						getTypographyHoverObject(props),
 				}),
 				...(isList && {
-					[` ${element}.maxi-text-block__content`]: {
-						...getListObject({
-							...props,
-							isRTL,
-						}),
-						...getTypographyObject(props),
-					},
+					[` ${element}.maxi-text-block__content`]: getListObject({
+						...props,
+						isRTL,
+					}),
 					[` ${element}.maxi-text-block__content li`]: {
 						...getTypographyObject(props),
 						...getListItemObject(props),

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -544,10 +544,13 @@ const getStyles = props => {
 						getTypographyHoverObject(props),
 				}),
 				...(isList && {
-					[` ${element}.maxi-text-block__content`]: getListObject({
-						...props,
-						isRTL,
-					}),
+					[` ${element}.maxi-text-block__content`]: {
+						...getListObject({
+							...props,
+							isRTL,
+						}),
+						...getTypographyObject(props),
+					},
 					[` ${element}.maxi-text-block__content li`]: {
 						...getTypographyObject(props),
 						...getListItemObject(props),

--- a/src/css/maxi-themes.scss
+++ b/src/css/maxi-themes.scss
@@ -152,10 +152,10 @@ body.maxi-blocks--active .edit-post-visual-editor {
 				}
 			}
 
-			&.maxi-list-block ul,
-			.maxi-list-block ul,
-			&.maxi-list-block ol,
-			.maxi-list-block ol {
+			&.maxi-list-block ul.maxi-text-block__content,
+			.maxi-list-block ul.maxi-text-block__content,
+			&.maxi-list-block ol.maxi-text-block__content,
+			.maxi-list-block ol.maxi-text-block__content {
 				margin-bottom: var(--maxi-#{$style}-p-margin-bottom-general);
 			}
 
@@ -369,10 +369,10 @@ body.maxi-blocks--active {
 							}
 						}
 
-						&.maxi-list-block ul,
-						.maxi-list-block ul,
-						&.maxi-list-block ol,
-						.maxi-list-block ol {
+						&.maxi-list-block ul.maxi-text-block__content,
+						.maxi-list-block ul.maxi-text-block__content,
+						&.maxi-list-block ol.maxi-text-block__content,
+						.maxi-list-block ol.maxi-text-block__content {
 							margin-bottom: var(
 								--maxi-#{$style}-p-margin-bottom-#{$responsive_size}
 							);
@@ -683,10 +683,10 @@ body.maxi-blocks--active {
 						}
 					}
 
-					&.maxi-list-block ul,
-					.maxi-list-block ul,
-					&.maxi-list-block ol,
-					.maxi-list-block ol {
+					&.maxi-list-block ul.maxi-text-block__content,
+					.maxi-list-block ul.maxi-text-block__content,
+					&.maxi-list-block ol.maxi-text-block__content,
+					.maxi-list-block ol.maxi-text-block__content {
 						margin-bottom: var(
 							--maxi-#{$style}-p-margin-bottom-#{$current_responsive_stage}
 						);


### PR DESCRIPTION
# Description

Shared an error on SC5 update on [this comment](https://github.com/maxi-blocks/maxi-blocks/discussions/4254#discussioncomment-4757902). This PR aims to fix the issue.

# How Has This Been Tested?

On master, create a Text Maxi and set it on list mode with some random content. With just one line is enough to test; add `bottom-gap` setting to 0.  Then, duplicate than same Text Maxi block and check that the SC `bottom-gap` option is affecting the `ul` or `ol` HTML element and adding the `bottom-gap`. If you return that Text Maxi to normal mode (no list), the bottom-gap disappears and it's correct. This branch fixes it 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Do the steps commented above

**_ Pre-Code Testing _**

-   [ ] Do the steps commented above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
