### PR TITLE
Inserter dropdown background

### DIFF
--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -162,7 +162,7 @@
 		outline: none;
 
 		.components-dropdown {
-			background-color: #fff;
+			background-color: transparent;
 		}
 
 		> div:first-of-type {


### PR DESCRIPTION
Removed inter block inserter background colour that was mistakenly added here: https://github.com/maxi-blocks/maxi-blocks/pull/4284/files

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test block inserter bg colour for inter block inserter and grouped elements (see #4284 as an example)

**_ Pre-Code Testing _**

-   [ ] Test block inserter bg colour for inter block inserter and grouped elements (see #4284 as an example)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
