### PR TITLE
Issue 4301 - Block indicator padding background

### DIFF
--- a/src/components/block-indicators/editor.scss
+++ b/src/components/block-indicators/editor.scss
@@ -11,7 +11,7 @@
 	&__padding {
 		background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23007CBA' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E");
 		border: 1px solid #c7e6f7;
-		background-color: rgba(249, 252, 253, 0.9);
+		background-color: rgba(249, 252, 253, 0.8);
 		color: #9b9b9b;
 	}
 

--- a/src/components/block-indicators/editor.scss
+++ b/src/components/block-indicators/editor.scss
@@ -11,7 +11,7 @@
 	&__padding {
 		background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23007CBA' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E");
 		border: 1px solid #c7e6f7;
-		background-color: #f9fcfd;
+		background-color: rgba(249, 252, 253, 0.9);
 		color: #9b9b9b;
 	}
 


### PR DESCRIPTION
Changed block indicator padding background colour.

Fixes #4391 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that block indicator padding bg is changed to rgba(249, 252, 253, 0.9)

**_ Pre-Code Testing _**

-   [ ] Test that block indicator padding bg is changed to rgba(249, 252, 253, 0.9)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
