### PR TITLE
Fixes SC variables in FSE

### DIFF
--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -238,8 +238,13 @@ class MaxiBlocks_StyleCards
 
         $text_level_values = (object) $style_card_values->$text_level;
 
-        $font = $text_level_values->{'font-family-general'};
 
+        if(!property_exists($text_level_values, 'font-family-general')) {
+            $text_level_values = (object) $default_values[$text_level];
+        }
+
+        $font = $text_level_values->{'font-family-general'};
+        
         /**
          * Button case has an exception for font-family. If it's empty, it will use the
          * font-family of the paragraph text level.

--- a/src/extensions/style-cards/updateSCOnEditor.js
+++ b/src/extensions/style-cards/updateSCOnEditor.js
@@ -83,17 +83,20 @@ const updateSCOnEditor = (
 		activeSCColour
 	);
 	const allSCFonts = getSCFontsData(SCObject);
+	const SCVariableString = createSCStyleString(SCObject);
 
 	const elements = isArray(rawElements) ? rawElements : [rawElements];
 
-	elements.forEach(element => {
+	elements.forEach((element, i) => {
 		if (!element) return;
 
 		let SCVarEl = element.getElementById('maxi-blocks-sc-vars-inline-css');
+
 		if (!SCVarEl) {
 			SCVarEl = element.createElement('style');
 			SCVarEl.id = 'maxi-blocks-sc-vars-inline-css';
-			SCVarEl.innerHTML = createSCStyleString(SCObject);
+			SCVarEl.innerHTML = SCVariableString;
+
 			// Iframe on creation generates head, then gutenberg generates their own head
 			// and in some moment we have two heads, so we need to add SC only to head which is second(gutenberg one)
 			const elementHead = Array.from(
@@ -105,7 +108,7 @@ const updateSCOnEditor = (
 			// Needs a delay, if not Redux returns error 3
 			setTimeout(() => saveSCStyles(false), 150);
 		} else {
-			SCVarEl.innerHTML = createSCStyleString(SCObject);
+			SCVarEl.innerHTML = SCVariableString;
 
 			updateSCStyles(element, SCObject);
 		}


### PR DESCRIPTION
# Description

While fixing #4833 found we have an issue with the SC variables that weren't rendering correctly on FSE. Have couple of comments related: [this one](https://github.com/maxi-blocks/maxi-blocks/pull/4833#issuecomment-1545429003) explains the issue showing the lack of SC variables, and [this one](https://github.com/maxi-blocks/maxi-blocks/pull/4833#pullrequestreview-1424791100) shows the effects. This implementation should deal with it 👍 

# How Has This Been Tested?

From `master`, test SC like Wally and check template parts like `header`; the SC fonts or any other SC setting won't be rendered. With this branch it should work as expect 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
