### PR TITLE
Fixes issue with SC1 version on migrators

### DIFF
--- a/src/extensions/styles/migrators/bottomGapMigrator.js
+++ b/src/extensions/styles/migrators/bottomGapMigrator.js
@@ -10,6 +10,7 @@ const name = 'Text bottom gap migrator';
 const maxiVersions = [
 	'0.1',
 	'0.0.1 SC1',
+	'0.0.1-SC1',
 	'0.0.1-SC2',
 	'0.0.1-SC3',
 	'0.0.1-SC4',

--- a/src/extensions/styles/migrators/maxiAttributesMigrator.js
+++ b/src/extensions/styles/migrators/maxiAttributesMigrator.js
@@ -11,7 +11,13 @@ import { isNil } from 'lodash';
 
 const name = 'maxiAttributes Migrator';
 
-const maxiVersions = ['0.1', '0.0.1 SC1', '0.0.1-SC2', '0.0.1-SC3'];
+const maxiVersions = [
+	'0.1',
+	'0.0.1 SC1',
+	'0.0.1-SC1',
+	'0.0.1-SC2',
+	'0.0.1-SC3',
+];
 
 const isEligible = blockAttributes => {
 	const {


### PR DESCRIPTION
# Description

When fixed #4253 I've suggested using '0.0.1-SC1', but the SC1 real version name was incorrect on the version we released, it hadn't the dash. So the migrators were looking for '0.0.1 SC1' and not '0.0.1-SC1'. Now it looks for both 👍 

# How Has This Been Tested?

You know what to do! lol

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Pay me a beer 🍻 

**_ Pre-Code Testing _**

-   [ ] You too 😝 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
