### PR TITLE
Issue 4278 - Inserter dropdown background

### DIFF
--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -126,6 +126,10 @@
 		border-radius: 0;
 		box-shadow: none;
 		outline: none;
+
+		.components-dropdown {
+			background-color: #fff;
+		}
 	}
 
 	&__button-wrapper {
@@ -156,6 +160,10 @@
 		border-radius: 0;
 		box-shadow: none;
 		outline: none;
+
+		.components-dropdown {
+			background-color: #fff;
+		}
 
 		> div:first-of-type {
 			display: flex;


### PR DESCRIPTION
Fixes background colour for the block inserter dropdown component.

Fixes #4278 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the case from the video and make sure that the dropdown menu is white and not transparent.

**_ Pre-Code Testing _**

-   [x] Test the case from the video and make sure that the dropdown menu is white and not transparent.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
