### PR TITLE
Issue 4720 - Fix reusable blocks editor crash

### DIFF
--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -19,6 +19,7 @@ import {
 	getHasParallax,
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
+import { getIsHoverPreview } from '../../extensions/maxi-block';
 import InnerBlocksBlock from './innerBlocksBlock';
 import MainMaxiBlock from './mainMaxiBlock';
 
@@ -318,7 +319,12 @@ const MaxiBlock = memo(
 		const { clientId, attributes, deviceType } = props;
 
 		const [isHovered, setHovered] = useReducer(e => !e, false);
-		const marginValue = select('maxiBlocks/styles').getBlockMarginValue();
+
+		const isHoverPreview = getIsHoverPreview();
+
+		const marginValue = !isHoverPreview
+			? select('maxiBlocks/styles').getBlockMarginValue()
+			: 0;
 
 		// In order to keep the structure that Gutenberg uses for the block,
 		// is necessary to add some inline styles to the first hierarchy blocks.

--- a/src/extensions/maxi-block/getIsHoverPreview.js
+++ b/src/extensions/maxi-block/getIsHoverPreview.js
@@ -1,0 +1,10 @@
+/**
+ * Returns if the block is in the preview iframe (for example on hover in block inserter)
+ *
+ * @param {*} blockEl
+ * @returns {boolean}
+ */
+const getIsHoverPreview = () =>
+	document.querySelector('.block-editor-block-preview__container');
+
+export default getIsHoverPreview;

--- a/src/extensions/maxi-block/index.js
+++ b/src/extensions/maxi-block/index.js
@@ -1,4 +1,5 @@
 export { default as getCustomLabel } from './getCustomLabel';
+export { default as getIsHoverPreview } from './getIsHoverPreview';
 export { default as getIsUniqueIDRepeated } from './getIsUniqueIDRepeated';
 export { default as goThroughMaxiBlocks } from './goThroughMaxiBlocks';
 export { default as handleSetAttributes } from './handleSetAttributes';

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -28,6 +28,7 @@ import {
 } from '../styles';
 import getBreakpoints from '../styles/helpers/getBreakpoints';
 import getIsUniqueIDRepeated from './getIsUniqueIDRepeated';
+import getIsHoverPreview from './getIsHoverPreview';
 import getCustomLabel from './getCustomLabel';
 import { loadFonts, getAllFonts } from '../text/fonts';
 import uniqueIDStructureChecker from './uniqueIDStructureChecker';
@@ -52,7 +53,6 @@ import propsObjectCleaner from './propsObjectCleaner';
  */
 import { isEmpty, isEqual, isFunction, isNil } from 'lodash';
 import { diff } from 'deep-object-diff';
-import getIsHoverPreview from './getIsHoverPreview';
 
 /**
  * Style Component

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -52,6 +52,7 @@ import propsObjectCleaner from './propsObjectCleaner';
  */
 import { isEmpty, isEqual, isFunction, isNil } from 'lodash';
 import { diff } from 'deep-object-diff';
+import getIsHoverPreview from './getIsHoverPreview';
 
 /**
  * Style Component
@@ -129,7 +130,7 @@ class MaxiBlockComponent extends Component {
 		this.blockRef = createRef();
 		this.typography = getGroupAttributes(attributes, 'typography');
 		this.isTemplatePartPreview = !!getTemplatePartChooseList();
-		this.isHoverPreview = false;
+		this.isHoverPreview = getIsHoverPreview();
 
 		dispatch('maxiBlocks').removeDeprecatedBlock(uniqueID);
 
@@ -158,10 +159,8 @@ class MaxiBlockComponent extends Component {
 		this.isReusable =
 			this.blockRef.current.parentNode.classList.contains('is-reusable');
 
-		// Check if the block is in the preview iframe (for example on hover in block inserter)
-		this.isHoverPreview = this.blockRef.current.ownerDocument
-			.querySelector('html')
-			.classList.contains('block-editor-block-preview__content-iframe');
+		// // Check if the block is in the preview iframe (for example on hover in block inserter)
+		// this.isHoverPreview = getIsHoverPreview(this.blockRef.current);
 
 		if (this.isReusable) {
 			this.widthObserver = updateReusableBlockSize(
@@ -519,7 +518,7 @@ class MaxiBlockComponent extends Component {
 				return wrapper;
 			};
 
-			const getPreviewWrapper = (element, onCreateWrapper) => {
+			const getPreviewWrapper = element => {
 				const elementHead = Array.from(
 					element.querySelectorAll('head')
 				).pop();
@@ -529,9 +528,12 @@ class MaxiBlockComponent extends Component {
 				).pop();
 
 				elementBody.classList.add('maxi-blocks--active');
+
+				const width =
+					elementBody.querySelector('.is-root-container').offsetWidth;
 				elementBody.setAttribute(
 					'maxi-blocks-responsive',
-					getWinBreakpoint(elementBody.offsetWidth)
+					getWinBreakpoint(width)
 				);
 
 				return getStylesWrapper(elementHead, () => {

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -159,9 +159,6 @@ class MaxiBlockComponent extends Component {
 		this.isReusable =
 			this.blockRef.current.parentNode.classList.contains('is-reusable');
 
-		// // Check if the block is in the preview iframe (for example on hover in block inserter)
-		// this.isHoverPreview = getIsHoverPreview(this.blockRef.current);
-
 		if (this.isReusable) {
 			this.widthObserver = updateReusableBlockSize(
 				this.blockRef.current,
@@ -670,7 +667,7 @@ class MaxiBlockComponent extends Component {
 			iframe ||
 			document;
 
-		if (!this.props.attributes.preview && !this.isHoverPreview)
+		if (!this.props.attributes.preview)
 			getEditorElement()
 				.getElementById(
 					getStylesWrapperId(this.props.attributes.uniqueID)


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4720 

The problems were in `maxiBlockComponent` cycle for reusable blocks preview (on reusable block card hover in block inserter)


https://user-images.githubusercontent.com/46112160/233181819-df305097-ce01-4e61-8b88-96ade1e8a5d4.mp4


# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test reusable blocks inserting, preview, work in general

**_ Pre-Code Testing _**

-   [ ] Test reusable blocks inserting, preview, work in general
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
-   [X] New and existing unit tests pass locally with my changes
