### PR TITLE
Issue 4310 - Reusable blocks save button position

### DIFF
--- a/src/components/toolbar/components/reusable-blocks/editor.scss
+++ b/src/components/toolbar/components/reusable-blocks/editor.scss
@@ -49,10 +49,10 @@
 
 				&::after {
 					content: '';
-					display: block;
-					bottom: 0;
+					width: 200%;
 					height: 1px;
 					margin: 8px -8px;
+					display: block;
 					background-color: #dbdde6;
 				}
 			}
@@ -72,17 +72,17 @@
 		}
 
 		form {
+			display: flex;
+			overflow: hidden;
+
 			.components-button {
-				float: right;
-				position: absolute !important;
-				right: 2px;
-				bottom: 1px;
 				width: auto !important;
-				height: 26px !important;
+				height: 29px !important;
+				margin-top: auto;
+				padding: 0px 12px;
 				background-color: #e5f2f8;
 				font-weight: 700;
 				color: #007cba;
-				padding: 0px 12px;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #4310 

**_ Front/Back Testing _**

-   [ ] Make sure that the save button for reusable blocks is positioned correctly.

**_ Pre-Code Testing _**

-   [ ] Make sure that the save button for reusable blocks is positioned correctly.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
