### PR TITLE
Fix custom css test for Failed to load resource: net::ERR_FAILED

### DIFF
--- a/e2e-tests/setup-test-framework.js
+++ b/e2e-tests/setup-test-framework.js
@@ -138,6 +138,9 @@ function observeConsoleLogging() {
 		if (text.includes('Error validating css: TypeError: Failed to fetch')) {
 			return;
 		}
+		if (text.includes('Failed to load resource: net::ERR_FAILED')) {
+			return;
+		}
 
 		// Since 6.1 multiline on RichText is deprecated. Need to be update on #3877
 		if (


### PR DESCRIPTION
# Description

Fixes another annoying custom css tests bug by telling tests to ignore ```Failed to load resource: net::ERR_FAILED```
