### PR TITLE
Issue 4659 - Toolbar hidden behind list view

### DIFF
--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -24,6 +24,14 @@
 		// to make the iframe look good with small breakpoints
 		background-color: transparent !important;
 	}
+
+	.maxi-toolbar-opened {
+		z-index: 25;
+
+		.edit-post-editor__document-overview-panel {
+			transform: translateY(40px);
+		}
+	}
 }
 
 // Scrollbar fix for Safari

--- a/src/editor/toolbar-buttons/index.js
+++ b/src/editor/toolbar-buttons/index.js
@@ -26,6 +26,18 @@ import { main } from '../../icons';
  */
 const ToolbarButtons = () => {
 	const [isResponsiveOpen, setIsResponsiveOpen] = useState(false);
+	const toggleSidebarClass = () => {
+		const sidebar = document.querySelector(
+			'.interface-interface-skeleton__body'
+		);
+		if (!sidebar) return;
+
+		if (isResponsiveOpen) {
+			sidebar.classList.remove('maxi-toolbar-opened');
+		} else {
+			sidebar.classList.add('maxi-toolbar-opened');
+		}
+	};
 
 	return (
 		<>
@@ -33,7 +45,10 @@ const ToolbarButtons = () => {
 				<Button
 					className='maxi-toolbar-layout__button'
 					aria-pressed={isResponsiveOpen}
-					onClick={() => setIsResponsiveOpen(!isResponsiveOpen)}
+					onClick={() => {
+						setIsResponsiveOpen(!isResponsiveOpen);
+						toggleSidebarClass();
+					}}
 				>
 					<Icon icon={main} />
 				</Button>


### PR DESCRIPTION
Toggles a class for the sidebar when Maxi toolbar opens and pushes the sidebar down.

Fixes #4659

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test opening list view and Maxi toolbar.

**_ Pre-Code Testing _**

-   [ ] Test opening list view and Maxi toolbar.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
