### PR TITLE
Fixes styles on changing breakpoint

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -237,8 +237,11 @@ class MaxiBlockComponent extends Component {
 		)
 			return false;
 
-		// If baseBreakpoint changes, render styles
-		if (this.props.baseBreakpoint !== prevProps.baseBreakpoint)
+		// If deviceType or baseBreakpoint changes, render styles
+		if (
+			this.props.deviceType !== prevProps.deviceType ||
+			this.props.baseBreakpoint !== prevProps.baseBreakpoint
+		)
 			return false;
 
 		return isEqual(prevProps.attributes, this.props.attributes);


### PR DESCRIPTION
# Description

As @Olekrut noticed, v1.0.0-RC2 has an issue when changing the responsive breakpoint:

![image (6)](https://user-images.githubusercontent.com/50477222/226549218-8e9f3f31-812a-4a15-bed7-9edc7ca20d9b.png)


This PR aims to fix it

# How Has This Been Tested?

Create a Container, change to XXL and check the value of `max-width` setting and the current CSS `max-width` setting are the same 👍 
