### PR TITLE
Issue 4432 - fix IB relations dissapearing on switch to code editor

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -293,8 +293,8 @@ class MaxiBlockComponent extends Component {
 				return false;
 			};
 
-			keepStylesOnEditor = blocks.some(block => getName(block));
-		});
+			keepStylesOnEditor ||= blocks.some(block => getName(block));
+		}, true);
 
 		// When duplicating Gutenberg creates a copy of the current copied block twice, making the first keep the same uniqueID and second
 		// has a different one. The original block is removed so componentWillUnmount method is triggered, and as its uniqueID coincide with

--- a/src/extensions/styles/entityRecordsWrapper.js
+++ b/src/extensions/styles/entityRecordsWrapper.js
@@ -11,13 +11,23 @@ import { isEmpty } from 'lodash';
 /**
  * Wrapper which go through all dirty entity records and execute callback for each of them.
  *
- * @param {void} callback Callback to execute for each of dirty entity records.
+ * @param {void}    callback       Callback to execute for each of dirty entity records.
+ * @param {boolean} addClearEntity If true, add current post id and type to dirty entity records.
  */
-const entityRecordsWrapper = callback => {
+const entityRecordsWrapper = (callback, addClearEntity = false) => {
 	const { __experimentalGetDirtyEntityRecords } = select('core');
 	const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
 
 	if (!isEmpty(dirtyEntityRecords)) dirtyEntityRecords.forEach(callback);
+
+	if (addClearEntity) {
+		const { getCurrentPostId, getCurrentPostType } = select('core/editor');
+
+		callback({
+			key: getCurrentPostId(),
+			name: getCurrentPostType(),
+		});
+	}
 };
 
 export default entityRecordsWrapper;


### PR DESCRIPTION
# Description
The issue was only on non-edited pages.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4432

# How Has This Been Tested?
Added Hero - PRO - 41 on the page, checked if its IB styles disappear on switch to code editor and back. 
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add Hero - PRO - 41 on page, save and reload the page, switch to code editor and back and then check IB.

**_ Pre-Code Testing _**

-   [ ] Add Hero - PRO - 41 on page, save and reload the page, switch to code editor and back and then check IB.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
