### PR TITLE
Issue 4802 - PHP warning - Undefinded slug

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -227,7 +227,22 @@ class MaxiBlocks_Styles
                     $template_id .= in_array('front-page', array_column($block_templates, 'slug')) ? 'front-page' : 'home';
                 }
             } else {
-                $template_id .= $block_templates[0]->slug;
+                // Arrived here, means we are probably trying to get index.php; so if the slug is not coming from $block_templates,
+                // we need to start going down on the WP hierarchy to find the correct template.
+                // TODO: create a better way to get the correct template.
+                if($block_templates && !empty($block_templates)) {
+                    $template_id .= $block_templates[0]->slug;
+                } elseif (is_search()) {
+                    $template_id .= 'search';
+                } elseif (is_404()) {
+                    $template_id .= '404';
+                } elseif (is_archive()) {
+                    $template_id .= 'archive';
+                } elseif (is_page()) {
+                    $template_id .= 'page';
+                } else {
+                    $template_id .= 'single';
+                }
             }
         } elseif (is_search()) {
             $template_id .= 'search';


### PR DESCRIPTION
# Description

Fixes the circuit when trying to get Home or FrontPage and it doesn't exist 👍 

Fixes #4802 

# How Has This Been Tested?

Using `master`, install GeneratePress theme and, ensuring `settings=>reading=>Your homepage display // A static page` is enabled, check frontend. You should have a PHP warning like the one in the issue. With this implementation it should work correctly 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
