### PR TITLE
Issue 4675 - Border around the gradient colour picker

### DIFF
--- a/src/components/list-control/editor.scss
+++ b/src/components/list-control/editor.scss
@@ -38,7 +38,7 @@
 		.components-custom-gradient-picker__gradient-bar {
 			margin-top: 0;
 			margin-bottom: 8px;
-			border: 1px solid var(--maxi-grey-3-color);
+			border: 1px solid var(--maxi-grey-1-color);
 		}
 
 		.components-custom-gradient-picker__ui-line {

--- a/src/components/list-control/editor.scss
+++ b/src/components/list-control/editor.scss
@@ -38,6 +38,7 @@
 		.components-custom-gradient-picker__gradient-bar {
 			margin-top: 0;
 			margin-bottom: 8px;
+			border: 1px solid var(--maxi-grey-3-color);
 		}
 
 		.components-custom-gradient-picker__ui-line {


### PR DESCRIPTION
Added border around gradient colour picker.

Fixes #4675 


-   [ ] Check that the gradient colour picker has a border now.

**_ Pre-Code Testing _**

-   [ ] Check that the gradient colour picker has a border now.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
