### PR TITLE
Issue 4260 - fix SC popover impossible to scroll

### DIFF
--- a/src/components/popover/index.js
+++ b/src/components/popover/index.js
@@ -38,6 +38,7 @@ import {
 	arrow,
 	offset as offsetMiddleware,
 	limitShift,
+	size,
 } from '@floating-ui/react-dom';
 
 /**
@@ -146,6 +147,7 @@ const Popover = (
 		useShift = false,
 		shiftPadding,
 		shiftLimit,
+		resize = false,
 		__unstableObserveElement,
 		__unstableSlotName = SLOT_NAME,
 		...contentProps
@@ -226,6 +228,23 @@ const Popover = (
 					};
 			  })
 			: undefined,
+		resize
+			? size({
+					apply(sizeProps) {
+						const { firstElementChild } =
+							// eslint-disable-next-line no-use-before-define
+							refs.floating.current ?? {};
+
+						if (!firstElementChild) return;
+
+						// Reduce the height of the popover to the available space.
+						Object.assign(firstElementChild.style, {
+							maxHeight: `${sizeProps.availableHeight}px`,
+							overflow: 'auto',
+						});
+					},
+			  })
+			: undefined,
 		useShift
 			? shift({
 					crossAxis: true,
@@ -261,6 +280,8 @@ const Popover = (
 		// Positioning coordinates
 		x,
 		y,
+		// regular references
+		refs,
 		// Callback refs (not regular refs). This allows the position to be updated.
 		// when either elements change.
 		reference,

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -4,7 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, forwardRef } from '@wordpress/element';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { PostPreviewButton } from '@wordpress/editor';
 
@@ -38,7 +38,6 @@ import { isEmpty, isNil, isEqual } from 'lodash';
  * Icons
  */
 import { styleCardBoat, reset, SCDelete, closeIcon } from '../../icons';
-import { forwardRef } from 'react';
 
 const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 	const {
@@ -263,6 +262,7 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 			<Popover
 				anchor={ref.current}
 				noArrow
+				resize
 				position={isRTL ? 'bottom left right' : 'bottom right left'}
 				className='maxi-style-cards__popover maxi-sidebar'
 				focusOnMount


### PR DESCRIPTION
# Description
Made SC popover resize when it is bigger than the screen size (was working like that before #4026)
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4260 

# How Has This Been Tested?
Checked that SC popover is scrollable.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that SC popover is scrollable.

**_ Pre-Code Testing _**

-   [ ] Check that SC popover is scrollable.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
