### PR TITLE
Issue 4561 - load default font weight for sc fonts

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -463,13 +463,13 @@ class MaxiBlocks_Styles
 
                     $font_url = "https://fonts.googleapis.com/css2?family=$font";
 
-					// Load default font weight for cases where the saved font weight doesn't exist
-					wp_enqueue_style(
-						$name . '-font-' . sanitize_title_with_dashes($font),
-						$font_url
-					);
+                    // Load default font weight for cases where the saved font weight doesn't exist
+                    wp_enqueue_style(
+                        $name . '-font-' . sanitize_title_with_dashes($font),
+                        $font_url
+                    );
 
-					$font_url .= ':';
+                    $font_url .= ':';
 
                     foreach ($font_weights as $font_weight) {
                         foreach ($font_styles as $font_style) {

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -197,7 +197,7 @@ class MaxiBlocks_Styles
             if (!$post) {
                 return null;
             }
-        
+
             return $post->ID;
         }
 
@@ -401,7 +401,6 @@ class MaxiBlocks_Styles
      *
      * @return object   Font name with font options
      */
-
     public function enqueue_fonts($fonts, $name)
     {
         if (empty($fonts) || !is_array($fonts)) {
@@ -462,7 +461,15 @@ class MaxiBlocks_Styles
                         $font_styles = [$font_data['style']];
                     }
 
-                    $font_url = "https://fonts.googleapis.com/css2?family=$font:";
+                    $font_url = "https://fonts.googleapis.com/css2?family=$font";
+
+					// Load default font weight for cases where the saved font weight doesn't exist
+					wp_enqueue_style(
+						$name . '-font-' . sanitize_title_with_dashes($font),
+						$font_url
+					);
+
+					$font_url .= ':';
 
                     foreach ($font_weights as $font_weight) {
                         foreach ($font_styles as $font_style) {


### PR DESCRIPTION
# Description
Since all style cards have 500 weight for h1 by default, some fonts that are set there by default as well might not have that weight, so for all SC fonts default weight is now loaded as well as specified one.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4561 

# How Has This Been Tested?
Checked that the issue has been fixed.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check frontend with bubble gum SC and h1 text (or other title size).

**_ Pre-Code Testing _**

-   [ ] Check frontend with bubble gum SC and h1 text (or other title size).
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
