### PR TITLE
Issue 4729-IB-map-wrong-targets

### DIFF
--- a/src/blocks/map-maxi/data.js
+++ b/src/blocks/map-maxi/data.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { createSelectors } from '../../extensions/styles/custom-css';
-import { getCanvasSettings } from '../../extensions/relations';
+import { getAdvancedSettings } from '../../extensions/relations';
 
 /**
  * Classnames
@@ -122,7 +122,7 @@ const customCss = {
 	],
 };
 const interactionBuilderSettings = {
-	canvas: getCanvasSettings({ name, customCss }),
+	advanced: getAdvancedSettings({ customCss }),
 };
 
 const data = {


### PR DESCRIPTION
Map had the canvas tab settings in IB, but it doesn't have a canvas. Added the advanced tab settings instead.

Fixes #4729 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test IB  on map. It should allow you to choose position, transform and opacity.


**_ Pre-Code Testing _**

-   [ ] Test IB  on map. It should allow you to choose position, transform and opacity.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
