### PR TITLE
Missing domain for translation texts

### DIFF
--- a/src/blocks/cloud-maxi/cloud-maxi.js
+++ b/src/blocks/cloud-maxi/cloud-maxi.js
@@ -21,8 +21,8 @@ import { registerBlockType } from '@wordpress/blocks';
  * Register the Layout block
  */
 registerBlockType('maxi-blocks/maxi-cloud', {
-	title: __('Template Library Maxi'),
-	description: __('Find templates or patterns'),
+	title: __('Template Library Maxi', 'maxi-blocks'),
+	description: __('Find templates or patterns', 'maxi-blocks'),
 	icon: library,
 	category: 'maxi-blocks',
 	example: {

--- a/src/blocks/container-maxi/components/shape-divider-control/index.js
+++ b/src/blocks/container-maxi/components/shape-divider-control/index.js
@@ -74,7 +74,7 @@ const ShapeDividerControl = props => {
 	const { onChangeInline, onChange, breakpoint } = props;
 
 	const shapeItemsTop = [
-		{ label: __('None', 'max-block'), value: '' },
+		{ label: __('None', 'maxi-blocks'), value: '' },
 		{ icon: wavesTop, value: 'waves-top' },
 		{ icon: wavesTopOpacity, value: 'waves-top-opacity' },
 		{ icon: waveTop, value: 'wave-top' },
@@ -98,7 +98,7 @@ const ShapeDividerControl = props => {
 	];
 
 	const shapeItemsBottom = [
-		{ label: __('None', 'max-block'), value: '' },
+		{ label: __('None', 'maxi-blocks'), value: '' },
 		{ icon: wavesBottom, value: 'waves-bottom' },
 		{ icon: wavesBottomOpacity, value: 'waves-bottom-opacity' },
 		{ icon: waveBottom, value: 'wave-bottom' },
@@ -208,7 +208,7 @@ const ShapeDividerControl = props => {
 			case 'cloud-bottom-opacity':
 				return cloudBottomOpacity;
 			default:
-				return __('Divider style', 'max-block');
+				return __('Divider style', 'maxi-blocks');
 		}
 	};
 

--- a/src/blocks/number-counter-maxi/components/number-counter-control/index.js
+++ b/src/blocks/number-counter-maxi/components/number-counter-control/index.js
@@ -331,7 +331,7 @@ const NumberCounterControl = props => {
 			/>
 			<ToggleSwitch
 				className='number-counter-percentage-sign-status'
-				label={__('Show percentage sign', 'maxi-block')}
+				label={__('Show percentage sign', 'maxi-blocks')}
 				selected={props['number-counter-percentage-sign-status']}
 				onChange={val =>
 					onChange({
@@ -360,7 +360,7 @@ const NumberCounterControl = props => {
 			{!props['number-counter-circle-status'] && (
 				<ToggleSwitch
 					className='number-counter-rounded-status'
-					label={__('Rounded bar', 'maxi-block')}
+					label={__('Rounded bar', 'maxi-blocks')}
 					selected={props['number-counter-rounded-status']}
 					onChange={val =>
 						onChange({

--- a/src/blocks/slider-maxi/components/navigation-control/index.js
+++ b/src/blocks/slider-maxi/components/navigation-control/index.js
@@ -42,7 +42,7 @@ const NavigationControl = props => {
 	return (
 		<div className={classes}>
 			<ToggleSwitch
-				label={__('Enable arrows')}
+				label={__('Enable arrows', 'maxi-blocks')}
 				selected={arrowsEnabled}
 				onChange={val =>
 					onChange({
@@ -51,7 +51,7 @@ const NavigationControl = props => {
 				}
 			/>
 			<ToggleSwitch
-				label={__('Enable dots')}
+				label={__('Enable dots', 'maxi-blocks')}
 				selected={dotsEnabled}
 				onChange={val =>
 					onChange({ [`${dotPrefix}status-${deviceType}`]: val })

--- a/src/blocks/svg-icon-maxi/data.js
+++ b/src/blocks/svg-icon-maxi/data.js
@@ -182,7 +182,7 @@ const interactionBuilderSettings = {
 	block: [
 		{
 			sid: 'ic',
-			label: __('Icon colour'),
+			label: __('Icon colour', 'maxi-blocks'),
 			transitionTarget: [
 				transition.block.colour.target,
 				transition.block['colour two'].target,

--- a/src/blocks/video-maxi/components/video-overlay-control/index.js
+++ b/src/blocks/video-maxi/components/video-overlay-control/index.js
@@ -181,7 +181,7 @@ const VideoOverlayControl = props => {
 					{!disableUploadImage && (
 						<MediaUploaderControl
 							className='maxi-video-overlay-control__cover-image'
-							placeholder={__('Image overlay')}
+							placeholder={__('Image overlay', 'maxi-blocks')}
 							mediaID={mediaID}
 							onSelectImage={val => {
 								const alt =

--- a/src/components/arrow-control/index.js
+++ b/src/components/arrow-control/index.js
@@ -102,7 +102,8 @@ const ArrowControl = props => {
 				props['show-warning-box'] && (
 					<InfoBox
 						message={__(
-							'Please ensure that the background color is not the same as the page background color.'
+							'Please ensure that the background color is not the same as the page background color.',
+							'maxi-blocks'
 						)}
 						onClose={() => onChange({ 'show-warning-box': false })}
 					/>

--- a/src/components/background-control/videoLayer.js
+++ b/src/components/background-control/videoLayer.js
@@ -53,7 +53,7 @@ const VideoLayerContent = props => {
 			{!isHover && !isIB && (
 				<MediaUploaderControl
 					className='maxi-mediauploader-control__video-fallback'
-					placeholder={__('Background fallback')}
+					placeholder={__('Background fallback', 'maxi-blocks')}
 					mediaID={getLastBreakpointAttribute({
 						target: `${prefix}background-video-fallbackID`,
 						breakpoint,

--- a/src/components/image-url/index.js
+++ b/src/components/image-url/index.js
@@ -87,7 +87,7 @@ const ImageURL = props => {
 					<div className='maxi-editor-url-input__button-modal-line'>
 						<Button
 							icon={check}
-							label={__('Submit')}
+							label={__('Submit', 'maxi-blocks')}
 							type='submit'
 						/>
 						<URLInput
@@ -103,7 +103,7 @@ const ImageURL = props => {
 						<Button
 							className='maxi-editor-url-input__back'
 							icon={close}
-							label={__('Close')}
+							label={__('Close', 'maxi-blocks')}
 							onClick={event => {
 								event.preventDefault();
 								setHideWarning(true);

--- a/src/components/inspector-tabs/inspector-anchor.js
+++ b/src/components/inspector-tabs/inspector-anchor.js
@@ -33,7 +33,10 @@ const anchor = ({ props }) => {
 					'maxi-blocks'
 				)}
 				className='maxi-anchor-link'
-				placeholder={__('Allowed chars: 0-9, A-Z, a-z, _ , -')}
+				placeholder={__(
+					'Allowed chars: 0-9, A-Z, a-z, _ , -',
+					'maxi-blocks'
+				)}
 				value={anchorLink}
 				onChange={anchorLink => {
 					const link = validateAnchor(anchorLink);

--- a/src/components/relation-control/index.js
+++ b/src/components/relation-control/index.js
@@ -380,7 +380,10 @@ const RelationControl = props => {
 									<TextControl
 										label={__('Name', 'maxi-blocks')}
 										value={item.title}
-										placeholder={__('Give memorable name…')}
+										placeholder={__(
+											'Give memorable name…',
+											'maxi-blocks'
+										)}
 										onChange={value =>
 											onChangeRelation(
 												relations,

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -497,7 +497,10 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 						{importedCardExists && (
 							<div className='maxi-style-cards__card-already-exists'>
 								<span>
-									{__('Imported card already exists.')}
+									{__(
+										'Imported card already exists.',
+										'maxi-blocks'
+									)}
 								</span>
 							</div>
 						)}


### PR DESCRIPTION
Added domain `('maxi-blocks')` to the translation texts where it was missing.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
