### PR TITLE
Replace `selected` and not `active` SC on ColorControl for SC `globalProps`

### DIFF
--- a/src/components/color-control/index.js
+++ b/src/components/color-control/index.js
@@ -61,7 +61,9 @@ const ColorControl = props => {
 
 	const { globalStatus, globalPaletteColor, globalPaletteOpacity } =
 		useSelect(select => {
-			const { receiveStyleCardValue } = select('maxiBlocks/style-cards');
+			const { receiveSelectedStyleCardValue } = select(
+				'maxiBlocks/style-cards'
+			);
 
 			const prefix = globalProps?.target
 				? isHover && !globalProps?.target.includes('hover')
@@ -70,21 +72,21 @@ const ColorControl = props => {
 				: '';
 
 			const globalStatus = globalProps
-				? receiveStyleCardValue(
+				? receiveSelectedStyleCardValue(
 						`${prefix}color-global`,
 						globalProps ? getBlockStyle(clientId) : null,
 						globalProps?.type
 				  )
 				: false;
 			const globalPaletteColor = globalProps
-				? receiveStyleCardValue(
+				? receiveSelectedStyleCardValue(
 						`${prefix}palette-color`,
 						globalProps ? getBlockStyle(clientId) : null,
 						globalProps?.type
 				  )
 				: false;
 			const globalPaletteOpacity = globalProps
-				? receiveStyleCardValue(
+				? receiveSelectedStyleCardValue(
 						`${prefix}palette-opacity`,
 						globalProps ? getBlockStyle(clientId) : null,
 						globalProps?.type

--- a/src/editor/library/util.js
+++ b/src/editor/library/util.js
@@ -110,14 +110,14 @@ export const svgCurrentColorStatus = (blockStyle, target = 'svg') => {
 
 	if (!currentAttributes) return null;
 
-	const { receiveStyleCardValue } = select('maxiBlocks/style-cards');
+	const { receiveActiveStyleCardValue } = select('maxiBlocks/style-cards');
 
-	const lineColorGlobal = receiveStyleCardValue(
+	const lineColorGlobal = receiveActiveStyleCardValue(
 		'line-color',
 		getBlockStyle(clientId),
 		'icon'
 	);
-	const lineColorGlobalStatus = receiveStyleCardValue(
+	const lineColorGlobalStatus = receiveActiveStyleCardValue(
 		'line-color-global',
 		getBlockStyle(clientId),
 		'icon'

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -249,7 +249,7 @@ class MaxiBlockComponent extends Component {
 					oldSC: SC,
 					scValues: select(
 						'maxiBlocks/style-cards'
-					).receiveStyleCardValue(
+					).receiveActiveStyleCardValue(
 						this.scProps.scElements,
 						this.props.attributes.blockStyle,
 						this.scProps.scType

--- a/src/extensions/style-cards/store/selectors.js
+++ b/src/extensions/style-cards/store/selectors.js
@@ -36,34 +36,58 @@ export const receiveStyleCardsList = state => {
 	return false;
 };
 
-export const receiveStyleCardValue = (
+const getSCValues = (SC, rawTarget, blockStyle, SCEntry) => {
+	const getSCValue = target => {
+		const styleCardEntry = {
+			...SC.value?.[blockStyle]?.defaultStyleCard[SCEntry],
+			...SC.value?.[blockStyle]?.styleCard[SCEntry],
+		};
+		const value = styleCardEntry?.[target];
+
+		return getIsValid(value, true) ? value : false;
+	};
+
+	if (typeof rawTarget === 'string') return getSCValue(rawTarget);
+
+	const response = {};
+
+	rawTarget.forEach(target => {
+		response[target] = getSCValue(target);
+	});
+
+	return response;
+};
+
+export const receiveActiveStyleCardValue = (
 	state,
 	rawTarget,
 	blockStyle,
 	SCEntry
 ) => {
-	if (state.styleCards) {
-		const getSCValue = target => {
-			const selectedSCStyleCard = getActiveStyleCard(state.styleCards);
-			const styleCardEntry = {
-				...selectedSCStyleCard.value?.[blockStyle]?.defaultStyleCard[
-					SCEntry
-				],
-				...selectedSCStyleCard.value?.[blockStyle]?.styleCard[SCEntry],
-			};
-			const value = styleCardEntry?.[target];
+	if (state.styleCards)
+		return getSCValues(
+			getActiveStyleCard(state.styleCards),
+			rawTarget,
+			blockStyle,
+			SCEntry
+		);
 
-			return getIsValid(value, true) ? value : false;
-		};
+	return false;
+};
 
-		if (typeof rawTarget === 'string') return getSCValue(rawTarget);
+export const receiveSelectedStyleCardValue = (
+	state,
+	rawTarget,
+	blockStyle,
+	SCEntry
+) => {
+	if (state.styleCards)
+		return getSCValues(
+			getActiveStyleCard(state.styleCards, true),
+			rawTarget,
+			blockStyle,
+			SCEntry
+		);
 
-		const response = {};
-		rawTarget.forEach(target => {
-			response[target] = getSCValue(target);
-		});
-
-		return response;
-	}
 	return false;
 };


### PR DESCRIPTION
# Description

Replaces `active` for `selected` SC source when checking `globalProps` for ColorControl as requested in [this comment](https://github.com/maxi-blocks/maxi-blocks/pull/4825#issuecomment-1547369363) 👍 

# How Has This Been Tested?

Create a page, add a Text Maxi and then select a non-active SC; add global support for the colour and see how the colour palette on the Text Maxi sidebar is nulled when the SC is not the activated one 👍 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
