### PR TITLE
Issue 4259 - Margin corrupted styles

### DIFF
--- a/src/extensions/styles/helpers/getMarginPaddingStyles.js
+++ b/src/extensions/styles/helpers/getMarginPaddingStyles.js
@@ -46,6 +46,10 @@ const getMarginPaddingStyles = ({ obj, prefix = '' }) => {
 						lastValue === 'auto'
 							? 'auto'
 							: `${lastValue}${lastUnit}`;
+
+				if (value === '') {
+					delete response[breakpoint][`${type}-${key}`];
+				}
 			})
 		);
 	});

--- a/src/extensions/styles/helpers/getMarginPaddingStyles.js
+++ b/src/extensions/styles/helpers/getMarginPaddingStyles.js
@@ -47,9 +47,7 @@ const getMarginPaddingStyles = ({ obj, prefix = '' }) => {
 							? 'auto'
 							: `${lastValue}${lastUnit}`;
 
-				if (value === '') {
-					delete response[breakpoint][`${type}-${key}`];
-				}
+				if (value === '') delete response[breakpoint][`${type}-${key}`];
 			})
 		);
 	});

--- a/src/extensions/styles/helpers/test/__snapshots__/getMarginPaddingStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getMarginPaddingStyles.js.snap
@@ -143,3 +143,15 @@ Object {
   },
 }
 `;
+
+exports[`getMarginPaddingStyles Get a correct margin and padding styles, when value is undefined but unit is defined 1`] = `
+Object {
+  "general": Object {},
+  "l": Object {},
+  "m": Object {},
+  "s": Object {},
+  "xl": Object {},
+  "xs": Object {},
+  "xxl": Object {},
+}
+`;

--- a/src/extensions/styles/helpers/test/getMarginPaddingStyles.js
+++ b/src/extensions/styles/helpers/test/getMarginPaddingStyles.js
@@ -201,4 +201,23 @@ describe('getMarginPaddingStyles', () => {
 		});
 		expect(result).toMatchSnapshot();
 	});
+
+	it('Get a correct margin and padding styles, when value is undefined but unit is defined', () => {
+		const obj = {
+			'margin-top-general': '',
+			'margin-right-general': '',
+			'margin-bottom-general': '',
+			'margin-left-general': '',
+			'margin-sync-general': 'all',
+			'margin-top-unit-general': 'px',
+			'margin-right-unit-general': 'px',
+			'margin-bottom-unit-general': 'px',
+			'margin-left-unit-general': 'px',
+		};
+
+		const result = getMarginPaddingStyles({
+			obj,
+		});
+		expect(result).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
Fixes #4259 

**_ Front/Back Testing _**

-   [x] Add any block and add some margin and padding. Inspect the block element and you should see the styles rendered. Remove margin and padding (input fields should be empty) and make sure that styles rendered are not empty but that they do not show at all.

**_ Pre-Code Testing _**
Add any block and add some margin and padding. Inspect the block element and you should see the styles rendered. Remove margin and padding (input fields should be empty) and make sure that styles rendered are not empty but that they do not show at all.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
