### PR TITLE
Issue 4791 - Button hover migration bug

### DIFF
--- a/src/blocks/button-maxi/button-maxi.js
+++ b/src/blocks/button-maxi/button-maxi.js
@@ -66,13 +66,11 @@ registerBlockType('maxi-blocks/button-maxi', {
 	},
 	edit: withMaxiPreview(withMaxiLoader(edit)),
 	save,
-	deprecated: [
-		...blockMigrator({
-			attributes,
-			save,
-			prefix: 'button-',
-			selectors: customCss.selectors,
-			migrators: [buttonIconTransitionMigrator, buttonAriaLabelMigrator],
-		}),
-	],
+	deprecated: blockMigrator({
+		attributes,
+		save,
+		prefix: 'button-',
+		selectors: customCss.selectors,
+		migrators: [buttonIconTransitionMigrator, buttonAriaLabelMigrator],
+	}),
 });

--- a/src/extensions/styles/migrators/blockMigrator.js
+++ b/src/extensions/styles/migrators/blockMigrator.js
@@ -82,6 +82,23 @@ export const handleBlockMigrator = ({
 
 		if (!newMigrator.save) newMigrator.save = save;
 
+		const originalSave = newMigrator.save;
+		if (originalSave) {
+			newMigrator.save = props => {
+				const { uniqueID } = props.attributes;
+
+				const prevAttr =
+					select('maxiBlocks').receiveDeprecatedBlock(uniqueID);
+
+				if (!isNil(prevAttr))
+					Object.keys(prevAttr).forEach(key => {
+						props.attributes[key] = prevAttr[key];
+					});
+
+				return originalSave(props);
+			};
+		}
+
 		return newMigrator;
 	});
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4791 

It was related with "save" maxi migrators. They didn't receive last version of attributes, so it was fixed.

# How Has This Been Tested?
Inserted Pure Team Light PTML- 01 and checked if button has hover.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if button-maxi has hover status turned on after inserting template from library (Pure Team Light PTML- 01 for example)
-   [ ] Test if other migrators works as expected (insert other templates and check if they look as expected)

**_ Pre-Code Testing _**

-   [ ] Test if button-maxi has hover status turned on after inserting template from library (Pure Team Light PTML- 01 for example)
-   [ ] Test if other migrators works as expected (insert other templates and check if they look as expected)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors
