### PR TITLE
Fix typography styles

### DIFF
--- a/src/extensions/styles/helpers/getTypographyStyles.js
+++ b/src/extensions/styles/helpers/getTypographyStyles.js
@@ -118,7 +118,6 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: isCustomFormat ? customFormatTypography : obj,
-			// avoidXXL: breakpoint === 'general',
 		});
 
 		if (!normalTypography || unit) return unit === '-' ? '' : unit;
@@ -127,7 +126,6 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: normalTypography,
-			// avoidXXL: breakpoint === 'general',
 		});
 	};
 

--- a/src/extensions/styles/helpers/getTypographyStyles.js
+++ b/src/extensions/styles/helpers/getTypographyStyles.js
@@ -118,7 +118,7 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: isCustomFormat ? customFormatTypography : obj,
-			avoidXXL: breakpoint === 'general',
+			// avoidXXL: breakpoint === 'general',
 		});
 
 		if (!normalTypography || unit) return unit === '-' ? '' : unit;
@@ -127,7 +127,7 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: normalTypography,
-			avoidXXL: breakpoint === 'general',
+			// avoidXXL: breakpoint === 'general',
 		});
 	};
 


### PR DESCRIPTION
# Description

Fixes the issue @Olekrut shared on the chat

@elzadj and @Marko64 you know about code, so you can easily see it's residual code. Check the deleted lines here, and compare the effect they were having on https://github.com/maxi-blocks/maxi-blocks/pull/4330. The `avoidXXL` was not changed on `getLastBreakpintAttribute`, so I changed there the logics of `getTypographyStyles` without changing the logics of `avoidXXL`; it was a test I did and forgot to clean. My fault 👍 

# How Has This Been Tested?

Check [code editor](https://github.com/maxi-blocks/maxi-blocks/files/10767368/badtype.txt) code editor and ensure it fixes the issue and doesn't break any of these PRs:


https://github.com/maxi-blocks/maxi-blocks/pull/4354
https://github.com/maxi-blocks/maxi-blocks/pull/4330

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
