### PR TITLE
Issue 4486 - content is pasted on 'Paste styles - all' part 2

### DIFF
--- a/src/blocks/accordion-maxi/data.js
+++ b/src/blocks/accordion-maxi/data.js
@@ -32,6 +32,7 @@ const copyPasteMapping = {
 		'Accordion line': { groupAttributes: 'accordionLine' },
 		'Accordion title': { groupAttributes: 'accordionTitle' },
 		Icon: { groupAttributes: 'accordionIcon' },
+		'Active icon': { groupAttributes: 'accordionIcon', prefix: 'active-' },
 		Background: {
 			template: 'blockBackground',
 		},

--- a/src/blocks/accordion-maxi/data.js
+++ b/src/blocks/accordion-maxi/data.js
@@ -15,6 +15,7 @@ import { targets as paneTargets } from '../pane-maxi/data';
  */
 const name = 'accordion-maxi';
 const copyPasteMapping = {
+	_exclude: ['icon-content', 'active-icon-content'],
 	settings: {
 		'Accordion settings': {
 			group: {

--- a/src/blocks/button-maxi/data.js
+++ b/src/blocks/button-maxi/data.js
@@ -50,7 +50,7 @@ const prefix = 'button-';
  */
 const name = 'button-maxi';
 const copyPasteMapping = {
-	_exclude: ['buttonContent'],
+	_exclude: ['buttonContent', 'icon-content'],
 	settings: {
 		'Button text': 'buttonContent',
 		Icon: {

--- a/src/blocks/map-maxi/data.js
+++ b/src/blocks/map-maxi/data.js
@@ -18,6 +18,7 @@ const popupDescriptionClass = `${popupContentClass}__description`;
  */
 const name = 'map-maxi';
 const copyPasteMapping = {
+	_exclude: ['map-marker-icon', 'map-marker'],
 	settings: {
 		'Configure map': {
 			group: {

--- a/src/blocks/search-maxi/data.js
+++ b/src/blocks/search-maxi/data.js
@@ -31,6 +31,7 @@ const prefixes = {
 	inputPrefix,
 };
 const copyPasteMapping = {
+	_exclude: ['icon-content', 'close-icon-content', 'placeholder'],
 	block: {
 		Border: {
 			template: 'border',

--- a/src/blocks/slider-maxi/data.js
+++ b/src/blocks/slider-maxi/data.js
@@ -6,6 +6,11 @@ import { createSelectors } from '../../extensions/styles/custom-css';
  */
 const name = 'slider-maxi';
 const copyPasteMapping = {
+	_exclude: [
+		'active-navigation-dot-icon-content',
+		'navigation-arrow-first-icon-content',
+		'navigation-arrow-second-icon-content',
+	],
 	settings: {
 		'Slider settings': {
 			group: {


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4486 

Update:
- on 'Paste styles - all' - search-maxi, map-maxi, button-maxi, accordion-maxi, slider-maxi icons won't be copied
- `accordion-maxi`: add ability to copy active icon

# How Has This Been Tested?
Tested if higher described things works as expected

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if on 'Paste styles - all' - search-maxi, map-maxi, button-maxi, accordion-maxi, slider-maxi icons won't be copied
-   [ ] Test if `accordion-maxi` have ability to copy active icon on 'special select' and 'paste all'

**_ Pre-Code Testing _**

-   [ ] Test if on 'Paste styles - all' - search-maxi, map-maxi, button-maxi, accordion-maxi, slider-maxi icons won't be copied
-   [ ] Test if `accordion-maxi` have ability to copy active icon on 'special select' and 'paste all'
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
