### PR TITLE
Issue 4505 - Range tooltip position for long numbers

### DIFF
--- a/src/blocks/number-counter-maxi/components/number-counter-control/editor.scss
+++ b/src/blocks/number-counter-maxi/components/number-counter-control/editor.scss
@@ -7,4 +7,7 @@
 		margin-bottom: 8px;
 		font-size: 12px !important;
 	}
+	.number-counter-control__start-end .maxi-advanced-number-control__value {
+		width: 105px;
+	}
 }

--- a/src/blocks/number-counter-maxi/components/number-counter-control/index.js
+++ b/src/blocks/number-counter-maxi/components/number-counter-control/index.js
@@ -176,6 +176,7 @@ const NumberCounterControl = props => {
 				</div>
 			)}
 			<AdvancedNumberControl
+				className='number-counter-control__start-end'
 				label={__('Start number', 'maxi-blocks')}
 				min={0}
 				max={props['number-counter-end']}
@@ -193,6 +194,7 @@ const NumberCounterControl = props => {
 				}
 			/>
 			<AdvancedNumberControl
+				className='number-counter-control__start-end'
 				label={__('End number', 'maxi-blocks')}
 				min={1}
 				max={props['number-counter-circle-status'] ? 9999999999 : 100}

--- a/src/components/advanced-number-control/editor.scss
+++ b/src/components/advanced-number-control/editor.scss
@@ -11,6 +11,17 @@
 		width: 100%;
 		flex: 100%;
 		margin: 8px 0 0;
+
+		&.maxi-advanced-number-control__range--small {
+			.components-simple-tooltip {
+				transform: none;
+			}
+		}
+		&.maxi-advanced-number-control__range--big {
+			.components-simple-tooltip {
+				transform: translateX(-90%);
+			}
+		}
 	}
 	.maxi-base-control__label {
 		flex: 2;

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -260,10 +260,19 @@ const AdvancedNumberControl = props => {
 							isSmall
 						/>
 					)}
+
 					{!disableRange && (
 						<RangeControl
 							label={label}
-							className='maxi-advanced-number-control__range'
+							className={`maxi-advanced-number-control__range${
+								value > 11111
+									? (value / max) * 100 <= 10
+										? '--small'
+										: (value / max) * 100 >= 90
+										? '--big'
+										: ''
+									: ''
+							}`}
 							value={
 								+[
 									value ||


### PR DESCRIPTION
Fixes the tooltip position for `RangeControl` for big numbers.

Fixes #4505 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test start and end numbers for NC. Test with different numbers (small, big, beginning and end of the slider)
-   [ ] Test the range slider for any other block and settings to make sure it works as before.


**_ Pre-Code Testing _**

-   [ ] Test start and end numbers for NC. Test with different numbers (small, big, beginning and end of the slider)
-   [ ] Test the range slider for any other block and settings to make sure it works as before.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
