### PR TITLE
Issue 4838 - Wrong image when downloading from Library

### DIFF
--- a/src/editor/library/utils/imageUploader.js
+++ b/src/editor/library/utils/imageUploader.js
@@ -123,18 +123,33 @@ const imageUploader = async (imageSrc, usePlaceholderImage) => {
 	// Check if it already exist
 	const media = await getEntityRecords('postType', 'attachment', {
 		post_status: 'inherit',
-		posts_per_page: 1,
 		search: title,
 		exact: true,
 	});
 
-	if (!isEmpty(media))
+	if (!isEmpty(media)) {
+		let mediaEl;
+
+		if (media.length === 0) return placeholderUploader();
+		if (media.length === 1) [mediaEl] = media;
+		else {
+			const mediaElIndex = media.findIndex(
+				({ title: { raw: rawTitle } }) =>
+					rawTitle === title || rawTitle === `${title}-1` // sometimes WP add a -1 to the title
+			);
+
+			if (mediaElIndex === -1) return placeholderUploader();
+
+			mediaEl = media[mediaElIndex];
+		}
+
 		return {
-			id: media[0].id,
+			id: mediaEl.id,
 			url:
-				media[0]?.media_details?.sizes?.full?.source_url ??
-				media[0].guid.rendered,
+				mediaEl?.media_details?.sizes?.full?.source_url ??
+				mediaEl.guid.rendered,
 		};
+	}
 
 	// In case the image is not found, let's fetch it from the Cloud server
 	const imageBlob = await fetch(imageSrc)

--- a/src/editor/library/utils/imageUploader.js
+++ b/src/editor/library/utils/imageUploader.js
@@ -125,6 +125,7 @@ const imageUploader = async (imageSrc, usePlaceholderImage) => {
 		post_status: 'inherit',
 		posts_per_page: 1,
 		search: title,
+		exact: true,
 	});
 
 	if (!isEmpty(media))


### PR DESCRIPTION
# Description

Fixes #4838 

# How Has This Been Tested?

Need to activate PRO (not sure what's the best approach for it) to test it.

From `master`, try downloading few times `Pure Testimonials Light PTLL-PRO-27`; in some moment the wrong image shared on the video of #4838 should happen. Change to this branch and test it again: it shouldn't happen anymore

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
