### PR TITLE
Issue 4316 - remove colour opacity for SVG in SC Editor

### DIFF
--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -14,6 +14,14 @@ body {
 			}
 		}
 
+		.maxi-blocks-sc__type--SVG {
+			.maxi-color-control__palette,
+			.maxi-color-control__display {
+				margin-top: 8px;
+				margin-bottom: 8px;
+			}
+		}
+
 		.maxi-color-control {
 			.chrome-picker {
 				width: 100% !important;

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -48,6 +48,7 @@ const GlobalColor = props => {
 		SC,
 		onChangeValue,
 		SCStyle,
+		disableOpacity = false,
 	} = props;
 
 	return (
@@ -132,6 +133,7 @@ const GlobalColor = props => {
 							);
 						}}
 						blockStyle={SCStyle}
+						disableOpacity={disableOpacity}
 						disableGradient
 					/>
 				</>
@@ -149,6 +151,7 @@ const SCAccordion = props => {
 		SCStyle,
 		onChangeValue,
 		disableTypography = false,
+		disableOpacity = false,
 	} = props;
 
 	return (
@@ -196,6 +199,7 @@ const SCAccordion = props => {
 							SC={SC}
 							onChangeValue={onChangeValue}
 							SCStyle={SCStyle}
+							disableOpacity={disableOpacity}
 						/>
 					)
 				)}
@@ -581,6 +585,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 								SCStyle={SCStyle}
 								onChangeValue={onChangeValue}
 								disableTypography
+								disableOpacity
 							/>
 						),
 					},


### PR DESCRIPTION
# Description

Removes colour opacity from SC Editor for Icon globals. Ignore the UI for now.

Fixes #4316 

# How Has This Been Tested?

Test the SC colour opacity for svg. 

# Test checklist

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in SC Editor
-   [ ] Test the component in hover state in SC Editor
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in SC Editor
-   [ ] Test the component in hover state in SC Editor
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
