### PR TITLE
Issue 4152 - `TransformControl` hover values inherit from normal fix

### DIFF
--- a/src/components/transform-control/index.js
+++ b/src/components/transform-control/index.js
@@ -40,7 +40,7 @@ const TransformControl = props => {
 		className,
 		onChangeInline = null,
 		onChange,
-		breakpoint = 'general',
+		breakpoint,
 		depth,
 		categories,
 		selectors,
@@ -360,6 +360,7 @@ const TransformControl = props => {
 										target: 'transform-scale',
 										key: 'y',
 									})}
+									breakpoint={breakpoint}
 									onChange={(x, y) => {
 										onChangeTransform({
 											'transform-scale': {
@@ -431,6 +432,7 @@ const TransformControl = props => {
 											key: 'y-unit',
 										}) ?? '%'
 									}
+									breakpoint={breakpoint}
 									onChange={(x, y, xUnit, yUnit) => {
 										onChangeTransform({
 											'transform-translate': {
@@ -551,6 +553,7 @@ const TransformControl = props => {
 											key: 'y-unit',
 										}) ?? '%'
 									}
+									breakpoint={breakpoint}
 									onChange={(x, y, xUnit, yUnit) => {
 										onChangeTransform({
 											'transform-origin': {

--- a/src/components/transform-control/square-control.js
+++ b/src/components/transform-control/square-control.js
@@ -34,6 +34,7 @@ const SquareControl = props => {
 		xUnit = null,
 		y,
 		yUnit = null,
+		breakpoint,
 		onChange,
 		onSave,
 		type = 'resize',
@@ -245,6 +246,7 @@ const SquareControl = props => {
 							topLeft: true,
 						}}
 						lockAspectRatio={sync}
+						deviceType={breakpoint}
 						onResize={(event, direction, elt) => {
 							changeXAxis(
 								pxToPercent(elt.style.width.replace('px', ''))


### PR DESCRIPTION
# Description

Update:
- `TransformControl` inherit logic fix
- fixed change process of responsive transform settings on responsive (the values from general breakpoint always changed)

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4152 

# How Has This Been Tested?
1. Checked if, on reset hover transform settings, `TransformControl`: inherits values from higher breakpoint of hover transform settings if they exist or inherits values from normal state
Example with problem:

https://user-images.githubusercontent.com/46112160/220176159-d0ac8ec9-ce52-443a-a7e6-aa45b8e0689d.mp4

On video, you can see two problems:
    - on reset, it is visually reset to 100, not to the value from the normal state, only after the second click it is visually reset correctly
    -  after changing the values of the normal state, the hover state values are not inherited, but should be inherited, since they were reset

2. Checked if `TransformControl` responsive works as expected

Example with problem:

https://user-images.githubusercontent.com/46112160/220178527-bc13f791-868f-457e-98d1-88710056fbdf.mp4

From any breakpoint, it was changing general values settings, not responsive.

So in this branch, you shouldn't experience described above problems.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if values inherit as in all other controls
-   [ ] Test if responsive works as expected when values were changed by handlers

**_ Pre-Code Testing _**

-   [ ] Test if values inherit as in all other controls
-   [ ] Test if responsive works as expected when values were changed by handlers
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
