### PR TITLE
Issue 4490 - Hides image dimension from toolbar

### DIFF
--- a/src/components/toolbar/components/more-settings/index.js
+++ b/src/components/toolbar/components/more-settings/index.js
@@ -108,22 +108,13 @@ const MoreSettings = props => {
 							</div>
 						)}
 						{blockName === 'maxi-blocks/image-maxi' && (
-							<>
-								<Button
-									onClick={() => {
-										openSidebarAccordion(0, 'dimension');
-									}}
-								>
-									{__('Image dimension', 'maxi-blocks')}
-								</Button>
-								<Button
-									onClick={() => {
-										openSidebarAccordion(0, 'caption');
-									}}
-								>
-									{__('Caption', 'maxi-blocks')}
-								</Button>
-							</>
+							<Button
+								onClick={() => {
+									openSidebarAccordion(0, 'caption');
+								}}
+							>
+								{__('Caption', 'maxi-blocks')}
+							</Button>
 						)}
 						{(blockName === 'maxi-blocks/svg-icon-maxi' ||
 							blockName === 'maxi-blocks/image-maxi') && (


### PR DESCRIPTION
Hides the image dimension option from the image block's toolbar.

Fixes #4490 

# How Has This Been Tested?

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Add an image and make sure there's no image dimension option in the toolbar (under more settings).
- 
**_ Pre-Code Testing _**

-   [ ] Add an image and make sure there's no image dimension option in the toolbar (under more settings).
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
