### PR TITLE
Optimization - Reduced attr labels prefix fix idea

### DIFF
--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -10,9 +10,10 @@ import AdvancedNumberControl from '../advanced-number-control';
 import ToggleSwitch from '../toggle-switch';
 import withRTC from '../../extensions/maxi-block/withRTC';
 import {
-	getLastBreakpointAttribute,
-	getDefaultAttribute,
+	getAttributeKey,
 	getAttributeValue,
+	getDefaultAttribute,
+	getLastBreakpointAttribute,
 } from '../../extensions/styles';
 
 /**
@@ -76,7 +77,8 @@ const FullSizeControl = props => {
 		!hideWidth &&
 		!isBlockFullWidth &&
 		!getLastBreakpointAttribute({
-			target: `${prefix}width-fit-content`,
+			target: 'width-fit-content',
+			prefix,
 			breakpoint,
 			attributes: props,
 		});
@@ -91,9 +93,12 @@ const FullSizeControl = props => {
 						selected={isBlockFullWidth}
 						onChange={val =>
 							onChange({
-								[`full-width-${breakpoint}`]: val
-									? 'full'
-									: 'normal',
+								[getAttributeKey(
+									'full-width',
+									false,
+									'',
+									breakpoint
+								)]: val === true ? 'full' : 'normal',
 							})
 						}
 					/>
@@ -107,12 +112,20 @@ const FullSizeControl = props => {
 										imageRatio: 'original',
 										imageSize: 'full',
 										imgWidth: 100,
-										[`${prefix}full-width-${breakpoint}`]:
-											val ? 'full' : 'normal',
+										[getAttributeKey(
+											'full-width',
+											false,
+											prefix,
+											breakpoint
+										)]: val ? 'full' : 'normal',
 								  })
 								: onChange({
-										[`${prefix}full-width-${breakpoint}`]:
-											val ? 'full' : 'normal',
+										[getAttributeKey(
+											'full-width',
+											false,
+											prefix,
+											breakpoint
+										)]: val ? 'full' : 'normal',
 								  })
 						}
 					/>
@@ -122,13 +135,19 @@ const FullSizeControl = props => {
 					label={__('Set width to fit content', 'maxi-blocks')}
 					className='maxi-full-size-control__width-fit-content'
 					selected={getLastBreakpointAttribute({
-						target: `${prefix}width-fit-content`,
+						target: 'width-fit-content',
+						prefix,
 						breakpoint,
 						attributes: props,
 					})}
 					onChange={val => {
 						onChange({
-							[`${prefix}width-fit-content-${breakpoint}`]: val,
+							[getAttributeKey(
+								'width-fit-content',
+								false,
+								prefix,
+								breakpoint
+							)]: val,
 						});
 					}}
 				/>
@@ -139,31 +158,54 @@ const FullSizeControl = props => {
 					className='maxi-full-size-control__width'
 					enableUnit
 					unit={getLastBreakpointAttribute({
-						target: `${prefix}width-unit`,
+						target: 'width-unit',
+						prefix,
 						breakpoint,
 						attributes: props,
 					})}
 					onChangeUnit={val =>
-						onChange({ [`${prefix}width-unit-${breakpoint}`]: val })
+						onChange({
+							[getAttributeKey(
+								'width-unit',
+								false,
+								prefix,
+								breakpoint
+							)]: val,
+						})
 					}
 					value={getLastBreakpointAttribute({
-						target: `${prefix}width`,
+						target: 'width',
+						prefix,
 						breakpoint,
 						attributes: props,
 					})}
 					onChangeValue={val =>
-						onChange({ [`${prefix}width-${breakpoint}`]: val })
+						onChange({
+							[getAttributeKey(
+								'width',
+								false,
+								prefix,
+								breakpoint
+							)]: val,
+						})
 					}
 					onReset={() => {
+						const widthKey = getAttributeKey(
+							'width',
+							false,
+							prefix,
+							breakpoint
+						);
+						const widthUnitKey = getAttributeKey(
+							'width-unit',
+							false,
+							prefix,
+							breakpoint
+						);
+
 						onChange({
-							[`${prefix}width-${breakpoint}`]:
-								getDefaultAttribute(
-									`${prefix}width-${breakpoint}`
-								),
-							[`${prefix}width-unit-${breakpoint}`]:
-								getDefaultAttribute(
-									`${prefix}width-unit-${breakpoint}`
-								),
+							[widthKey]: getDefaultAttribute(widthKey),
+							[widthUnitKey]: getDefaultAttribute(widthUnitKey),
 							isReset: true,
 						});
 					}}
@@ -180,19 +222,26 @@ const FullSizeControl = props => {
 					)}
 					className='maxi-full-size-control__force-aspect-ratio'
 					selected={getLastBreakpointAttribute({
-						target: `${prefix}force-aspect-ratio`,
+						target: 'force-aspect-ratio',
+						prefix,
 						breakpoint,
 						attributes: props,
 					})}
 					onChange={val =>
 						onChange({
-							[`${prefix}force-aspect-ratio-${breakpoint}`]: val,
+							[getAttributeKey(
+								'force-aspect-ratio',
+								false,
+								prefix,
+								breakpoint
+							)]: val,
 						})
 					}
 				/>
 			)}
 			{!getLastBreakpointAttribute({
-				target: `${prefix}force-aspect-ratio`,
+				target: 'force-aspect-ratio',
+				prefix,
 				breakpoint,
 				attributes: props,
 			}) &&
@@ -202,34 +251,55 @@ const FullSizeControl = props => {
 						className='maxi-full-size-control__height'
 						enableUnit
 						unit={getLastBreakpointAttribute({
-							target: `${prefix}height-unit`,
+							target: 'height-unit',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeUnit={val =>
 							onChange({
-								[`${prefix}height-unit-${breakpoint}`]: val,
+								[getAttributeKey(
+									'height-unit',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
 							})
 						}
 						value={getLastBreakpointAttribute({
-							target: `${prefix}height`,
+							target: 'height',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeValue={val =>
-							onChange({ [`${prefix}height-${breakpoint}`]: val })
+							onChange({
+								[getAttributeKey(
+									'height',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
+							})
 						}
 						onReset={() => {
-							onChange({
-								[`${prefix}height-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}height-${breakpoint}`
-									),
+							const heightKey = getAttributeKey(
+								'height',
+								false,
+								prefix,
+								breakpoint
+							);
+							const heightUnitKey = getAttributeKey(
+								'height-unit',
+								false,
+								prefix,
+								breakpoint
+							);
 
-								[`${prefix}height-unit-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}height-unit-${breakpoint}`
-									),
+							onChange({
+								[heightKey]: getDefaultAttribute(heightKey),
+								[heightUnitKey]:
+									getDefaultAttribute(heightUnitKey),
 								isReset: true,
 							});
 						}}
@@ -250,7 +320,11 @@ const FullSizeControl = props => {
 				}
 				onChange={val => {
 					onChange({
-						[`${prefix}size-advanced-options`]: val,
+						[getAttributeKey(
+							'size-advanced-options',
+							false,
+							prefix
+						)]: val,
 					});
 				}}
 			/>
@@ -262,7 +336,8 @@ const FullSizeControl = props => {
 				<>
 					{!hideMaxWidth &&
 						!getLastBreakpointAttribute({
-							target: `${prefix}width-fit-content`,
+							target: 'width-fit-content',
+							prefix,
 							breakpoint,
 							attributes: props,
 						}) && (
@@ -271,36 +346,57 @@ const FullSizeControl = props => {
 								className='maxi-full-size-control__max-width'
 								enableUnit
 								unit={getLastBreakpointAttribute({
-									target: `${prefix}max-width-unit`,
+									target: 'max-width-unit',
+									prefix,
 									breakpoint,
 									attributes: props,
 								})}
 								onChangeUnit={val =>
 									onChange({
-										[`${prefix}max-width-unit-${breakpoint}`]:
-											val,
+										[getAttributeKey(
+											'max-width-unit',
+											false,
+											prefix,
+											breakpoint
+										)]: val,
 									})
 								}
 								value={getLastBreakpointAttribute({
-									target: `${prefix}max-width`,
+									target: 'max-width',
+									prefix,
 									breakpoint,
 									attributes: props,
 								})}
 								onChangeValue={val =>
 									onChange({
-										[`${prefix}max-width-${breakpoint}`]:
-											val,
+										[getAttributeKey(
+											'max-width',
+											false,
+											prefix,
+											breakpoint
+										)]: val,
 									})
 								}
 								onReset={() => {
+									const maxWidthKey = getAttributeKey(
+										'max-width',
+										false,
+										prefix,
+										breakpoint
+									);
+									const maxWidthUnitKey = getAttributeKey(
+										'max-width-unit',
+										false,
+										prefix,
+										breakpoint
+									);
+
 									onChange({
-										[`${prefix}max-width-${breakpoint}`]:
+										[maxWidthKey]:
+											getDefaultAttribute(maxWidthKey),
+										[maxWidthUnitKey]:
 											getDefaultAttribute(
-												`${prefix}max-width-${breakpoint}`
-											),
-										[`${prefix}max-width-unit-${breakpoint}`]:
-											getDefaultAttribute(
-												`${prefix}max-width-unit-${breakpoint}`
+												maxWidthUnitKey
 											),
 										isReset: true,
 									});
@@ -311,7 +407,8 @@ const FullSizeControl = props => {
 							/>
 						)}
 					{!getLastBreakpointAttribute({
-						target: `${prefix}width-fit-content`,
+						target: 'width-fit-content',
+						prefix,
 						breakpoint,
 						attributes: props,
 					}) && (
@@ -320,36 +417,56 @@ const FullSizeControl = props => {
 							className='maxi-full-size-control__min-width'
 							enableUnit
 							unit={getLastBreakpointAttribute({
-								target: `${prefix}min-width-unit`,
+								target: 'min-width-unit',
+								prefix,
 								breakpoint,
 								attributes: props,
 							})}
 							onChangeUnit={val =>
 								onChange({
-									[`${prefix}min-width-unit-${breakpoint}`]:
-										val,
+									[getAttributeKey(
+										'min-width-unit',
+										false,
+										prefix,
+										breakpoint
+									)]: val,
 								})
 							}
 							value={getLastBreakpointAttribute({
-								target: `${prefix}min-width`,
+								target: 'min-width',
+								prefix,
 								breakpoint,
 								attributes: props,
 							})}
 							onChangeValue={val =>
 								onChange({
-									[`${prefix}min-width-${breakpoint}`]: val,
+									[getAttributeKey(
+										'min-width',
+										false,
+										prefix,
+										breakpoint
+									)]: val,
 								})
 							}
 							onReset={() => {
+								const minWidthKey = getAttributeKey(
+									'min-width',
+									false,
+									prefix,
+									breakpoint
+								);
+								const minWidthUnitKey = getAttributeKey(
+									'min-width-unit',
+									false,
+									prefix,
+									breakpoint
+								);
+
 								onChange({
-									[`${prefix}min-width-${breakpoint}`]:
-										getDefaultAttribute(
-											`${prefix}min-width-${breakpoint}`
-										),
-									[`${prefix}min-width-unit-${breakpoint}`]:
-										getDefaultAttribute(
-											`${prefix}min-width-unit-${breakpoint}`
-										),
+									[minWidthKey]:
+										getDefaultAttribute(minWidthKey),
+									[minWidthUnitKey]:
+										getDefaultAttribute(minWidthUnitKey),
 									isReset: true,
 								});
 							}}
@@ -363,35 +480,56 @@ const FullSizeControl = props => {
 						className='maxi-full-size-control__max-height'
 						enableUnit
 						unit={getLastBreakpointAttribute({
-							target: `${prefix}max-height-unit`,
+							target: 'max-height-unit',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeUnit={val =>
 							onChange({
-								[`${prefix}max-height-unit-${breakpoint}`]: val,
+								[getAttributeKey(
+									'max-height-unit',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
 							})
 						}
 						value={getLastBreakpointAttribute({
-							target: `${prefix}max-height`,
+							target: 'max-height',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeValue={val =>
 							onChange({
-								[`${prefix}max-height-${breakpoint}`]: val,
+								[getAttributeKey(
+									'max-height',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
 							})
 						}
 						onReset={() => {
+							const maxHeightKey = getAttributeKey(
+								'max-height',
+								false,
+								prefix,
+								breakpoint
+							);
+							const maxHeightUnitKey = getAttributeKey(
+								'max-height-unit',
+								false,
+								prefix,
+								breakpoint
+							);
+
 							onChange({
-								[`${prefix}max-height-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}max-height-${breakpoint}`
-									),
-								[`${prefix}max-height-unit-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}max-height-unit-${breakpoint}`
-									),
+								[maxHeightKey]:
+									getDefaultAttribute(maxHeightKey),
+								[maxHeightUnitKey]:
+									getDefaultAttribute(maxHeightUnitKey),
 								isReset: true,
 							});
 						}}
@@ -404,35 +542,56 @@ const FullSizeControl = props => {
 						className='maxi-full-size-control__min-height'
 						enableUnit
 						unit={getLastBreakpointAttribute({
-							target: `${prefix}min-height-unit`,
+							target: 'min-height-unit',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeUnit={val =>
 							onChange({
-								[`${prefix}min-height-unit-${breakpoint}`]: val,
+								[getAttributeKey(
+									'min-height-unit',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
 							})
 						}
 						value={getLastBreakpointAttribute({
-							target: `${prefix}min-height`,
+							target: 'min-height',
+							prefix,
 							breakpoint,
 							attributes: props,
 						})}
 						onChangeValue={val =>
 							onChange({
-								[`${prefix}min-height-${breakpoint}`]: val,
+								[getAttributeKey(
+									'min-height',
+									false,
+									prefix,
+									breakpoint
+								)]: val,
 							})
 						}
 						onReset={() => {
+							const minHeightKey = getAttributeKey(
+								'min-height',
+								false,
+								prefix,
+								breakpoint
+							);
+							const minHeightUnitKey = getAttributeKey(
+								'min-height-unit',
+								false,
+								prefix,
+								breakpoint
+							);
+
 							onChange({
-								[`${prefix}min-height-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}min-height-${breakpoint}`
-									),
-								[`${prefix}min-height-unit-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}min-height-unit-${breakpoint}`
-									),
+								[minHeightKey]:
+									getDefaultAttribute(minHeightKey),
+								[minHeightUnitKey]:
+									getDefaultAttribute(minHeightUnitKey),
 								isReset: true,
 							});
 						}}

--- a/src/extensions/maxi-block/handleSetAttributes.js
+++ b/src/extensions/maxi-block/handleSetAttributes.js
@@ -10,7 +10,6 @@ import getBreakpointFromAttribute from '../styles/getBreakpointFromAttribute';
 import getDefaultAttribute from '../styles/getDefaultAttribute';
 import handleOnReset from '../attributes/handleOnReset';
 import cleanAttributes from './cleanAttributes';
-import parseLongAttrKey from '../styles/dictionary/parseLongAttrKey';
 
 /**
  * External dependencies
@@ -20,21 +19,13 @@ import { isNil } from 'lodash';
 const breakpoints = ['xxl', 'xl', 'l', 'm', 's', 'xs'];
 
 const handleSetAttributes = ({
-	obj: { isReset, ...rawObj },
+	obj: { isReset, ...obj },
 	attributes,
 	onChange,
 	clientId = null,
 	defaultAttributes,
 	isStyleCard = false,
 }) => {
-	const obj = Object.entries(rawObj).reduce(
-		(acc, [key, value]) => ({
-			...acc,
-			[parseLongAttrKey(key)]: value,
-		}),
-		{}
-	);
-
 	const response = isReset ? { ...handleOnReset(obj) } : { ...obj };
 
 	const baseBreakpoint = select('maxiBlocks').receiveBaseBreakpoint();

--- a/src/extensions/styles/getAttributeKey.js
+++ b/src/extensions/styles/getAttributeKey.js
@@ -1,11 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import parseLongAttrKey from './dictionary/parseLongAttrKey';
+
 const getAttributeKey = (
 	key = '',
 	isHover = false,
 	prefix = false,
 	breakpoint = false
 ) =>
-	`${prefix || ''}${key}${breakpoint ? `-${breakpoint}` : ''}${
-		isHover ? '-hover' : ''
-	}`;
+	`${prefix || ''}${parseLongAttrKey(
+		`${key}${breakpoint ? `-${breakpoint}` : ''}${isHover ? '-hover' : ''}`
+	)}`;
 
 export default getAttributeKey;

--- a/src/extensions/styles/getAttributeValue.js
+++ b/src/extensions/styles/getAttributeValue.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import parseLongAttrKey from './dictionary/parseLongAttrKey';
 import getAttributeKey from './getAttributeKey';
 
 /**
@@ -17,12 +16,7 @@ const getAttributeValue = ({
 	prefix = '',
 	allowNil = false,
 }) => {
-	const value =
-		props?.[
-			parseLongAttrKey(
-				getAttributeKey(target, isHover, prefix, breakpoint)
-			)
-		];
+	const value = props?.[getAttributeKey(target, isHover, prefix, breakpoint)];
 
 	if (
 		(value || isNumber(value) || isBoolean(value) || isEmpty(value)) &&
@@ -44,7 +38,7 @@ const getAttributeValue = ({
 			prefix,
 		});
 
-	return props?.[parseLongAttrKey(getAttributeKey(target, null, prefix))];
+	return props?.[getAttributeKey(target, false, prefix)];
 };
 
 export default getAttributeValue;

--- a/src/extensions/styles/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/getLastBreakpointAttribute.js
@@ -28,6 +28,7 @@ const getValueFromKeys = (value, keys) =>
  */
 const getLastBreakpointAttributeSingle = (
 	target,
+	prefix,
 	breakpoint,
 	attributes,
 	isHover,
@@ -48,6 +49,7 @@ const getLastBreakpointAttributeSingle = (
 		return getValueFromKeys(
 			getAttributeValue({
 				target,
+				prefix,
 				props: attr,
 				isHover,
 				breakpoint,
@@ -73,6 +75,7 @@ const getLastBreakpointAttributeSingle = (
 	) {
 		const baseBreakpointAttr = getLastBreakpointAttributeSingle(
 			target,
+			prefix,
 			baseBreakpoint,
 			attributes,
 			isHover,
@@ -86,6 +89,7 @@ const getLastBreakpointAttributeSingle = (
 	let currentAttr = getValueFromKeys(
 		getAttributeValue({
 			target,
+			prefix,
 			props: attr,
 			breakpoint,
 			isHover,
@@ -114,6 +118,7 @@ const getLastBreakpointAttributeSingle = (
 			currentAttr = getValueFromKeys(
 				getAttributeValue({
 					target,
+					prefix,
 					props: attr,
 					breakpoint: breakpoints[breakpointPosition],
 					isHover,
@@ -126,6 +131,7 @@ const getLastBreakpointAttributeSingle = (
 	if (isHover && !attrFilter(currentAttr))
 		currentAttr = getLastBreakpointAttributeSingle(
 			target,
+			prefix,
 			breakpoint,
 			attributes,
 			false,
@@ -138,6 +144,7 @@ const getLastBreakpointAttributeSingle = (
 	if (!currentAttr && breakpoint === 'general' && baseBreakpoint)
 		currentAttr = getLastBreakpointAttributeSingle(
 			target,
+			prefix,
 			baseBreakpoint,
 			attributes,
 			isHover,
@@ -150,6 +157,7 @@ const getLastBreakpointAttributeSingle = (
 
 const getLastBreakpointAttributeGroup = (
 	target,
+	prefix,
 	breakpoint,
 	isHover,
 	avoidXXL,
@@ -165,6 +173,7 @@ const getLastBreakpointAttributeGroup = (
 
 		return getLastBreakpointAttributeSingle(
 			target,
+			prefix,
 			breakpoint,
 			attributes,
 			isHover,
@@ -181,6 +190,7 @@ const getLastBreakpointAttributeGroup = (
 
 const getLastBreakpointAttribute = ({
 	target,
+	prefix = '',
 	breakpoint,
 	attributes = null,
 	isHover = false,
@@ -195,6 +205,7 @@ const getLastBreakpointAttribute = ({
 	if (getSelectedBlockCount() > 1 && !forceSingle)
 		return getLastBreakpointAttributeGroup(
 			target,
+			prefix,
 			breakpoint,
 			isHover,
 			avoidXXL,
@@ -203,6 +214,7 @@ const getLastBreakpointAttribute = ({
 
 	return getLastBreakpointAttributeSingle(
 		target,
+		prefix,
 		breakpoint,
 		attributes,
 		isHover,


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Size settings don't work with attributes, which have prefixes in #4449 . It's because for example in `getAttributeValue` firstly we're calling `getAttributeKey` and then `parseLongAttrKey`, but on `parseLongAttrKey` after clearing for example attribute key: `button-width-general-hover` we will have `button-width`, so I suppose we will need:
1) to move `parseLongAttrKey` logic inside `getAttributeKey` and not include `prefix` in `parseLongAttrKey` call.
2) add to `getLastBreakpointAttribute` `prefix` param to define exactly where `target` and where `prefix`
3) don't modify object with`parseLongAttrKey` in `handleSetAttribute`, we should do it straight away in every `onChange`, because we won't be able to define `prefix` in `handleSetAttribute`

This PR tries to deal with this.


# How Has This Been Tested?
Checked if size settings works for prefix attributes, for example for button-maxi width(not canvas!)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test size control with prefix attributes(button-maxi width/height for example, not canvas!)

**_ Pre-Code Testing _**

-   [ ] Test size control with prefix attributes(button-maxi width/height for example, not canvas!)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
