### PR TITLE
Issue 4313 - Align button width and bug

### DIFF
--- a/src/components/toolbar/editor.scss
+++ b/src/components/toolbar/editor.scss
@@ -163,7 +163,7 @@
 				&__duplicate .components-button,
 				&__move,
 				&__replay,
-				&__alignment,
+				&__alignment:not(.maxi-dropdown),
 				&__bold,
 				&__italic,
 				&__button {
@@ -211,7 +211,7 @@
 						outline: 0;
 					}
 				}
-				&__alignment,
+				&__alignment:not(.maxi-dropdown),
 				&__bold,
 				&__italic {
 					height: auto;


### PR DESCRIPTION
Fixes #4313 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the align button for the button and icon block. It should look and behave like the rest of the buttons. Check that the bug is fixed when hovering align 'remove block' was also hovered.
- 
**_ Pre-Code Testing _**

-   [ ] Test the align button for the button and icon block. It should look and behave like the rest of the buttons. Check that the bug is fixed when hovering align 'remove block' was also hovered.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
