### PR TITLE
Issue - Fix button migrators

### DIFF
--- a/src/blocks/button-maxi/button-maxi.js
+++ b/src/blocks/button-maxi/button-maxi.js
@@ -70,7 +70,7 @@ registerBlockType('maxi-blocks/button-maxi', {
 			attributes,
 			save: saveOld,
 		},
-		blockMigrator({
+		...blockMigrator({
 			attributes,
 			save,
 			prefix: 'button-',


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

### ⚠️ Don't update old patterns with button-maxi blocks like HOL-01, 02, 04, 05, 06, 13, etc. on maxiblocks demo ⚠️ 
So we need this ASAP on maxiblocks/demo and other sites, which dev team use, I suppose 🤔 , to avoid breaking some patterns on their update accidentally.

Fixes Sasha's request

https://user-images.githubusercontent.com/46112160/227578211-48c79926-1f79-4890-aa49-f4fe225ed712.mp4

# How Has This Been Tested?
Inserted old patterns, which haven't been migrated yet. (video)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Insert old patterns like HOL-01, 02, 04, 05, 06, 13, etc. and test if button blocks look as on preview

**_ Pre-Code Testing _**

-   [ ] Insert old patterns like HOL-01, 02, 04, 05, 06, 13, etc. and test if button blocks look as on preview
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
