### PR TITLE
Fixes style mechanism on XXL

### DIFF
--- a/src/extensions/maxi-block/test/cleanAttributes.js
+++ b/src/extensions/maxi-block/test/cleanAttributes.js
@@ -10,6 +10,7 @@ jest.mock('@wordpress/data', () => {
 		select: jest.fn(() => {
 			return {
 				receiveBaseBreakpoint: jest.fn(() => 'm'),
+				receiveMaxiDeviceType: jest.fn(() => 'general'),
 				getPrevSavedAttrs: jest.fn(() => []),
 				getSelectedBlockCount: jest.fn(() => 1),
 			};
@@ -338,9 +339,9 @@ describe('cleanAttributes', () => {
 		select.mockImplementation(
 			jest.fn(() => {
 				return {
+					receiveBaseBreakpoint: jest.fn(() => 'xl'),
 					receiveMaxiDeviceType: jest.fn(() => 'xl'),
 					getSelectedBlockCount: jest.fn(() => 1),
-					receiveBaseBreakpoint: jest.fn(() => 'xl'),
 					getPrevSavedAttrs: jest.fn(() => {
 						i += 1;
 						switch (i) {
@@ -411,6 +412,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -650,6 +652,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'm'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -874,6 +877,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'l'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -913,6 +917,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'm'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -976,6 +981,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'l'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1036,6 +1042,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'm'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1091,6 +1098,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1127,6 +1135,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'l'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1166,6 +1175,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1206,6 +1216,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1242,6 +1253,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => [
 						'test-general',
 						'test-m',
@@ -1290,6 +1302,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1331,6 +1344,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1371,6 +1385,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1403,6 +1418,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1439,6 +1455,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1475,6 +1492,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};
@@ -1511,6 +1529,7 @@ describe('cleanAttributes', () => {
 			jest.fn(() => {
 				return {
 					receiveBaseBreakpoint: jest.fn(() => 'xl'),
+					receiveMaxiDeviceType: jest.fn(() => 'general'),
 					getPrevSavedAttrs: jest.fn(() => []),
 					getSelectedBlockCount: jest.fn(() => 1),
 				};

--- a/src/extensions/styles/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/getLastBreakpointAttribute.js
@@ -55,6 +55,8 @@ const getLastBreakpointAttributeSingle = (
 			keys
 		);
 
+	const currentBreakpoint =
+		select('maxiBlocks')?.receiveMaxiDeviceType() ?? 'general';
 	const baseBreakpoint = select('maxiBlocks')?.receiveBaseBreakpoint();
 
 	const attrFilter = attr =>
@@ -63,7 +65,7 @@ const getLastBreakpointAttributeSingle = (
 
 	// In case that breakpoint is general and baseBreakpoint attribute exists,
 	// give priority to baseBreakpoint attribute
-	if (breakpoint === 'general') {
+	if (breakpoint === 'general' && currentBreakpoint === 'general') {
 		const baseBreakpointAttr = getValueFromKeys(
 			attr[
 				`${!isEmpty(target) ? `${target}-` : ''}${baseBreakpoint}${

--- a/src/extensions/styles/helpers/getTypographyStyles.js
+++ b/src/extensions/styles/helpers/getTypographyStyles.js
@@ -118,7 +118,7 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: isCustomFormat ? customFormatTypography : obj,
-			avoidXXL: false,
+			avoidXXL: breakpoint === 'general',
 		});
 
 		if (!normalTypography || unit) return unit === '-' ? '' : unit;
@@ -127,7 +127,7 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: normalTypography,
-			avoidXXL: false,
+			avoidXXL: breakpoint === 'general',
 		});
 	};
 

--- a/src/extensions/styles/helpers/test/__snapshots__/getTypographyStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getTypographyStyles.js.snap
@@ -103,6 +103,28 @@ Object {
 }
 `;
 
+exports[`getTypographyStyles Get a correct typography styles when there is a unit value set for XXL and general has no value (it has unit) 1`] = `
+Object {
+  "general": Object {
+    "color": "var(--maxi-light-p-color,rgba(var(--maxi-light-color-5,0,0,0),1))",
+    "font-size": "90px",
+    "line-height": "99px",
+  },
+  "m": Object {
+    "font-size": "60px",
+    "line-height": "70px",
+  },
+  "s": Object {
+    "font-size": "36px",
+    "line-height": "48px",
+  },
+  "xxl": Object {
+    "font-size": "6.12em",
+    "line-height": "1.19em",
+  },
+}
+`;
+
 exports[`getTypographyStyles Get a correct typography styles with hover 1`] = `
 Object {
   "general": Object {

--- a/src/extensions/styles/helpers/test/getTypographyStyles.js
+++ b/src/extensions/styles/helpers/test/getTypographyStyles.js
@@ -1,5 +1,12 @@
 import getTypographyStyles from '../getTypographyStyles';
 
+jest.mock('@wordpress/data', () => {
+	return {
+		select: jest.fn(),
+	};
+});
+import { select } from '@wordpress/data';
+
 jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () => {
 	return jest.fn(() => {
 		return {
@@ -319,6 +326,44 @@ describe('getTypographyStyles', () => {
 			blockStyle: 'light',
 			isHover: true,
 			normalTypography: obj,
+		});
+		expect(result).toMatchSnapshot();
+	});
+
+	it('Get a correct typography styles when there is a unit value set for XXL and general has no value (it has unit)', () => {
+		select.mockImplementation(
+			jest.fn(() => {
+				return {
+					receiveMaxiDeviceType: jest.fn(() => 'xl'),
+					receiveBaseBreakpoint: jest.fn(() => 'xxl'),
+					getSelectedBlockCount: jest.fn(() => 1),
+				};
+			})
+		);
+		const obj = {
+			'palette-status-general': true,
+			'palette-color-general': 5,
+			'list-palette-status-general': true,
+			'list-palette-color-general': 4,
+			'font-size-unit-general': 'px',
+			'font-size-unit-xxl': 'em',
+			'font-size-unit-m': 'px',
+			'font-size-general': 90,
+			'font-size-xxl': 6.12,
+			'font-size-m': 60,
+			'font-size-s': 36,
+			'line-height-unit-general': 'px',
+			'line-height-unit-xxl': 'em',
+			'line-height-unit-m': 'px',
+			'line-height-general': 99,
+			'line-height-xxl': 1.19,
+			'line-height-m': 70,
+			'line-height-s': 48,
+		};
+
+		const result = getTypographyStyles({
+			obj,
+			blockStyle: 'light',
 		});
 		expect(result).toMatchSnapshot();
 	});

--- a/src/extensions/styles/test/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/test/getLastBreakpointAttribute.js
@@ -6,6 +6,7 @@ jest.mock('@wordpress/data', () => {
 			return {
 				getSelectedBlockCount: jest.fn(() => 1),
 				receiveBaseBreakpoint: jest.fn(() => 'xl'),
+				receiveMaxiDeviceType: jest.fn(() => 'general'),
 			};
 		}),
 	};
@@ -163,6 +164,7 @@ describe('getLastBreakpointAttribute', () => {
 	test('Should return XXL value when breakpoint is General but there is not General attribute; baseBreakpoint is XXL', () => {
 		select.mockImplementation(() => ({
 			getSelectedBlockCount: jest.fn(() => 1),
+			receiveMaxiDeviceType: jest.fn(() => 'general'),
 			receiveBaseBreakpoint: jest.fn(() => 'xxl'),
 		}));
 
@@ -185,6 +187,7 @@ describe('getLastBreakpointAttribute', () => {
 	test('Should return XXL value when breakpoint is General and baseBreakpoint is XXL', () => {
 		select.mockImplementation(() => ({
 			getSelectedBlockCount: jest.fn(() => 1),
+			receiveMaxiDeviceType: jest.fn(() => 'general'),
 			receiveBaseBreakpoint: jest.fn(() => 'xxl'),
 		}));
 


### PR DESCRIPTION
# Description

Going to describe this issue in 2 parts: the visual and experience one, and the code/logics one.
As visual, the case is the next one:

https://user-images.githubusercontent.com/50477222/217794510-93ede23b-07dc-4c1b-9784-16bad0cf0eb7.mp4

As code and logics: the main problem comes from `getLastBreakpointAttribute`, concretely from these lines:
https://github.com/maxi-blocks/maxi-blocks/blob/428d69b726ffc90154103d8fa8a4f33465bf3c43/src/extensions/styles/getLastBreakpointAttribute.js#L64-L77

This logic, what is checking, it's that in case the breakpoint received by the function it's equal to 'general' and the `baseBreakpoint` attribute exists, returns that attribute. It has sense in 99% of cases, but not in XXL. Why? Let's have some examples:
```
// baseBreakpoint = xl
// maxiBreakpoint = general
// attributes: { general: 1, xl: 2 }
// Result: we should receive 2, as the baseBreakpoint overlaps the general one
```
```
// baseBreakpoint = xl
// maxiBreakpoint = general
// attributes: { general: 1, xl: undefined }
// Result: we should receive 1, as the baseBreakpoint attribute doesn't exist
```
```
// baseBreakpoint = xxl
// maxiBreakpoint = general
// attributes: { general: 1, xxl: 2 }
// Result: we should receive 2, as the baseBreakpoint overlaps the general one
```
```
## Current case!

// baseBreakpoint = xxl
// maxiBreakpoint = xl
// attributes: { general: 1, xxl: 2 }
// Result: we should receive 1, as the baseBreakpoint is XXL, which is above General in logics (remeber the order [XXL, General, XL, L, M, S, XS] => XXL values shouldn't affect lower values.
```
** `xl` breakpoint can be swapped with any other lower breakpoint than XXL

The last exposed case wasn't working like that, and was returning XXL value instead of general on the case of the video where the values were:
```
	{
			'font-size-unit-general': 'px',
			'font-size-unit-xxl': 'em',
			'font-size-unit-m': 'px',
			'font-size-general': 90,
			'font-size-xxl': 6.12,
			'font-size-m': 60,
			'font-size-s': 36,
		}
```

I explain  this fix detailed because it might affect other aspects in future and in case it's necessary to remember why it was done, it can stay here. The logics of the implementation should fix this issue and shouldn't break anything else in 99% of cases.

# How Has This Been Tested?

Followed the steps of video.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Follow the steps of the video

**_ Pre-Code Testing _**

-   [ ] Follow the steps of the video
- [ ] Think if there's any situation where the implemented logical condition can have side effects ❗ 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
