### PR TITLE
Template support for child themes

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -128,6 +128,13 @@ class MaxiBlocks_Styles
         }
     }
 
+    public function get_template_name()
+    {
+        $template_name = wp_get_theme()->stylesheet ?? get_template();
+
+        return $template_name;
+    }
+
     public function get_template_parts($content)
     {
         if ($content && array_key_exists('template_parts', $content)) {
@@ -142,7 +149,7 @@ class MaxiBlocks_Styles
          * so it doesn't have template parts. In this case, we need to get default
          * template parts (header and footer).
          */
-        $theme_name = get_template();
+        $theme_name = $this->get_template_name();
         return [
             $theme_name . '//header',
             $theme_name . '//footer',
@@ -172,7 +179,7 @@ class MaxiBlocks_Styles
             if ($fonts) {
                 $this->enqueue_fonts($fonts, $name);
             }
-        } elseif (get_template() === 'maxi-theme' && $is_template_part) {
+        } elseif ($this->get_template_name() === 'maxi-theme' && $is_template_part) {
             do_action('maxi_enqueue_template_styles', $name, $id, $is_template);
         }
 
@@ -204,7 +211,7 @@ class MaxiBlocks_Styles
         }
 
         $template_slug = get_page_template_slug();
-        $template_id = get_template() . '//';
+        $template_id = $this->get_template_name() . '//';
 
         if ($template_slug != '' && $template_slug !== false) {
             $template_id .= $template_slug;
@@ -722,10 +729,10 @@ class MaxiBlocks_Styles
         global $wpdb;
 
         if (class_exists('MaxiBlocks_API')) {
-            $home_id =  get_template() . '//' . 'home';
+            $home_id =  $this->get_template_name() . '//' . 'home';
             $home_content = $this->get_content(true, $home_id);
 
-            $front_page_id = get_template() . '//' . 'front-page';
+            $front_page_id = $this->get_template_name() . '//' . 'front-page';
 
             $api = new MaxiBlocks_API();
 


### PR DESCRIPTION
# Description

As we are experiencing on staging.devdemo.com, there's an incompatibility between child themes and MaxiBlocks FSE support. This implementation deals with it ensuring the theme name we receive to match with the templates parts even if it's a child theme 👍 

# How Has This Been Tested?

Use a child theme like [this one](https://github.com/maxi-blocks/maxi-blocks/files/11322597/maxi-2023-child.zip) (`2023` child theme) on `master` branch and try to modify any template part like `header` or `footer` and check frontend: styles should be broken. This implementation should fix it 👍 

Video in:



https://user-images.githubusercontent.com/50477222/234568862-db05fb24-aa5e-439e-ae40-ff8768f28b28.mp4


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
