### PR TITLE
Issue 4222 - Image border target IB

### DIFF
--- a/src/extensions/relations/getCanvasSettings.js
+++ b/src/extensions/relations/getCanvasSettings.js
@@ -108,7 +108,7 @@ const getCanvasSettings = ({ name }) => [
 			}),
 	},
 	{
-		label: __('Border', 'maxi-blocks'),
+		label: __('Canvas border', 'maxi-blocks'),
 		transitionTarget: ['', ' > .maxi-background-displayer'],
 		hoverProp: 'border-status-hover',
 		attrGroupName: ['border', 'borderWidth', 'borderRadius'],


### PR DESCRIPTION
If a block has settings with the same name, like "Border" in the settings and canvas tabs, IB can't differentiate between them.
They need a prefix or a different label in IB only. Did the latter as a simple solution this time and changed "Border" to "Canvas border", only in IB.

Editor code: [ib-targets.txt](https://github.com/maxi-blocks/maxi-blocks/files/10577201/ib-targets.txt)

Fixes #4222 

**_ Front/Back Testing _**

-   [ ] Insert the code attached. Try it on master - you should get a single border on hover only. Then try in this branch and you should see both borders from the block and the canvas.
-   [ ] Test other blocks to see if we have the same issue with any other settings.

**_ Pre-Code Testing _**

-   [ ] Insert the code attached. Try it on master - you should get a single border on hover only. Then try in this branch and you should see both borders from the block and the canvas.
-   [ ] Test other blocks to see if we have the same issue with any other settings.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
