### PR TITLE
Issue 4393 - Block indicators z-index

### DIFF
--- a/src/components/block-indicators/editor.scss
+++ b/src/components/block-indicators/editor.scss
@@ -60,7 +60,7 @@
 			right: 0;
 			height: 100%;
 			width: auto;
-			z-index: 3 !important;
+			z-index: 3;
 		}
 
 		&--bottom {
@@ -71,6 +71,7 @@
 			left: 0;
 			height: 100%;
 			width: auto;
+			z-index: 3;
 		}
 	}
 


### PR DESCRIPTION
The MVP solution for Beta was good, so implementing the same to Master. See https://github.com/maxi-blocks/maxi-blocks/pull/4325 for more details (first video).

Fixes #4393 

# Test checklist

**_ Front/Back Testing _**

-   [ ] Create a container and focus it. Make sure that the left block indicator isn't visible.

**_ Pre-Code Testing _**

-   [ ] Create a container and focus it. Make sure that the left block indicator isn't visible.

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
