### PR TITLE
Issue 4748 - Font weight not working when font-family comes from SC

### DIFF
--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -154,6 +154,15 @@ class MaxiBlocks_StyleCards
         $text_level_values = (object) $style_card_values->$text_level;
 
         $font = $text_level_values->{'font-family-general'};
+
+        /**
+         * Button case has an exception for font-family. If it's empty, it will use the
+         * font-family of the paragraph text level.
+         */
+        if ($text_level === 'button' && empty($font)) {
+            $font = $style_card_values->p['font-family-general'];
+        }
+
         $font_weights = [];
         $font_styles = [];
 

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -411,6 +411,8 @@ class MaxiBlocks_Styles
 
         $use_local_fonts = (bool) get_option('local_fonts');
 
+        $loaded_fonts = [];
+
         foreach ($fonts as $font => $font_data) {
             $is_sc_font = strpos($font, 'sc_font') !== false;
 
@@ -482,7 +484,36 @@ class MaxiBlocks_Styles
                     $font_url .= ':';
 
                     foreach ($font_weights as $font_weight) {
+                        if(!is_array($font_weight)) {
+                            $font_weight = [ $font_weight ];
+                        }
+
                         foreach ($font_styles as $font_style) {
+                            $already_loaded = false;
+
+                            if (in_array(
+                                [
+                                    'font' => $font,
+                                    'font_weight' => $font_weight,
+                                    'font_style' => $font_style,
+                                ],
+                                $loaded_fonts
+                            )) {
+                                $already_loaded = true;
+                            }
+
+                            foreach($font_weight as $weight) {
+                                foreach($loaded_fonts as $loaded_font) {
+                                    if(in_array($weight, $loaded_font['font_weight']) && $loaded_font['font'] === $font) {
+                                        $already_loaded = true;
+                                    }
+                                }
+                            }
+
+                            if ($already_loaded) {
+                                continue;
+                            }
+
                             $font_data = [
                                 'weight' => $font_weight,
                                 'style' => $font_style,
@@ -493,6 +524,12 @@ class MaxiBlocks_Styles
                                 $font_url,
                                 $font_data
                             );
+
+                            $loaded_fonts[] = [
+                                'font' => $font,
+                                'font_weight' => $font_weight,
+                                'font_style' => $font_style,
+                            ];
 
                             if (is_array($font_weight)) {
                                 $font_weight = implode('-', $font_weight);

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -424,6 +424,14 @@ class MaxiBlocks_Styles
 
                     @list($font, $font_weights, $font_styles) = $sc_fonts;
                 }
+
+                if (isset($font_data['weight']) && !in_array($font_data['weight'], $font_weights)) {
+                    $font_weights = [[...$font_weights, intval($font_data['weight'])]];
+                }
+
+                if (isset($font_data['style']) && !in_array($font_data['style'], $font_styles)) {
+                    $font_styles = [[...$font_styles, intval($font_data['style'])]];
+                }
             }
 
             if ($font) {
@@ -485,6 +493,10 @@ class MaxiBlocks_Styles
                                 $font_url,
                                 $font_data
                             );
+
+                            if (is_array($font_weight)) {
+                                $font_weight = implode('-', $font_weight);
+                            }
 
                             wp_enqueue_style(
                                 $name . '-font-' . sanitize_title_with_dashes($font . '-' . $font_weight . '-' . $font_style),


### PR DESCRIPTION
## Update 1
While checking the error @ckp267 shared with Button Maxi, found another error. As Button Maxi default font-family is empty as it gets by default the paragraph one, when adding just a Button on a page and checking frontend the font wasn't loaded (because basically is empty). Now is fixed 👍 

# Description

There was a conflict when trying to download a font that was coming from SC and the font-weight of that font coming from block. This implementation should fix it 👍 

Fixes #4748 

# How Has This Been Tested?

Do the commented on the issue 👍 

Also check that a single Button Maxi on a page has a correct font-family in frontend 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
