### PR TITLE
Issue 4728 - Inspector advanced tab

### DIFF
--- a/src/blocks/map-maxi/inspector.js
+++ b/src/blocks/map-maxi/inspector.js
@@ -22,6 +22,7 @@ import {
 } from './components';
 import { getGroupAttributes } from '../../extensions/styles';
 import { customCss } from './data';
+import { withMaxiInspector } from '../../extensions/inspector';
 import * as inspectorTabs from '../../components/inspector-tabs';
 
 /**
@@ -264,4 +265,4 @@ const Inspector = props => {
 	);
 };
 
-export default Inspector;
+export default withMaxiInspector(Inspector);

--- a/src/blocks/slide-maxi/inspector.js
+++ b/src/blocks/slide-maxi/inspector.js
@@ -10,6 +10,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { AccordionControl, SettingTabsControl } from '../../components';
 import * as inspectorTabs from '../../components/inspector-tabs';
 import { customCss } from './data';
+import { withMaxiInspector } from '../../extensions/inspector';
 
 /**
  * Inspector
@@ -121,4 +122,4 @@ const Inspector = props => {
 	);
 };
 
-export default Inspector;
+export default withMaxiInspector(Inspector);

--- a/src/blocks/slider-maxi/inspector.js
+++ b/src/blocks/slider-maxi/inspector.js
@@ -17,6 +17,7 @@ import SliderControl from './components/slider-control';
 import NavigationControl from './components/navigation-control';
 import NavigationIconsControl from './components/navigation-control/navigation-control';
 import { customCss } from './data';
+import { withMaxiInspector } from '../../extensions/inspector';
 
 /**
  * Inspector
@@ -251,4 +252,4 @@ const Inspector = props => {
 	);
 };
 
-export default Inspector;
+export default withMaxiInspector(Inspector);

--- a/src/blocks/video-maxi/edit.js
+++ b/src/blocks/video-maxi/edit.js
@@ -195,7 +195,10 @@ class edit extends MaxiBlockComponent {
 					ref={this.blockRef}
 					{...getMaxiBlockAttributes(this.props)}
 				>
-					<img src={previews.video_preview} />
+					<img // eslint-disable-next-line no-undef
+						src={previews.video_preview}
+						alt={__('Container block preview', 'maxi-blocks')}
+					/>
 				</MaxiBlock>
 			);
 

--- a/src/blocks/video-maxi/inspector.js
+++ b/src/blocks/video-maxi/inspector.js
@@ -10,6 +10,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { AccordionControl, SettingTabsControl } from '../../components';
 import * as inspectorTabs from '../../components/inspector-tabs';
 import { customCss } from './data';
+import { withMaxiInspector } from '../../extensions/inspector';
 import { getGroupAttributes } from '../../extensions/styles';
 import {
 	PopupSettingsControl,
@@ -317,4 +318,4 @@ const Inspector = props => {
 	);
 };
 
-export default Inspector;
+export default withMaxiInspector(Inspector);


### PR DESCRIPTION
Fixed "extra" advanced tab in the inspector. 

Fixes #4728 

**_ Front/Back Testing _**

-   [ ] Test inspector for Map, Video, Slider and Slide blocks.

**_ Pre-Code Testing _**


-   [ ] Test inspector for Map, Video, Slider and Slide blocks.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
