### PR TITLE
Issue 4805 - DC - post id reset

### DIFF
--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -300,10 +300,7 @@ const DynamicContent = props => {
 										}
 										onReset={() =>
 											changeProps({
-												'dc-id':
-													getDefaultAttribute(
-														'dc-id'
-													),
+												'dc-id': postIdOptions[0].value,
 											})
 										}
 									/>


### PR DESCRIPTION
Post ID wasn't resetting because it was set to return a default value which didn't exist. Set it now so it gets the first ID from the posts list. 

Fixes #4805 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that the post id resets correctly

**_ Pre-Code Testing _**

-   [ ] Check that the post id resets correctly
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
