### PR TITLE
Issue 4716 - Error on loading styles

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -10,7 +10,13 @@
  * WordPress dependencies
  */
 import { Component, createRoot, render, createRef } from '@wordpress/element';
-import { dispatch, resolveSelect, select, useSelect } from '@wordpress/data';
+import {
+	dispatch,
+	resolveSelect,
+	select,
+	useDispatch,
+	useSelect,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -76,6 +82,8 @@ const StyleComponent = ({
 		return { breakpoints, currentBreakpoint };
 	});
 
+	const { saveCSSCache } = useDispatch('maxiBlocks/styles');
+
 	if (isBreakpointChange && !isPreview) {
 		const styleContent =
 			select('maxiBlocks/styles').getCSSCache(uniqueID)[
@@ -97,13 +105,7 @@ const StyleComponent = ({
 
 	const styleContent = styleGenerator(styles, isIframe, isSiteEditor);
 
-	if (!isPreview)
-		dispatch('maxiBlocks/styles').saveCSSCache(
-			uniqueID,
-			styles,
-			isIframe,
-			isSiteEditor
-		);
+	if (!isPreview) saveCSSCache(uniqueID, styles, isIframe, isSiteEditor);
 
 	return <style>{styleContent}</style>;
 };

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -71,15 +71,14 @@ const StyleComponent = ({
 	isSiteEditor = false,
 	isPreview = false,
 	isBreakpointChange,
+	currentBreakpoint,
 }) => {
-	const { breakpoints, currentBreakpoint } = useSelect(select => {
-		const { receiveMaxiBreakpoints, receiveMaxiDeviceType } =
-			select('maxiBlocks');
+	const { breakpoints } = useSelect(select => {
+		const { receiveMaxiBreakpoints } = select('maxiBlocks');
 
 		const breakpoints = receiveMaxiBreakpoints();
-		const currentBreakpoint = receiveMaxiDeviceType();
 
-		return { breakpoints, currentBreakpoint };
+		return { breakpoints };
 	});
 
 	const { saveCSSCache } = useDispatch('maxiBlocks/styles');

--- a/src/extensions/styles/helpers/getBreakpoints.js
+++ b/src/extensions/styles/helpers/getBreakpoints.js
@@ -1,10 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
+import { resolveSelect } from '@wordpress/data';
 
-const getBreakpoints = obj => {
-	const defaultBreakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
+const getBreakpoints = async obj => {
+	const defaultBreakpoints = await resolveSelect(
+		'maxiBlocks'
+	).receiveMaxiBreakpoints();
 
 	return {
 		xxl: obj['breakpoints-xl'] || defaultBreakpoints.xl,

--- a/src/extensions/styles/helpers/getBreakpoints.js
+++ b/src/extensions/styles/helpers/getBreakpoints.js
@@ -1,12 +1,10 @@
 /**
  * WordPress dependencies
  */
-import { resolveSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 
-const getBreakpoints = async obj => {
-	const defaultBreakpoints = await resolveSelect(
-		'maxiBlocks'
-	).receiveMaxiBreakpoints();
+const getBreakpoints = obj => {
+	const defaultBreakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
 
 	return {
 		xxl: obj['breakpoints-xl'] || defaultBreakpoints.xl,

--- a/src/extensions/styles/helpers/test/getBreakpoints.js
+++ b/src/extensions/styles/helpers/test/getBreakpoints.js
@@ -1,5 +1,12 @@
 import getBreakpoints from '../getBreakpoints';
-import '../../../store';
+
+jest.mock('@wordpress/data', () => {
+	return {
+		select: jest.fn(() => ({
+			receiveMaxiBreakpoints: jest.fn(),
+		})),
+	};
+});
 
 describe('getBreakpoints', () => {
 	it('Get a correct breakpoint', () => {
@@ -12,6 +19,7 @@ describe('getBreakpoints', () => {
 			'breakpoints-xs': 500,
 		};
 		const result = getBreakpoints(object);
+
 		expect(result).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
# Description

The CSSCache process was interrupting the correct load of the styles as the `dispatch` action was in the middle of the process. Used the hook `useDispatch` to ensure an asynchronous 👍 

Fixes #4716 

# How Has This Been Tested?

Reduced the speed of the explorer using `performance` option `CPU throttling` to `x6`:
<img width="957" alt="Captura de Pantalla 2023-04-25 a las 10 33 33" src="https://user-images.githubusercontent.com/50477222/234220861-0986232f-532b-41a7-843b-1f04668a4cff.png">

all in a saved page with some huge pattern. The styles weren't loading correctly on master; they do in this version.
Important to also test:
1. Open list view or block inserter
2. Change Maxi responsive breakpoint 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
