### PR TITLE
Issue 4361 - Remove warning from WordPress search page

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -194,7 +194,10 @@ class MaxiBlocks_Styles
     {
         if (!$is_template) {
             global $post;
-            return $post->ID;
+			if (!$post) {
+				return null;
+			}
+			return $post->ID;
         }
 
         $template_slug = get_page_template_slug();
@@ -305,7 +308,7 @@ class MaxiBlocks_Styles
     {
         global $post;
 
-        if (!$is_template && (!$post || !isset($post->ID))) {
+        if ((!$is_template && (!$post || !isset($post->ID))) || !$id) {
             return false;
         }
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4361 

# How Has This Been Tested?
Checked if no more warning on search page, if post and FSE frontend works as expected.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if no more warning on search page (for test: http://localhost:8888/?s=123123123123)
-   [ ] Test if post and FSE frontend works as expected

**_ Pre-Code Testing _**

-   [ ] Test if no more warning on search page (for test: http://localhost:8888/?s=123123123123)
-   [ ] Test if post and FSE frontend works as expected
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
