### PR TITLE
Transition migrator from old broken patterns

### DIFF
--- a/src/extensions/styles/migrators/blockMigrator.js
+++ b/src/extensions/styles/migrators/blockMigrator.js
@@ -22,6 +22,7 @@ import backgroundPositionMigrator from './backgroundPositionMigrator';
 import disableTransitionIBMigrator from './disableTransitionIBMigrator';
 import corruptedHoverAttributesMigrator from './corruptedHoverAttributesMigrator';
 import bottomGapMigrator from './bottomGapMigrator';
+import transitionMigrator from './transitionMigrator';
 
 /**
  * External dependencies
@@ -101,6 +102,7 @@ const blockMigrator = blockMigratorProps => {
 		disableTransitionIBMigrator,
 		corruptedHoverAttributesMigrator,
 		bottomGapMigrator,
+		transitionMigrator,
 		...(blockMigratorProps.migrators ?? []),
 	];
 

--- a/src/extensions/styles/migrators/transitionMigrator.js
+++ b/src/extensions/styles/migrators/transitionMigrator.js
@@ -1,0 +1,81 @@
+/**
+ * This migrator is used to ensure transition objects are complete
+ */
+
+import breakpointAttributesCreator from '../breakpointAttributesCreator';
+import { getBlockNameFromUniqueID } from './utils';
+import { getBlockData } from '../../attributes';
+import getTransformTransitionData from '../transitions/getTransformTransitionData';
+import transitionDefault from '../transitions/transitionDefault';
+
+import { isNil } from 'lodash';
+
+const name = 'Transition migrator';
+
+const attributes = breakpointAttributesCreator({
+	obj: {
+		'transform-scale': {},
+		'transform-translate-unit': {},
+		'transform-translate': {},
+		'transform-rotate': {},
+		'transform-rotate-z': {},
+		'transform-origin': {},
+		'transform-origin-unit': {},
+	},
+});
+
+const isEligible = blockAttributes => {
+	const { transition } = blockAttributes;
+
+	if (isNil(transition)) return false;
+
+	const hasTransform = Object.keys(blockAttributes).some(
+		key => key in attributes
+	);
+
+	if (!hasTransform) return false;
+
+	const blockName = getBlockNameFromUniqueID(blockAttributes.uniqueID);
+
+	const data = getBlockData(blockName);
+
+	const selectors = data?.customCss?.selectors;
+
+	const transitionSelectors = {
+		...(transition || transitionDefault),
+		transform: getTransformTransitionData(selectors, blockAttributes),
+	};
+
+	const hasAllTransitionSelectors = Object.keys(transitionSelectors).every(
+		selector => selector in transition
+	);
+
+	if (!hasAllTransitionSelectors) return true;
+
+	return false;
+};
+
+const migrate = newAttributes => {
+	const { transition } = newAttributes;
+
+	const blockName = getBlockNameFromUniqueID(newAttributes.uniqueID);
+
+	const data = getBlockData(blockName);
+
+	const selectors = data?.customCss?.selectors;
+
+	const transitionSelectors = {
+		...(transition || transitionDefault),
+		transform: getTransformTransitionData(selectors, newAttributes),
+	};
+
+	Object.keys(transitionSelectors).forEach(selector => {
+		if (!(selector in transition)) {
+			newAttributes.transition[selector] = transitionSelectors[selector];
+		}
+	});
+
+	return newAttributes;
+};
+
+export default { name, isEligible, migrate };

--- a/src/extensions/styles/migrators/transitionMigrator.js
+++ b/src/extensions/styles/migrators/transitionMigrator.js
@@ -9,6 +9,8 @@ import getTransformTransitionData from '../transitions/getTransformTransitionDat
 import transitionDefault from '../transitions/transitionDefault';
 
 import { isNil } from 'lodash';
+import getDefaultAttribute from '../getDefaultAttribute';
+import createTransitionObj from '../transitions/createTransitionObj';
 
 const name = 'Transition migrator';
 
@@ -72,6 +74,13 @@ const migrate = newAttributes => {
 	Object.keys(transitionSelectors).forEach(selector => {
 		if (!(selector in transition)) {
 			newAttributes.transition[selector] = transitionSelectors[selector];
+
+			Object.keys(transitionSelectors[selector]).forEach(key => {
+				if (key in newAttributes.transition[selector])
+					newAttributes.transition[selector][key] =
+						getDefaultAttribute('transition')?.[selector]?.[key] ||
+						createTransitionObj();
+			});
 		}
 	});
 


### PR DESCRIPTION
# Description

As @Olekrut shared on chat, some old blocks are breaking when loading. The reason is that we didn't update their transition objects. Here comes a migrator to deal with it 👍 

# How Has This Been Tested?

Check this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/10837928/brokentransition.txt) on master, and the left Group Maxi will break. Won't do it with this branch 👍 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the commented above

**_ Pre-Code Testing _**

-   [ ] Test the commented above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
