### PR TITLE
Fixes for v1.0.1

### DIFF
--- a/src/blocks/number-counter-maxi/style.scss
+++ b/src/blocks/number-counter-maxi/style.scss
@@ -14,7 +14,8 @@ body.maxi-blocks--active .maxi-number-counter-block {
 				transform-origin: center;
 			}
 
-			&__text:not(.circle-hidden) {
+			// Fixes issues coming from #4309 as the CSS is not migrated
+			svg + .maxi-number-counter__box__text {
 				text-align: center;
 				position: absolute;
 				top: 50%;
@@ -22,6 +23,7 @@ body.maxi-blocks--active .maxi-number-counter-block {
 				transform: translate(-50%, -50%);
 				-webkit-transform: translate(-50%, -50%);
 			}
+
 			.circle-hidden {
 				display: block;
 				text-align: center;


### PR DESCRIPTION
# Description

This branch pretends to fix 2 issues found on the update for v1.0.1:
1. NC was broken on some staging.devdemo due to some changes on the static CSS that affect it. To avoid doing strange movements and migrators modified the CSS to do the same without relying on CSS classes updates. Here's a video of how it deals with the issue:


https://user-images.githubusercontent.com/50477222/230400989-4e826945-93d7-408a-a30d-5618be63af20.mp4

3. Some Image Maxi with `clip-path` settings weren't having transitions. Modified a migrator to ensure it works with it 👍 

# How Has This Been Tested?

To test NC, use Maxi v1.0.0-RC2 with this [code editor(https://github.com/maxi-blocks/maxi-blocks/files/11171357/ncissue.txt) and save the page. Then step to `master` and WITHOUT entering the editor, check the frontend; the NC blocks should look broken. Then get into this branch and check the frontend again without passing by the editor side. Also, check everything tested on #4309 is still working correctly as this fix modifies that fix 👍 

To test `clip-path` transition, paste this [code editor](https://github.com/maxi-blocks/maxi-blocks/files/11171396/cptransition.txt) in `master` and check the clip-path transition doesn't work. Then jump to this branch and test again: it should work correctly

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the commented above

**_ Pre-Code Testing _**

-   [ ] Test the commented above
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
