### PR TITLE
Issue 4745 - Search input border can't be set to none

### DIFF
--- a/src/blocks/search-maxi/style.scss
+++ b/src/blocks/search-maxi/style.scss
@@ -39,6 +39,8 @@ body.maxi-blocks--active .maxi-search-block {
 		display: flex;
 		align-items: center;
 		outline: none;
+		border-width: 0;
+		border-radius: 0;
 		margin: 0;
 		padding: 0;
 


### PR DESCRIPTION
WP is adding a 1px border around all inputs by default. When the Search Maxi input border was set to none this WP border line was showing. Added a CSS to overwrite this.

Fixes #4745 


# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test that there's a default search border (coming from Search Maxi settings)
-   [ ] Set it to none and make sure it doesn't display anymore.

**_ Pre-Code Testing _**

-   [ ] Test that there's a default search border (coming from Search Maxi settings)
-   [ ] Set it to none and make sure it doesn't display anymore.

-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
