### PR TITLE
Issue 4612 - IB relation label substring

### DIFF
--- a/src/components/list-control/editor.scss
+++ b/src/components/list-control/editor.scss
@@ -94,6 +94,12 @@
 		padding-right: 5px;
 		background-color: #fff;
 
+		&__title-text {
+			overflow: hidden;
+			max-width: 190px;
+			width: 100%;
+		}
+
 		&__text {
 			line-height: 25px;
 		}

--- a/src/components/list-control/editor.scss
+++ b/src/components/list-control/editor.scss
@@ -94,10 +94,9 @@
 		padding-right: 5px;
 		background-color: #fff;
 
-		&__title-text {
-			overflow: hidden;
-			max-width: 190px;
+		&__wrapper {
 			width: 100%;
+			display: flex;
 		}
 
 		&__text {

--- a/src/components/list-control/list-item-control.js
+++ b/src/components/list-control/list-item-control.js
@@ -50,7 +50,9 @@ const ListItemControl = props => {
 				</span>
 				<div className='maxi-list-item-control__title'>
 					<span className='maxi-list-item-control__title__id' />
-					{title.substring(0, 25) + (title.length > 25 ? '...' : '')}
+					<span className='maxi-list-item-control__title__title-text'>
+						{title}
+					</span>
 					{isCloseButton && (
 						<span
 							className={classnames(

--- a/src/components/list-control/list-item-control.js
+++ b/src/components/list-control/list-item-control.js
@@ -50,9 +50,9 @@ const ListItemControl = props => {
 				</span>
 				<div className='maxi-list-item-control__title'>
 					<span className='maxi-list-item-control__title__id' />
-					<span className='maxi-list-item-control__title__title-text'>
+					<div className='maxi-list-item-control__title__wrapper'>
 						{title}
-					</span>
+					</div>
 					{isCloseButton && (
 						<span
 							className={classnames(

--- a/src/components/list-control/list-item-control.js
+++ b/src/components/list-control/list-item-control.js
@@ -50,7 +50,7 @@ const ListItemControl = props => {
 				</span>
 				<div className='maxi-list-item-control__title'>
 					<span className='maxi-list-item-control__title__id' />
-					{title}
+					{title.substring(0, 25) + (title.length > 25 ? '...' : '')}
 					{isCloseButton && (
 						<span
 							className={classnames(

--- a/src/components/relation-control/editor.scss
+++ b/src/components/relation-control/editor.scss
@@ -9,9 +9,9 @@
 		margin-bottom: 10px;
 	}
 	.maxi-list-item-control__title__wrapper {
+		display: block;
 		overflow: hidden;
 		max-width: 190px;
-		display: block;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}

--- a/src/components/relation-control/editor.scss
+++ b/src/components/relation-control/editor.scss
@@ -8,4 +8,8 @@
 	&__block-access {
 		margin-bottom: 10px;
 	}
+	.maxi-list-item-control__title__wrapper {
+		overflow: hidden;
+		max-width: 190px;
+	}
 }

--- a/src/components/relation-control/editor.scss
+++ b/src/components/relation-control/editor.scss
@@ -11,5 +11,8 @@
 	.maxi-list-item-control__title__wrapper {
 		overflow: hidden;
 		max-width: 190px;
+		display: block;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 }


### PR DESCRIPTION
Limited the label text width.

Fixes #4612 


**_ Front/Back Testing _**

-   [ ] Go to IB and type in a long relation name. Make sure that the title text is cut off and doesn't exceed the parent's container.

**_ Pre-Code Testing _**

-   [ ] Go to IB and type in a long relation name. Make sure that the title text is cut off and doesn't exceed the parent's container.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
