### PR TITLE
Issue 4267 - `search-maxi`: remove box-shadow on input focus

### DIFF
--- a/src/blocks/search-maxi/style.scss
+++ b/src/blocks/search-maxi/style.scss
@@ -41,6 +41,10 @@ body.maxi-blocks--active .maxi-search-block {
 		margin: 0;
 		padding: 0;
 
+		&:focus {
+			box-shadow: none;
+		}
+
 		&--hidden {
 			width: 0;
 			opacity: 0;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4267

# How Has This Been Tested?
Checked if there is no more box-shadow(which looks like border and comes from default wordpress styles) for search-maxi input


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check if there is no more box-shadow for search-maxi input

**_ Pre-Code Testing _**

-   [x] Check if there is no more box-shadow for search-maxi input
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
