### PR TITLE
Fix return for useEffect

### DIFF
--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -347,8 +347,6 @@ const MaxiBlock = memo(
 					style.remove();
 				};
 			}
-
-			return null;
 		}, [styleStr, isFirstOnHierarchy, clientId]);
 
 		return (

--- a/src/extensions/maxi-block/withMaxiLoader.js
+++ b/src/extensions/maxi-block/withMaxiLoader.js
@@ -57,7 +57,7 @@ const withMaxiLoader = createHigherOrderComponent(
 				useState(false);
 
 			useEffect(() => {
-				if (canRender && hasBeenConsolidated) return;
+				if (canRender && hasBeenConsolidated) return () => {};
 
 				const interval = setInterval(async () => {
 					if (getIsPageLoaded()) {


### PR DESCRIPTION
# Description

Fixes block removal breaking on WP 6.2 + removes a warning on editor load.