### PR TITLE
Issue 4447 - Only the last font weight from the page is loaded on frontend

### DIFF
--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -93,12 +93,12 @@ class MaxiBlocks_Local_Fonts
     public function generateFontURL($font_url, $font_data)
     {
         if (!empty($font_data)) {
-			// For legacy reasons font data is saved both as 'weight' ('style') and 'fontWeight' ('fontStyle')
-			// See https://github.com/maxi-blocks/maxi-blocks/pull/4305#discussion_r1098988152
-			$font_weight = array_key_exists('fontWeight', $font_data) ? $font_data['fontWeight'] :
-				(array_key_exists('weight', $font_data) ? $font_data['weight'] : false);
-			$font_style = array_key_exists('fontStyle', $font_data) ? $font_data['fontStyle'] :
-				(array_key_exists('style', $font_data) ? $font_data['style'] : false);
+            // For legacy reasons font data is saved both as 'weight' ('style') and 'fontWeight' ('fontStyle')
+            // See https://github.com/maxi-blocks/maxi-blocks/pull/4305#discussion_r1098988152
+            $font_weight = array_key_exists('fontWeight', $font_data) ? $font_data['fontWeight'] :
+                (array_key_exists('weight', $font_data) ? $font_data['weight'] : false);
+            $font_style = array_key_exists('fontStyle', $font_data) ? $font_data['fontStyle'] :
+                (array_key_exists('style', $font_data) ? $font_data['style'] : false);
 
             if (is_array($font_weight)) {
                 $font_weight = implode(',', array_unique($font_weight));
@@ -157,7 +157,9 @@ class MaxiBlocks_Local_Fonts
                     $breakpoint  = isset($split_font[2]) ? $split_font[2] : 'general';
 
                     if (class_exists('MaxiBlocks_StyleCards')) {
-                        $font_name = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level, $breakpoint);
+                        $sc_fonts = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level, $breakpoint);
+
+                        @list($font_name) = $sc_fonts;
                     }
                 }
             }
@@ -196,7 +198,9 @@ class MaxiBlocks_Local_Fonts
                 $breakpoint = $split_font[2];
 
                 if (class_exists('MaxiBlocks_StyleCards')) {
-                    $font_name = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level, $breakpoint);
+                    $sc_fonts = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level, $breakpoint);
+
+                    @list($font_name) = $sc_fonts;
                 }
             }
 

--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -154,8 +154,19 @@ class MaxiBlocks_StyleCards
         $text_level_values = (object) $style_card_values->$text_level;
 
         $font = $text_level_values->{'font-family-general'};
+        $font_weights = [];
+        $font_styles = [];
 
-        return $font;
+        foreach ($text_level_values as $key => $value) {
+            if (strpos($key, 'font-weight') !== false) {
+                $font_weights[] = $value;
+            }
+            if (strpos($key, 'font-style') !== false) {
+                $font_styles[] = $value;
+            }
+        }
+
+        return [$font, $font_weights, $font_styles];
     }
 
 

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -193,10 +193,10 @@ class MaxiBlocks_Styles
     {
         if (!$is_template) {
             global $post;
-			if (!$post) {
-				return null;
-			}
-			return $post->ID;
+            if (!$post) {
+                return null;
+            }
+            return $post->ID;
         }
 
         $template_slug = get_page_template_slug();
@@ -409,43 +409,79 @@ class MaxiBlocks_Styles
         $use_local_fonts = (bool) get_option('local_fonts');
 
         foreach ($fonts as $font => $font_data) {
-            if (strpos($font, 'sc_font') !== false) {
+            $is_sc_font = strpos($font, 'sc_font') !== false;
+
+            if ($is_sc_font) {
                 $split_font = explode('_', str_replace('sc_font_', '', $font));
                 $block_style = $split_font[0];
                 $text_level = $split_font[1];
 
                 if (class_exists('MaxiBlocks_StyleCards')) {
-                    $font = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level);
+                    $sc_fonts = MaxiBlocks_StyleCards::get_maxi_blocks_style_card_fonts($block_style, $text_level);
+
+                    @list($font, $font_weights, $font_styles) = $sc_fonts;
                 }
             }
 
             if ($font) {
-                if ($use_local_fonts) {
-                    $font_name_sanitized = str_replace(
-                        ' ',
-                        '',
-                        strtolower($font)
-                    );
-                    $font_url =
-                        wp_upload_dir()['baseurl'] .
-                        '/maxi/fonts/' .
-                        $font_name_sanitized .
-                        '/style.css';
-                } else {
-                    $font_url = "https://fonts.googleapis.com/css2?family=$font:";
-                }
-                if (!$use_local_fonts) {
-                    $local_fonts = new MaxiBlocks_Local_Fonts();
-                    $font_url = $local_fonts->generateFontURL(
-                        $font_url,
-                        $font_data
-                    );
-                }
+                if (!$is_sc_font) {
+                    if ($use_local_fonts) {
+                        $font_name_sanitized = str_replace(
+                            ' ',
+                            '',
+                            strtolower($font)
+                        );
+                        $font_url =
+                            wp_upload_dir()['baseurl'] .
+                            '/maxi/fonts/' .
+                            $font_name_sanitized .
+                            '/style.css';
+                    } else {
+                        $font_url = "https://fonts.googleapis.com/css2?family=$font:";
+                    }
 
-                wp_enqueue_style(
-                    $name . '-font-' . sanitize_title_with_dashes($font),
-                    $font_url
-                );
+                    if (!$use_local_fonts) {
+                        $local_fonts = new MaxiBlocks_Local_Fonts();
+                        $font_url = $local_fonts->generateFontURL(
+                            $font_url,
+                            $font_data
+                        );
+                    }
+
+                    wp_enqueue_style(
+                        $name . '-font-' . sanitize_title_with_dashes($font),
+                        $font_url
+                    );
+                } else {
+                    if (empty($font_weights)) {
+                        $font_weights = [$font_data['weight']];
+                    }
+                    if (empty($font_styles)) {
+                        $font_styles = [$font_data['style']];
+                    }
+
+                    $font_url = "https://fonts.googleapis.com/css2?family=$font:";
+
+                    foreach ($font_weights as $font_weight) {
+                        foreach ($font_styles as $font_style) {
+                            $font_data = [
+                                'weight' => $font_weight,
+                                'style' => $font_style,
+                            ];
+
+                            $local_fonts = new MaxiBlocks_Local_Fonts();
+                            $font_url = $local_fonts->generateFontURL(
+                                $font_url,
+                                $font_data
+                            );
+
+                            wp_enqueue_style(
+                                $name . '-font-' . sanitize_title_with_dashes($font),
+                                $font_url
+                            );
+                        }
+                    }
+                }
             }
         }
 

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -476,7 +476,7 @@ class MaxiBlocks_Styles
                             );
 
                             wp_enqueue_style(
-                                $name . '-font-' . sanitize_title_with_dashes($font),
+                                $name . '-font-' . sanitize_title_with_dashes($font . '-' . $font_weight . '-' . $font_style),
                                 $font_url
                             );
                         }


### PR DESCRIPTION
# Description

Seems the frontend font loader was mixing terms: was loading fonts from SC, but the font-weight and font-style were coming from the post, not from SC. Modified in a way that checks all possible SC weights and styles to load them. 

Fixes #4447 

# How Has This Been Tested?

Made a shallow test with the code editor of the issue. Please, test changing SC with different font-families for Headings, with different font-weights and font-styles. Also test saving the fonts on local from maxi-dashboard. All should work correctly, but before sharing there's an issue, check it in master 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check the commented above

**_ Pre-Code Testing _**

-   [ ] Check the commented above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
