### PR TITLE
Fixes DialogBox on FSE

### DIFF
--- a/src/components/dialog-box/index.js
+++ b/src/components/dialog-box/index.js
@@ -9,6 +9,7 @@ import { createPortal, useState } from '@wordpress/element';
  */
 import Button from '../button';
 import Icon from '../icon';
+import { getIsSiteEditor } from '../../extensions/fse';
 
 /**
  * Styles and icons
@@ -28,6 +29,11 @@ const DialogBox = props => {
 	} = props;
 
 	const [isHidden, setIsHidden] = useState(true);
+
+	const getContainer = () =>
+		!getIsSiteEditor()
+			? document.getElementById('editor')
+			: document.getElementById('site-editor');
 
 	return isHidden ? (
 		<Button
@@ -71,7 +77,7 @@ const DialogBox = props => {
 					</div>
 				</div>
 			</div>,
-			document.getElementById('editor')
+			getContainer()
 		)
 	);
 };


### PR DESCRIPTION
# Description

Fixes what @Olekrut commented [here](https://github.com/maxi-blocks/maxi-blocks/pull/4849#pullrequestreview-1426061384) 👍 

Fixes # (issue)

# How Has This Been Tested?

From FSE, open SC and activate a new one. The confirmation box should appear and the button for the Maxi toolbar shouldn't disappear

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
