### PR TITLE
Fix Fatal error: Cannot redeclare filterNull() 

### DIFF
--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -45,6 +45,11 @@ class MaxiBlocks_Local_Fonts
         }
     }
 
+    public function filterNull($arr)
+    {
+        return ($arr !== null && $arr !== false && $arr !== '');
+    }
+
     public function getAllFontsDB()
     {
         global $wpdb;
@@ -78,12 +83,7 @@ class MaxiBlocks_Local_Fonts
             $array[$key] = json_decode($value, true);
         }
 
-        function filterNull($arr)
-        {
-            return ($arr !== null && $arr !== false && $arr !== '');
-        }
-
-        $array = array_filter($array, 'filterNull');
+        $array = array_filter($array, $this->filterNull);
 
         $array_all = array_merge_recursive(...$array);
 


### PR DESCRIPTION
# Description

Fixes Fatal error: Cannot redeclare filterNull()  for local fonts.

Fixes #4637

# How Has This Been Tested?

Check that there is no error in the log, and that local google fonts work fine.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check the debug log
-   [ ] Test local google fonts

**_ Pre-Code Testing _**

-   [ ] Check the debug log
-   [ ] Test local google fonts
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
