### PR TITLE
Fix CustomCSS validations fake positives in tests

### DIFF
--- a/e2e-tests/setup-test-framework.js
+++ b/e2e-tests/setup-test-framework.js
@@ -134,6 +134,11 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// CustomCSS validator returns connection errors sometimes
+		if (text.includes('Error validating css: TypeError: Failed to fetch')) {
+			return;
+		}
+
 		// Since 6.1 multiline on RichText is deprecated. Need to be update on #3877
 		if (
 			text.includes(


### PR DESCRIPTION
# Description

Are you tired of Github tests fake positive with CustomCSS validation? Are you all day re-running tests because there's a validation error? Here you have the solution! An exception! It can be yours for just one click: approve it and will be in your repository in an instant. This easy, this simple. 

# How Has This Been Tested?

My tick in the eye has disappeared after this implementation, you'll sleep better and you'll get back your love for human beings (fake)

Anyway, can't be tested. Just can wait to don't see any new fake positive on Github tests for CustomCSS validation