### PR TITLE
Issue 4117 - Image transition, grayscale and boundry

### DIFF
--- a/js/maxi-hover-effects.js
+++ b/js/maxi-hover-effects.js
@@ -70,14 +70,13 @@ const hovers = () => {
 						else if (
 							hoverData['hover-basic-effect-type'] === 'slide'
 						)
-							e.target.style.marginLeft = `${hoverData['hover-basic-slide-value']}px`;
+							e.target.style.transform = `translateX(${hoverData['hover-basic-slide-value']}px)`;
 						else if (
 							hoverData['hover-basic-effect-type'] === 'blur'
 						)
 							e.target.style.filter = `blur(${hoverData['hover-basic-blur-value']}px)`;
 						else {
 							e.target.style.transform = '';
-							e.target.style.marginLeft = '';
 							e.target.style.filter = '';
 						}
 					}
@@ -98,14 +97,14 @@ const hovers = () => {
 						else if (
 							hoverData['hover-basic-effect-type'] === 'slide'
 						)
-							e.target.style.marginLeft = 0;
+							e.target.style.transform = 'translateX(0)';
 						else if (
 							hoverData['hover-basic-effect-type'] === 'blur'
 						)
 							e.target.style.filter = 'blur(0)';
 						else {
 							e.target.style.transform = '';
-							e.target.style.marginLeft = '';
+
 							e.target.style.filter = '';
 						}
 					}

--- a/js/maxi-hover-effects.js
+++ b/js/maxi-hover-effects.js
@@ -70,7 +70,7 @@ const hovers = () => {
 						else if (
 							hoverData['hover-basic-effect-type'] === 'slide'
 						)
-							e.target.style.transform = `translateX(${hoverData['hover-basic-slide-value']}px)`;
+							e.target.style.transform = `translateX(${hoverData['hover-basic-slide-value']}%)`;
 						else if (
 							hoverData['hover-basic-effect-type'] === 'blur'
 						)
@@ -97,7 +97,7 @@ const hovers = () => {
 						else if (
 							hoverData['hover-basic-effect-type'] === 'slide'
 						)
-							e.target.style.transform = 'translateX(0)';
+							e.target.style.transform = 'translateX(0%)';
 						else if (
 							hoverData['hover-basic-effect-type'] === 'blur'
 						)

--- a/src/blocks/image-maxi/components/hover-effect-control/index.js
+++ b/src/blocks/image-maxi/components/hover-effect-control/index.js
@@ -57,6 +57,24 @@ const HoverEffectControl = props => {
 
 	const classes = classnames('maxi-hover-effect-control', className);
 
+	const effectNone = () => {
+		onChange({
+			'hover-type': 'none',
+		});
+		document
+			.getElementsByClassName('maxi-image-block__image')[0]
+			.removeAttribute('style');
+	};
+
+	const disablePreview = () => {
+		onChange({
+			'hover-preview': false,
+		});
+		document
+			.getElementsByClassName('maxi-image-block__image')[0]
+			.removeAttribute('style');
+	};
+
 	return (
 		<div className={classes}>
 			<SettingTabsControl
@@ -69,10 +87,12 @@ const HoverEffectControl = props => {
 					{ icon: <Icon icon={hoverText} />, value: 'text' },
 				]}
 				onChange={val => {
-					onChange({
-						'hover-type': val,
-						'hover-transition-duration': 0.5,
-					});
+					val === 'none'
+						? effectNone()
+						: onChange({
+								'hover-type': val,
+								'hover-transition-duration': 0.5,
+						  });
 				}}
 				hasBorder
 			/>
@@ -80,7 +100,11 @@ const HoverEffectControl = props => {
 				<ToggleSwitch
 					label={__('Show hover preview', 'maxi-blocks')}
 					selected={props['hover-preview']}
-					onChange={val => onChange({ 'hover-preview': val })}
+					onChange={val => {
+						val === false
+							? disablePreview()
+							: onChange({ 'hover-preview': val });
+					}}
 				/>
 			)}
 			<ToggleSwitch

--- a/src/blocks/image-maxi/components/hover-effect-control/index.js
+++ b/src/blocks/image-maxi/components/hover-effect-control/index.js
@@ -53,7 +53,14 @@ import {
  * Component
  */
 const HoverEffectControl = props => {
-	const { className, onChangeInline, onChange, blockStyle, clientId } = props;
+	const {
+		className,
+		onChangeInline,
+		onChange,
+		blockStyle,
+		clientId,
+		breakpoint,
+	} = props;
 
 	const classes = classnames('maxi-hover-effect-control', className);
 
@@ -97,21 +104,23 @@ const HoverEffectControl = props => {
 				hasBorder
 			/>
 			{props['hover-type'] !== 'none' && (
-				<ToggleSwitch
-					label={__('Show hover preview', 'maxi-blocks')}
-					selected={props['hover-preview']}
-					onChange={val => {
-						val === false
-							? disablePreview()
-							: onChange({ 'hover-preview': val });
-					}}
-				/>
+				<>
+					<ToggleSwitch
+						label={__('Show hover preview', 'maxi-blocks')}
+						selected={props['hover-preview']}
+						onChange={val => {
+							val === false
+								? disablePreview()
+								: onChange({ 'hover-preview': val });
+						}}
+					/>
+					<ToggleSwitch
+						label={__('Extend outside boundary', 'maxi-blocks')}
+						selected={props['hover-extension']}
+						onChange={val => onChange({ 'hover-extension': val })}
+					/>
+				</>
 			)}
-			<ToggleSwitch
-				label={__('Extend outside boundary', 'maxi-blocks')}
-				selected={props['hover-extension']}
-				onChange={val => onChange({ 'hover-extension': val })}
-			/>
 			{props['hover-type'] !== 'none' &&
 				(props['hover-type'] === 'text' ||
 					props['hover-basic-effect-type'] === 'zoom-in' ||
@@ -559,6 +568,7 @@ const HoverEffectControl = props => {
 							label={__('Padding', 'maxi-blocks')}
 							onChange={onChange}
 							target='hover-padding'
+							breakpoint={breakpoint}
 							disableAuto
 						/>
 					)}
@@ -578,6 +588,7 @@ const HoverEffectControl = props => {
 							onChange={onChange}
 							target='hover-margin'
 							optionType='string'
+							breakpoint={breakpoint}
 						/>
 					)}
 				</>

--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -598,13 +598,13 @@ body.maxi-blocks--active figure.maxi-image-block {
 			&__slide {
 				img,
 				svg {
-					margin-left: 0;
+					transform: translateX(0);
 					transition: 0.3s ease-in-out;
 				}
 				&:hover {
 					img,
 					svg {
-						margin-left: 30px;
+						transform: translateX(0);
 					}
 				}
 			}

--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -634,7 +634,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 					}
 				}
 			}
-			&__greay-scale {
+			&__grey-scale {
 				img,
 				svg {
 					filter: grayscale(0);

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -63,7 +63,6 @@ const HoverPreview = props => {
 			showEffects
 		) {
 			targetWrapper.style.transform = '';
-			targetWrapper.style.marginLeft = '';
 			targetWrapper.style.filter = '';
 			targetWrapper.style.transitionDuration = `${hoverTransitionDuration}s`;
 			targetWrapper.style.transitionTimingFunction =
@@ -78,12 +77,11 @@ const HoverPreview = props => {
 			else if (hoverBasicEffectType === 'zoom-out')
 				targetWrapper.style.transform = 'scale(1)';
 			else if (hoverBasicEffectType === 'slide')
-				targetWrapper.style.marginLeft = `${props['hover-basic-slide-value']}px`;
+				targetWrapper.style.transform = `translateX(${props['hover-basic-slide-value']}px)`;
 			else if (hoverBasicEffectType === 'blur')
 				targetWrapper.style.filter = `blur(${props['hover-basic-blur-value']}px)`;
 			else {
 				targetWrapper.style.transform = '';
-				targetWrapper.style.marginLeft = '';
 				targetWrapper.style.filter = '';
 			}
 		}
@@ -99,12 +97,11 @@ const HoverPreview = props => {
 			else if (hoverBasicEffectType === 'zoom-out')
 				targetWrapper.style.transform = `scale(${props['hover-basic-zoom-out-value']})`;
 			else if (hoverBasicEffectType === 'slide')
-				targetWrapper.style.marginLeft = 0;
+				targetWrapper.style.transform = 'translateX(0)';
 			else if (hoverBasicEffectType === 'blur')
 				targetWrapper.style.filter = 'blur(0)';
 			else {
 				targetWrapper.style.transform = '';
-				targetWrapper.style.marginLeft = '';
 				targetWrapper.style.filter = '';
 			}
 		}

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -77,7 +77,7 @@ const HoverPreview = props => {
 			else if (hoverBasicEffectType === 'zoom-out')
 				targetWrapper.style.transform = 'scale(1)';
 			else if (hoverBasicEffectType === 'slide')
-				targetWrapper.style.transform = `translateX(${props['hover-basic-slide-value']}px)`;
+				targetWrapper.style.transform = `translateX(${props['hover-basic-slide-value']}%)`;
 			else if (hoverBasicEffectType === 'blur')
 				targetWrapper.style.filter = `blur(${props['hover-basic-blur-value']}px)`;
 			else {
@@ -97,7 +97,7 @@ const HoverPreview = props => {
 			else if (hoverBasicEffectType === 'zoom-out')
 				targetWrapper.style.transform = `scale(${props['hover-basic-zoom-out-value']})`;
 			else if (hoverBasicEffectType === 'slide')
-				targetWrapper.style.transform = 'translateX(0)';
+				targetWrapper.style.transform = 'translateX(0%)';
 			else if (hoverBasicEffectType === 'blur')
 				targetWrapper.style.filter = 'blur(0)';
 			else {

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -38,13 +38,13 @@ const HoverPreview = props => {
 		'clear-grey-scale',
 	];
 
-	const classes = classnames(
-		'maxi-hover-preview',
-		wrapperClassName,
-		hoverType !== 'none' && hoverClassName
-	);
-
 	const showEffects = props['hover-preview'] || isSave;
+
+	const classes = classnames(
+		showEffects && hoverType !== 'none' && 'maxi-hover-preview',
+		wrapperClassName,
+		showEffects && hoverType !== 'none' && hoverClassName
+	);
 
 	const transitionTimingFunction = `${
 		hoverTransitionEasing !== 'cubic-bezier'
@@ -55,10 +55,12 @@ const HoverPreview = props => {
 	}`;
 
 	const mouseHoverHandle = ({ target }) => {
-		const targetWrapper = target.closest('.maxi-hover-preview');
+		const targetWrapper = target.closest('.maxi-hover-preview img');
 		if (
-			hoverType === 'text' ||
-			transitionDurationEffects.includes(hoverBasicEffectType)
+			hoverType !== 'none' &&
+			(hoverType === 'text' ||
+				transitionDurationEffects.includes(hoverBasicEffectType)) &&
+			showEffects
 		) {
 			targetWrapper.style.transform = '';
 			targetWrapper.style.marginLeft = '';
@@ -88,7 +90,7 @@ const HoverPreview = props => {
 	};
 
 	const mouseOutHandle = ({ target }) => {
-		const targetWrapper = target.closest('.maxi-hover-preview');
+		const targetWrapper = target.closest('.maxi-hover-preview img');
 		if (hoverType === 'basic') {
 			if (hoverBasicEffectType === 'zoom-in')
 				targetWrapper.style.transform = 'scale(1)';
@@ -109,12 +111,12 @@ const HoverPreview = props => {
 	};
 
 	const getEnhancedChildren = children => {
-		if (children.type === 'img')
+		if (children.type === 'img') {
 			return cloneElement(children, {
 				onMouseOver: mouseHoverHandle,
 				onMouseOut: mouseOutHandle,
 			});
-
+		}
 		if (children?.props?.children) {
 			const cleanedChildren = DOMPurify.sanitize(children.props.children);
 			const parsedContent = parse(cleanedChildren, {

--- a/src/extensions/maxi-block/handleSetAttributes.js
+++ b/src/extensions/maxi-block/handleSetAttributes.js
@@ -177,7 +177,6 @@ const handleSetAttributes = ({
 		defaultAttributes,
 	});
 
-	console.log(cleanedResponse);
 	return onChange(cleanedResponse);
 };
 

--- a/src/extensions/maxi-block/handleSetAttributes.js
+++ b/src/extensions/maxi-block/handleSetAttributes.js
@@ -177,6 +177,7 @@ const handleSetAttributes = ({
 		defaultAttributes,
 	});
 
+	console.log(cleanedResponse);
 	return onChange(cleanedResponse);
 };
 


### PR DESCRIPTION
- Removes unnecessary transition styles from the image which were rendered even if no effects were selected.
- Fixes grayscale effect
- Fixes boundary glitch

Fixes #3808
Fixes #4117

**_ Front/Back Testing _**

-   [ ] Test that grayscale effect works (backend and frontend)
-   [ ] Test that zoom-in effect works normally and that the "Extend outside boundary" option works
-   [ ] Ensure that the image doesn't have any inline styles if no effects are selected or if show preview isn't selected

**_ Pre-Code Testing _**

-   [ ] Test that grayscale effect works (backend and frontend)
-   [ ] Test that zoom-in effect works normally and that the "Extend outside boundary" option works
-   [ ] Ensure that the image doesn't have any inline styles if no effects are selected or if show preview isn't selected
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
