### PR TITLE
Issue 4411 - Special paste UI

### DIFF
--- a/src/components/toolbar/components/copy-paste/editor.scss
+++ b/src/components/toolbar/components/copy-paste/editor.scss
@@ -1,8 +1,6 @@
 .toolbar-item__copy-paste {
 	&__popover {
 		form {
-			padding: 5px;
-			background-color: var(--maxi-white-1-color);
 			min-width: max-content;
 
 			/* width */
@@ -130,12 +128,12 @@
 			&--special {
 				display: block;
 				height: 30px;
-				margin-top: 10px;
 				background: var(--maxi-primary-color);
 				border-radius: 0;
 				color: #fff;
 				font-size: 12px;
 				text-align: center !important;
+				padding-top: 4px !important;
 
 				&::before,
 				&::after {

--- a/src/components/toolbar/components/copy-paste/editor.scss
+++ b/src/components/toolbar/components/copy-paste/editor.scss
@@ -1,7 +1,5 @@
 .toolbar-item__copy-paste {
 	&__popover {
-		min-width: 170px;
-
 		form {
 			padding: 5px;
 			background-color: var(--maxi-white-1-color);
@@ -35,7 +33,7 @@
 			position: relative;
 			cursor: pointer;
 			margin: 0;
-			padding: 5px 7px;
+			padding: 5px 20px 5px 7px;
 			display: flex;
 			align-items: center;
 			&:hover {
@@ -184,7 +182,7 @@
 
 .maxi-copy-paste__popover {
 	.components-popover__content {
-		width: fit-content !important;
+		padding-right: 50px;
 		border-radius: 0 !important;
 
 		/* width */


### PR DESCRIPTION
> ![image](https://user-images.githubusercontent.com/46112160/221238988-1748efe4-7fcb-4e6c-87f3-06cadab4ad3a.png)
> 
> @kyrapieterse

https://github.com/maxi-blocks/maxi-blocks/issues/4411#issuecomment-1444011210

@Fybex Don't see the issue you are referring to - perhaps the button being chopped of at the bottom? That's something already fixed. 

But I did notice another styling issue, so fixed that.

Fixes #4411 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
