### PR TITLE
Local fonts fix, 404 for google fonts fix

### DIFF
--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -74,6 +74,8 @@ class MaxiBlocks_Local_Fonts
             }
         }
 
+
+
         if (empty($array)) {
             return false;
         }
@@ -84,7 +86,7 @@ class MaxiBlocks_Local_Fonts
             }
         }
 
-        $array = array_filter($array, function ($arr) {$arr !== null && $arr !== false && $arr !== '';});
+        $array = array_filter($array, function ($arr) {return $arr !== null && $arr !== false && $arr !== '';});
 
         if (empty($array)) {
             return false;

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -56,9 +56,20 @@ class MaxiBlocks_Local_Fonts
             "SELECT DISTINCT prev_fonts_value FROM {$wpdb->prefix}maxi_blocks_styles",
         );
 
+        // for templates
+        $post_content_templates_array = (array) $wpdb->get_results(
+            "SELECT DISTINCT fonts_value FROM {$wpdb->prefix}maxi_blocks_styles_templates",
+        );
+
+        $prev_post_content_templates_array = (array) $wpdb->get_results(
+            "SELECT DISTINCT prev_fonts_value FROM {$wpdb->prefix}maxi_blocks_styles_templates",
+        );
+
         if (
             empty($post_content_array) &&
             empty($prev_post_content_array) &&
+            empty($post_content_templates_array) &&
+            empty($prev_post_content_templates_array) &&
             $sc_string === ''
         ) {
             return false;
@@ -74,7 +85,17 @@ class MaxiBlocks_Local_Fonts
             }
         }
 
+        if (!empty($post_content_templates_array)) {
+            foreach ($post_content_templates_array as $font) {
+                $array[] = $font->fonts_value;
+            }
+        }
 
+        if (!empty($prev_post_content_templates_array)) {
+            foreach ($prev_post_content_templates_array as $font) {
+                $array[] = $font->prev_fonts_value;
+            }
+        }
 
         if (empty($array)) {
             return false;

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -405,15 +405,6 @@ class MaxiBlocks_Styles
         ];
     }
 
-    public function write_log($log)
-    {
-        if (is_array($log) || is_object($log)) {
-            error_log(print_r($log, true));
-        } else {
-            error_log($log);
-        }
-    }
-
     /**
      * Check font url status code
      */
@@ -428,10 +419,6 @@ class MaxiBlocks_Styles
         }
 
         $string = $array[0];
-
-        $this->write_log($font_url);
-        $this->write_log($string);
-        $this->write_log('------------------');
 
         if(strpos($string, '200')) {
             return true;

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -480,7 +480,21 @@ class MaxiBlocks_Styles
                         $font_styles = [$font_data['style']];
                     }
 
-                    $font_url = "https://fonts.googleapis.com/css2?family=$font";
+                    if ($use_local_fonts) {
+                        $font_name_sanitized = str_replace(
+                            ' ',
+                            '',
+                            strtolower($font)
+                        );
+                        $font_url =
+                            wp_upload_dir()['baseurl'] .
+                            '/maxi/fonts/' .
+                            $font_name_sanitized .
+                            '/style.css';
+                    } else {
+
+                        $font_url = "https://fonts.googleapis.com/css2?family=$font";
+                    }
 
                     // Load default font weight for cases where the saved font weight doesn't exist
                     wp_enqueue_style(

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -636,7 +636,7 @@ class MaxiBlocks_Styles
             add_filter(
                 'style_loader_tag',
                 function ($html, $handle) {
-                    if (strpos($handle, 'maxi-font-') !== false) {
+                    if (strpos($handle, 'maxi-blocks-styles-font-') !== false) {
                         $html = str_replace(
                             "rel='stylesheet'",
                             "rel='stylesheet preload'",

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -419,6 +419,8 @@ class MaxiBlocks_Styles
      */
     public function check_font_url($font_url)
     {
+        $font_url = str_replace(' ', '+', $font_url);
+
         $array = @get_headers($font_url);
 
         if(!$array) {
@@ -609,6 +611,7 @@ class MaxiBlocks_Styles
                                             $font_url
                                         );
                                     } else {  // Load default font weight for cases where the saved font weight doesn't exist
+                                        $font_url = strstr($font_url, ':wght', true);
                                         wp_enqueue_style(
                                             $name . '-font-' . sanitize_title_with_dashes($font),
                                             $font_url

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -632,15 +632,10 @@ class MaxiBlocks_Styles
             add_filter(
                 'style_loader_tag',
                 function ($html, $handle) {
-                    if (strpos($handle, 'maxi-blocks-styles-font-') !== false) {
+                    if (strpos($handle, 'maxi-blocks-styles-font-') !== false || strpos($handle, 'maxi-blocks-style-templates-header-font-') !== false) {
                         $html = str_replace(
                             "rel='stylesheet'",
                             "rel='stylesheet preload'",
-                            $html
-                        );
-                        $html = str_replace(
-                            "media='all'",
-                            "as='style' media='all'",
                             $html
                         );
                     }

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -438,9 +438,16 @@ class MaxiBlocks_Styles
             return;
         }
 
+        if(str_contains($name, '-templates-')) {
+            $pattern = '/(-templates-)(\w*)/';
+            $name = preg_replace($pattern, '', $name);
+            $name = str_replace('style', 'styles', $name);
+        }
+
         $use_local_fonts = (bool) get_option('local_fonts');
 
         $loaded_fonts = [];
+
 
         foreach ($fonts as $font => $font_data) {
             $is_sc_font = strpos($font, 'sc_font') !== false;

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -495,7 +495,10 @@ class MaxiBlocks_Styles
                             if($this->check_font_url($font_url)) {
                                 wp_enqueue_style(
                                     $name . '-font-' . sanitize_title_with_dashes($font),
-                                    $font_url
+                                    $font_url,
+                                    array(),
+                                    null,
+                                    'all'
                                 );
                             }
                         }
@@ -595,13 +598,19 @@ class MaxiBlocks_Styles
                                     if($this->check_font_url($font_url)) {
                                         wp_enqueue_style(
                                             $name . '-font-' . sanitize_title_with_dashes($font . '-' . $font_weight . '-' . $font_style),
-                                            $font_url
+                                            $font_url,
+                                            array(),
+                                            null,
+                                            'all'
                                         );
                                     } else {  // Load default font weight for cases where the saved font weight doesn't exist
                                         $font_url = strstr($font_url, ':wght', true);
                                         wp_enqueue_style(
                                             $name . '-font-' . sanitize_title_with_dashes($font),
-                                            $font_url
+                                            $font_url,
+                                            array(),
+                                            null,
+                                            'all'
                                         );
                                     }
                                 }
@@ -631,7 +640,7 @@ class MaxiBlocks_Styles
                         );
                         $html = str_replace(
                             "media='all'",
-                            "as='style' crossorigin media='all'",
+                            "as='style' media='all'",
                             $html
                         );
                     }


### PR DESCRIPTION
# Description

Brings back Local Fonts, fixes them for SC. Also adds back some optimizations for local fonts that we lost along the way.
Fixes google fonts 404 errors when trying to load non-existent font weights. 

This is not a full optimization PR, we still need code refactoring for fonts.

Fixes #4757

# How Has This Been Tested?

Fonts settings in different variations. Different SCs, custom fonts, local and not. 

# Test checklist

**_ Front/Back Testing _**

-   [ ] Test local fonts disabled and enabled
-   [ ] Test different SCs
-   [ ] Test custom fonts
-   [ ] Mix 1-3 and test
-   [ ] Check that backend works and saves the settings after the editor reload

**_ Pre-Code Testing _**

-   [ ] Test local fonts disabled and enabled
-   [ ] Test different SCs
-   [ ] Test custom fonts
-   [ ] Mix 1-3 and test
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
