### PR TITLE
Adds `forceUseBreakpoint` feature

### DIFF
--- a/src/extensions/styles/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/getLastBreakpointAttribute.js
@@ -32,7 +32,8 @@ const getLastBreakpointAttributeSingle = (
 	attributes,
 	isHover,
 	avoidXXL,
-	keys
+	keys,
+	forceUseBreakpoint = false
 ) => {
 	const { getBlockAttributes, getSelectedBlockClientId } = select(
 		'core/block-editor'
@@ -67,6 +68,7 @@ const getLastBreakpointAttributeSingle = (
 	// give priority to baseBreakpoint attribute just when the currentBreakpoint it's 'general'
 	// or the baseBreakpoint is different from 'xxl' and currentBreakpoint
 	if (
+		!forceUseBreakpoint &&
 		breakpoint === 'general' &&
 		(currentBreakpoint === 'general' ||
 			(baseBreakpoint !== 'xxl' && currentBreakpoint !== baseBreakpoint))
@@ -183,6 +185,7 @@ const getLastBreakpointAttribute = ({
 	forceSingle = false,
 	avoidXXL = true,
 	keys = [],
+	forceUseBreakpoint = false,
 }) => {
 	const { getSelectedBlockCount } = select('core/block-editor') || {
 		getSelectedBlockCount: () => 1, // Necessary for testing, mocking '@wordpress/data' is too dense
@@ -194,7 +197,8 @@ const getLastBreakpointAttribute = ({
 			breakpoint,
 			isHover,
 			avoidXXL,
-			keys
+			keys,
+			forceUseBreakpoint
 		);
 
 	return getLastBreakpointAttributeSingle(
@@ -203,7 +207,8 @@ const getLastBreakpointAttribute = ({
 		attributes,
 		isHover,
 		avoidXXL,
-		keys
+		keys,
+		forceUseBreakpoint
 	);
 };
 

--- a/src/extensions/styles/helpers/getTypographyStyles.js
+++ b/src/extensions/styles/helpers/getTypographyStyles.js
@@ -118,6 +118,7 @@ const getTypographyStyles = ({
 			target: `${prefix}${prop}`,
 			breakpoint,
 			attributes: isCustomFormat ? customFormatTypography : obj,
+			forceUseBreakpoint: true,
 		});
 
 		if (!normalTypography || unit) return unit === '-' ? '' : unit;

--- a/src/extensions/styles/test/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/test/getLastBreakpointAttribute.js
@@ -331,4 +331,44 @@ describe('getLastBreakpointAttribute', () => {
 		});
 		expect(result).toBe(3);
 	});
+
+	test('Should return general value being on XXL baseBreakpoint and enabling `forceUseBreakpoint`', () => {
+		const args = {
+			target: 'line-height-unit',
+			breakpoint: 'general',
+			attributes: {
+				'palette-status-general': true,
+				'palette-sc-status-general': false,
+				'palette-color-general': 5,
+				'list-palette-status-general': true,
+				'list-palette-sc-status-general': false,
+				'list-palette-color-general': 4,
+				'font-size-unit-general': 'px',
+				'font-size-general': 65,
+				'font-size-xxl': 94,
+				'font-size-l': 50,
+				'font-size-m': 40,
+				'font-size-xs': 30,
+				'line-height-unit-general': 'px',
+				'line-height-unit-xxl': 'em',
+				'line-height-unit-l': 'px',
+				'line-height-general': 78,
+				'line-height-xxl': 1.2,
+				'line-height-l': 65,
+				'line-height-m': 55,
+				'line-height-xs': 42,
+				'letter-spacing-unit-general': 'px',
+				'font-weight-general': '700',
+				'text-indent-unit-general': 'px',
+				'word-spacing-unit-general': 'px',
+				'bottom-gap-general': 0,
+				'bottom-gap-unit-general': 'px',
+			},
+			forceUseBreakpoint: true,
+		};
+
+		const result = getLastBreakpointAttribute(args);
+
+		expect(result).toBe('px');
+	});
 });

--- a/src/extensions/styles/test/getLastBreakpointAttribute.js
+++ b/src/extensions/styles/test/getLastBreakpointAttribute.js
@@ -333,6 +333,12 @@ describe('getLastBreakpointAttribute', () => {
 	});
 
 	test('Should return general value being on XXL baseBreakpoint and enabling `forceUseBreakpoint`', () => {
+		select.mockImplementation(() => ({
+			getSelectedBlockCount: jest.fn(() => 1),
+			receiveMaxiDeviceType: jest.fn(() => 'general'),
+			receiveBaseBreakpoint: jest.fn(() => 'xxl'),
+		}));
+
 		const args = {
 			target: 'line-height-unit',
 			breakpoint: 'general',


### PR DESCRIPTION
# Description

This PR fixes the issue found on staging.devdemo.maxiblocks.com. To whom who wants to understand the issue, here's the situation; it's hard to reproduce but we might need to check in other helpers:
This concrete situation has been produced by a Text Maxi that has [this code editor](https://github.com/maxi-blocks/maxi-blocks/files/11452980/forUseBreakpoint.txt). This block contains next `line-height-unit` attributes:
```json
{
    "line-height-unit-general": "px",
    "line-height-unit-l": "px",
    "line-height-unit-xxl": "em",
}
```
So, what we should expect on frontend is, on a XXL screen to have `line-height: ?em` and when is not XXL to have `line-height: ?px`. When we save this block on a baseBreakpoint < XL, it saves the frontend styles correctly, but when we are on baseBreakpoint XXL, it saves the line-height CSS setting in all cases using `em`. The reason is: we modified `getLastBreakpointAttribute` to get always the baseBreakpoint attribute over the `general` attribute in case it exists. But this is just a method to deal with the EE and what we display there to be sure we offer a good UX, but is not the same for saving styles. Basically, we can't depend on the baseBreakpoint from where we are saving the styles to generate one type of style or other; the frontend styles should be the same wherever baseBreakpoint we are saving. So, for it, I've create a new parameter on `getLastBreakpointAttribute` called `forceUseBreakpoint` to avoid this mechanism that gives preference to the baseBreakpoint attribute over the `general` attribute on this function. Couple of thoughts before ending:
1. Probably we should implement this in all helpers, as they don't need to interact with baseBreakpoint and we have to ensure the same styles not depending on it. Not doing in this PR as it needs to be controlled and done with love, creating tests and ensuring a good functionality of this feature,
2. This situation IS EXTREMELY HARD TO REPRODUCE, and tbh, considering this block was created on version `0.0.1 SC1`, it's probably that with the improvements we did and the way we clean the attributes with the filters it shouldn't happen. I've tried to reproduce in different ways and I couldn't, so, what I try to share with this comment is: in case the issue is there and persists, is hard to find. Anyway, will derive into a new issue and we'll discuss about it 👍 

# How Has This Been Tested?

From `master` branch, get the code editor shared above and paste in the editor. Then, try this:
1. Using the responsiveness of the Chrome console, save from XXL baseBreakpoint. Then check frontend from XXL and <XL: it should break <XL styles giving a line-height in `em` 👍 
2. Do the same, but saving from <XL breakpoint: it should look perfect in all responsive screens.

With this branch, saving in both situations should return same result 👍 

PS: when I use the expression `<XL`, I mean lower responsive than XL 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
