### PR TITLE
Issue 4328 - SVG Icon deferred transitions from IB  

### DIFF
--- a/src/blocks/svg-icon-maxi/data.js
+++ b/src/blocks/svg-icon-maxi/data.js
@@ -182,7 +182,10 @@ const interactionBuilderSettings = {
 	block: [
 		{
 			label: __('Icon colour'),
-			transitionTarget: transition.block.colour.target,
+			transitionTarget: [
+				transition.block.colour.target,
+				transition.block['colour two'].target,
+			],
 			transitionTrigger: `${iconClass} svg`,
 			hoverProp: 'svg-status-hover',
 			attrGroupName: 'svg',


### PR DESCRIPTION
# Description

This is an MVP solution for #4328. The issue seems to come from a change done on #4180, that sets the `transitionTarget` as `svg > *:not(g)` and not `svg *:not(g)`. That `>` makes the inner elements inside `g` elements don't be affected by the `transition` and generates this glitch. As an MVP, it fixes it urgently but needs to be checked, so will be moved to a new issue. 

Fixes #4328 

# How Has This Been Tested?

Checked the code editor of the issue and also these tests from #4180 :
You can use this editor's code for tests [svg-bugs.txt](https://github.com/maxi-blocks/maxi-blocks/files/10332444/svg-bugs.txt) from https://devdemo.maxiblocks.com/svg-hover-test/

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the issue has been fixed
-   [ ] Test the implementations done on #4180 aren't broken

**_ Pre-Code Testing _**

-   [ ] Test the issue has been fixed
-   [ ] Test the implementations done on #4180 aren't broken
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
