### PR TITLE
Image Maxi `fit on wrapper` fix

### DIFF
--- a/src/blocks/image-maxi/components/hover-effect-control/index.js
+++ b/src/blocks/image-maxi/components/hover-effect-control/index.js
@@ -320,15 +320,15 @@ const HoverEffectControl = props => {
 								onReset={() =>
 									onChange({
 										[`hover-basic-${props['hover-basic-effect-type']}-value`]:
-											getDefaultAttribute([
-												`hover-basic-${props['hover-basic-effect-type']}-value`,
-											]),
+											getDefaultAttribute(
+												`hover-basic-${props['hover-basic-effect-type']}-value`
+											),
 										isReset: true,
 									})
 								}
-								initialPosition={getDefaultAttribute([
-									`hover-basic-${props['hover-basic-effect-type']}-value`,
-								])}
+								initialPosition={getDefaultAttribute(
+									`hover-basic-${props['hover-basic-effect-type']}-value`
+								)}
 							/>
 						)}
 				</>

--- a/src/components/hover-preview/index.js
+++ b/src/components/hover-preview/index.js
@@ -41,7 +41,7 @@ const HoverPreview = props => {
 	const showEffects = props['hover-preview'] || isSave;
 
 	const classes = classnames(
-		showEffects && hoverType !== 'none' && 'maxi-hover-preview',
+		'maxi-hover-preview',
 		wrapperClassName,
 		showEffects && hoverType !== 'none' && hoverClassName
 	);


### PR DESCRIPTION
# Description

@Olekrut shared this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/10555120/team-pro-95.txt) on the chat and showed that the Image Maxi nested on the Columns was looking like this:

![image (5)](https://user-images.githubusercontent.com/50477222/215996608-3f3f26ca-fdc3-419d-9d3b-52dc133d5900.png)

This PR aims to fix it. Also fixes an issue when opening `Hover preview` tab that broke the block.

This PR is overwriting part of #4282, so please @Marko64, check if it breaks something fixed there 👍 

# How Has This Been Tested?

Test the code editor shared before on master and see the result; then check on this branch. Also, on master, try to open 'Hover preview', it should break the block, not like this branch 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Do the test commented above

**_ Pre-Code Testing _**

-   [ ] Do the test commented above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
