### PR TITLE
Issue 4662 – DC. Get by date and get alphabetical relations

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -224,6 +224,9 @@ class MaxiBlocks_DynamicContent
         if (empty($dc_accumulator)) {
             $dc_accumulator = 0;
         }
+        if (empty($dc_order)) {
+            $dc_order = 'desc';
+        }
 
         $is_sort_relation = in_array($dc_relation, ['by-date', 'alphabetical']);
         $is_random = $dc_relation === 'random';
@@ -577,20 +580,8 @@ class MaxiBlocks_DynamicContent
     {
         return [
             'orderby' => $relation === 'by-date' ? 'date' : 'title',
-            'order' => $this->get_order($relation, $order),
+            'order' => $order,
             'posts_per_page' => $accumulator + 1,
         ];
-    }
-
-    public function get_order($relation, $order)
-    {
-        switch ($relation) {
-            case 'by-date':
-                return $order === 'new-old' ? 'desc' : 'asc';
-            case 'alphabetical':
-                return $order === 'a-z' ? 'desc' : 'asc';
-            default:
-                return 'asc';
-        }
     }
 }

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -211,6 +211,8 @@ class MaxiBlocks_DynamicContent
             'dc-relation' => $dc_relation,
             'dc-id' => $dc_id,
             'dc-author' => $dc_author,
+            'dc-order' => $dc_order_by,
+            'dc-accumulator' => $dc_accumulator,
         ) = $attributes;
 
         if (empty($dc_type)) {
@@ -219,6 +221,12 @@ class MaxiBlocks_DynamicContent
         if (empty($dc_relation)) {
             $dc_relation = 'id';
         }
+        if (empty($dc_accumulator)) {
+            $dc_accumulator = 0;
+        }
+
+        $is_sort_relation = in_array($dc_relation, ['by-date', 'alphabetical']);
+        $is_random = $dc_relation === 'random';
 
         if (in_array($dc_type, ['posts', 'pages'])) {
             // Basic args
@@ -233,13 +241,15 @@ class MaxiBlocks_DynamicContent
                 $args['p'] = $dc_id;
             } elseif ($dc_relation == 'author') {
                 $args['author'] = $dc_author ?? $dc_id;
-            } elseif ($dc_relation == 'random') {
+            } elseif ($is_random) {
                 $args['orderby'] = 'rand';
+            } elseif ($is_sort_relation) {
+                $args = array_merge($args, $this->get_order_by_args($dc_relation, $dc_order_by, $dc_accumulator));
             }
 
             $query = new WP_Query($args);
 
-            return $query->post;
+            return end($query->posts);
         } elseif ($dc_type === 'media') {
             $args = [
                 'post_type' => 'attachment',
@@ -247,7 +257,6 @@ class MaxiBlocks_DynamicContent
             ];
 
             // DC Relation
-            $is_random = $dc_relation === 'random';
             if ($dc_relation == 'id') {
                 $args['p'] = $dc_id;
             } elseif ($is_random) {
@@ -256,6 +265,9 @@ class MaxiBlocks_DynamicContent
                     'post_status' => 'inherit',
                     'posts_per_page' => -1
                 ];
+            } elseif ($is_sort_relation) {
+                $args['post_status'] = 'inherit';
+                $args = array_merge($args, $this->get_order_by_args($dc_relation, $dc_order_by, $dc_accumulator));
             }
 
             $query = new WP_Query($args);
@@ -266,7 +278,7 @@ class MaxiBlocks_DynamicContent
                 $posts = $query->posts;
                 $post = $posts[array_rand($posts)];
             } else {
-                $post = $query->post;
+                $post = end($query->posts);
             }
 
             return $post;
@@ -283,7 +295,7 @@ class MaxiBlocks_DynamicContent
                 'number' => 1,
             ];
 
-            if ($dc_relation == 'random') {
+            if ($is_random) {
                 $args['orderby'] = 'rand';
             } else {
                 $args['include'] = $dc_id;
@@ -300,6 +312,8 @@ class MaxiBlocks_DynamicContent
 
             if ($dc_relation == 'random') {
                 $args['orderby'] = 'rand';
+            } elseif ($is_sort_relation) {
+                $args = array_merge($args, $this->get_order_by_args($dc_relation, $dc_order_by, $dc_accumulator));
             } else {
                 $args['include'] = $dc_id;
             }
@@ -557,5 +571,26 @@ class MaxiBlocks_DynamicContent
         }
 
         return $string;
+    }
+
+    public function get_order_by_args($relation, $order, $accumulator)
+    {
+        return [
+            'orderby' => $relation === 'by-date' ? 'date' : 'title',
+            'order' => $this->get_order($relation, $order),
+            'posts_per_page' => $accumulator + 1,
+        ];
+    }
+
+    public function get_order($relation, $order)
+    {
+        switch ($relation) {
+            case 'by-date':
+                return $order === 'new-old' ? 'desc' : 'asc';
+            case 'alphabetical':
+                return $order === 'a-z' ? 'desc' : 'asc';
+            default:
+                return 'asc';
+        }
     }
 }

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -251,6 +251,7 @@ const DynamicContent = props => {
 														),
 												})
 											}
+											disableRange
 										/>
 									</>
 								)}

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -20,6 +20,7 @@ import {
 	limitOptions,
 	limitTypes,
 	limitFields,
+	orderByOptions,
 } from '../../extensions/DC/constants';
 import getDCOptions from '../../extensions/DC/getDCOptions';
 import DateFormatting from './custom-date-formatting';
@@ -34,7 +35,6 @@ import classnames from 'classnames';
 /**
  * Dynamic Content
  */
-
 const DynamicContent = props => {
 	const {
 		className,
@@ -55,6 +55,8 @@ const DynamicContent = props => {
 		'dc-author': author,
 		'dc-limit': limit,
 		'dc-error': error,
+		'dc-order': order,
+		'dc-accumulator': accumulator,
 	} = dynamicContent;
 
 	const [postAuthorOptions, setPostAuthorOptions] = useState(null);
@@ -143,9 +145,10 @@ const DynamicContent = props => {
 						value={type}
 						options={typeOptions[contentType]}
 						onChange={value => {
-							const dcFieldActual = validationsValues(
+							const validatedAttributes = validationsValues(
 								value,
 								field,
+								relation,
 								contentType
 							);
 
@@ -153,7 +156,7 @@ const DynamicContent = props => {
 								'dc-type': value,
 								'dc-show': 'current',
 								'dc-error': '',
-								...dcFieldActual,
+								...validatedAttributes,
 							});
 						}}
 					/>
@@ -206,13 +209,55 @@ const DynamicContent = props => {
 										}
 									/>
 								)}
+							{['posts', 'pages', 'media'].includes(type) &&
+								['by-date', 'alphabetical'].includes(
+									relation
+								) && (
+									<>
+										<SelectControl
+											label={__('Order', 'maxi-blocks')}
+											value={order}
+											options={orderByOptions[relation]}
+											onChange={value =>
+												changeProps({
+													'dc-order': value,
+												})
+											}
+										/>
+										<AdvancedNumberControl
+											label={__(
+												'Accumulator',
+												'maxi-blocks'
+											)}
+											value={accumulator}
+											onChangeValue={value =>
+												changeProps({
+													'dc-accumulator': value,
+												})
+											}
+											onReset={() =>
+												changeProps({
+													'dc-accumulator':
+														getDefaultAttribute(
+															'dc-accumulator'
+														),
+												})
+											}
+										/>
+									</>
+								)}
+
 							{(['settings'].includes(type) ||
 								(relation === 'by-id' && isFinite(id)) ||
 								(relation === 'author' &&
 									!isEmpty(postIdOptions)) ||
-								['date', 'modified', 'random'].includes(
-									relation
-								)) && (
+								[
+									'date',
+									'modified',
+									'random',
+									'by-date',
+									'alphabetical',
+								].includes(relation)) && (
 								<SelectControl
 									label={__('Field', 'maxi-blocks')}
 									value={field}

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -174,6 +174,14 @@ const DynamicContent = props => {
 											'dc-relation': value,
 											'dc-show': 'current',
 											'dc-error': '',
+											...([
+												'by-date',
+												'alphabetical',
+											].includes(value) && {
+												'dc-order':
+													orderByOptions[value][0]
+														.value,
+											}),
 										})
 									}
 								/>

--- a/src/extensions/DC/constants.js
+++ b/src/extensions/DC/constants.js
@@ -363,11 +363,11 @@ export const limitOptions = {
 
 export const orderByOptions = {
 	'by-date': [
-		{ label: __('New/old', 'maxi-blocks'), value: 'new-old' },
-		{ label: __('Old/new', 'maxi-blocks'), value: 'old-new' },
+		{ label: __('New/old', 'maxi-blocks'), value: 'desc' },
+		{ label: __('Old/new', 'maxi-blocks'), value: 'asc' },
 	],
 	alphabetical: [
-		{ label: __('A/Z', 'maxi-blocks'), value: 'a-z' },
-		{ label: __('Z/A', 'maxi-blocks'), value: 'z-a' },
+		{ label: __('A/Z', 'maxi-blocks'), value: 'asc' },
+		{ label: __('Z/A', 'maxi-blocks'), value: 'desc' },
 	],
 };

--- a/src/extensions/DC/constants.js
+++ b/src/extensions/DC/constants.js
@@ -31,6 +31,8 @@ const generalRelationOptionsPosts = [
 	{ label: __('Get by id', 'maxi-blocks'), value: 'by-id' },
 	// { label: __('Get by author', 'maxi-blocks'), value: 'author' }, // TODO: add author support
 	{ label: __('Get random'), value: 'random' },
+	{ label: __('Get by date'), value: 'by-date' },
+	{ label: __('Get alphabetical'), value: 'alphabetical' },
 	// { label: __('Date', 'maxi-blocks'), value: 'date' },	// TODO: add date support
 	// { label: __('Modified', 'maxi-blocks'), value: 'modified' },	// TODO: add modified support
 ];
@@ -39,6 +41,8 @@ const generalRelationOptionsPages = [
 	{ label: __('Get by id', 'maxi-blocks'), value: 'by-id' },
 	// { label: __('Get by author', 'maxi-blocks'), value: 'author' }, // TODO: add author support
 	{ label: __('Get random'), value: 'random' },
+	{ label: __('Get by date'), value: 'by-date' },
+	{ label: __('Get alphabetical'), value: 'alphabetical' },
 ];
 
 const generalRelationOptionsCategories = [
@@ -355,4 +359,15 @@ export const limitOptions = {
 	withInputField: false,
 	min: 0,
 	max: 9999,
+};
+
+export const orderByOptions = {
+	'by-date': [
+		{ label: __('New/old', 'maxi-blocks'), value: 'new-old' },
+		{ label: __('Old/new', 'maxi-blocks'), value: 'old-new' },
+	],
+	alphabetical: [
+		{ label: __('A/Z', 'maxi-blocks'), value: 'a-z' },
+		{ label: __('Z/A', 'maxi-blocks'), value: 'z-a' },
+	],
 };

--- a/src/extensions/DC/getDCEntity.js
+++ b/src/extensions/DC/getDCEntity.js
@@ -26,17 +26,6 @@ const nameDictionary = {
 	tags: 'post_tag',
 };
 
-const getOrderForQuery = (relation, order) => {
-	switch (relation) {
-		case 'by-date':
-			return order === 'new-old' ? 'desc' : 'asc';
-		case 'alphabetical':
-			return order === 'a-z' ? 'desc' : 'asc';
-		default:
-			return 'asc';
-	}
-};
-
 const getDCEntity = async dataRequest => {
 	const {
 		'dc-type': type,
@@ -86,7 +75,7 @@ const getDCEntity = async dataRequest => {
 			{
 				per_page: accumulator + 1,
 				hide_empty: false,
-				order: getOrderForQuery(relation, order),
+				order,
 				orderby: relation === 'by-date' ? 'date' : 'title',
 			}
 		);

--- a/src/extensions/DC/getDCEntity.js
+++ b/src/extensions/DC/getDCEntity.js
@@ -26,6 +26,17 @@ const nameDictionary = {
 	tags: 'post_tag',
 };
 
+const getOrderForQuery = (relation, order) => {
+	switch (relation) {
+		case 'by-date':
+			return order === 'new-old' ? 'desc' : 'asc';
+		case 'alphabetical':
+			return order === 'a-z' ? 'desc' : 'asc';
+		default:
+			return 'asc';
+	}
+};
+
 const getDCEntity = async dataRequest => {
 	const {
 		'dc-type': type,
@@ -34,6 +45,8 @@ const getDCEntity = async dataRequest => {
 		'dc-show': show,
 		'dc-relation': relation,
 		'dc-author': author,
+		'dc-order': order,
+		'dc-accumulator': accumulator,
 	} = dataRequest;
 
 	const contentError = getDCErrors(type, error, show, relation);
@@ -63,6 +76,24 @@ const getDCEntity = async dataRequest => {
 
 		return randomEntity[Math.floor(Math.random() * randomEntity.length)];
 	}
+	if (
+		relationTypes.includes(type) &&
+		['by-date', 'alphabetical'].includes(relation)
+	) {
+		const entities = await resolveSelect('core').getEntityRecords(
+			kindDictionary[type],
+			nameDictionary[type],
+			{
+				per_page: accumulator + 1,
+				hide_empty: false,
+				order: getOrderForQuery(relation, order),
+				orderby: relation === 'by-date' ? 'date' : 'title',
+			}
+		);
+
+		return entities.at(-1);
+	}
+
 	if (type === 'settings') {
 		const settings = await resolveSelect('core').getEditedEntityRecord(
 			kindDictionary[type],

--- a/src/extensions/DC/utils.js
+++ b/src/extensions/DC/utils.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { fieldOptions } from './constants';
+import { fieldOptions, relationOptions } from './constants';
 
 /**
  * External dependencies
@@ -45,10 +45,25 @@ export const sanitizeDCContent = content =>
 		? __(content, 'maxi-blocks')
 		: __('No content found', 'maxi-blocks');
 
-export const validationsValues = (variableValue, field, contentType) => {
-	const result = fieldOptions[contentType][variableValue].map(x => x.value);
+export const validationsValues = (
+	variableValue,
+	field,
+	relation,
+	contentType
+) => {
+	const fieldResult = fieldOptions[contentType][variableValue].map(
+		x => x.value
+	);
+	const relationResult = relationOptions[contentType][variableValue].map(
+		x => x.value
+	);
 
-	return result.includes(field) ? {} : { 'dc-field': result[0] };
+	return {
+		...(!fieldResult.includes(field) && { 'dc-field': fieldResult[0] }),
+		...(!relationResult.includes(relation) && {
+			'dc-relation': relationResult[0],
+		}),
+	};
 };
 
 export const getDCDateCustomFormat = date => moment.parseFormat(date);

--- a/src/extensions/styles/defaults/dynamicContent.js
+++ b/src/extensions/styles/defaults/dynamicContent.js
@@ -107,6 +107,13 @@ const dynamicContent = {
 	'dc-link-url': {
 		type: 'string',
 	},
+	'dc-order': {
+		type: 'string',
+	},
+	'dc-accumulator': {
+		type: 'number',
+		default: 0,
+	},
 };
 
 export default dynamicContent;

--- a/src/extensions/styles/defaults/dynamicContent.js
+++ b/src/extensions/styles/defaults/dynamicContent.js
@@ -109,6 +109,7 @@ const dynamicContent = {
 	},
 	'dc-order': {
 		type: 'string',
+		default: 'desc',
 	},
 	'dc-accumulator': {
 		type: 'number',


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4662 

@Naaaaiix at the keyboard:
This implementation adds 2 new types of relations on DC that are necessary for the future implementation of Context Loop (CL). These 2 new types are:
- Alphabetical
- By date

Each one has an `order` setting to decide if A->Z/Z->A and New->Old/Old->New respectively. And then it appears a new input called `Accumulator`; some points about it:
1. The label is temporary, let's focus on its functionality
2. What it does is to jump its value in the list of the requested elements; I think a video helps understanding:


https://user-images.githubusercontent.com/50477222/229063932-88c168d4-cdc5-402b-98f4-1b08b8abe774.mp4

(Seems the change from `new/old` to `old/new` didn't work on the video, but the video is to share what's accumulator)

So, if we want posts organizes by date and we've got a list of:
1. Post 1
2. Post 2
3. Post 3
4. Post 4

we'll receive `Post 1` if accumulator is 0, and `Post 2` if accumulator is 1, and so on...

# How Has This Been Tested?
Checked if new relations works as expected.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test get by date DC relation
-   [ ] Test get alphabetical DC relation 

**_ Pre-Code Testing _**

-   [ ] Test get by date DC relation
-   [ ] Test get alphabetical DC relation 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [X] New and existing unit tests pass locally with my changes
