### PR TITLE
Issue 4818 - NC percentege sign not aligned

### DIFF
--- a/js/maxi-number-counter.js
+++ b/js/maxi-number-counter.js
@@ -80,10 +80,7 @@ const numberCounterEffect = () => {
 					let newInnerHTML = `${count}`;
 
 					if (usePercentage) {
-						const percentageNode =
-							numberCounterElemText.nodeName === 'SPAN'
-								? '<sup>%</sup>'
-								: '<tspan baseline-shift="super">%</tspan>';
+						const percentageNode = '%';
 
 						newInnerHTML += percentageNode;
 					}

--- a/js/maxi-number-counter.js
+++ b/js/maxi-number-counter.js
@@ -49,6 +49,8 @@ const numberCounterEffect = () => {
 					'number-counter-end': numberCounterEnd,
 					'number-counter-duration': numberCounterDuration,
 					'number-counter-percentage-sign-status': usePercentage,
+					'number-counter-percentage-sign-position-status':
+						centeredPercentage,
 					'number-counter-start-animation': startAnimation,
 					'number-counter-start-animation-offset':
 						startAnimationOffset,
@@ -80,7 +82,9 @@ const numberCounterEffect = () => {
 					let newInnerHTML = `${count}`;
 
 					if (usePercentage) {
-						const percentageNode = '%';
+						const percentageNode = centeredPercentage
+							? '%'
+							: '<sup>%</sup>';
 
 						newInnerHTML += percentageNode;
 					}

--- a/src/blocks/number-counter-maxi/components/number-counter-control/index.js
+++ b/src/blocks/number-counter-maxi/components/number-counter-control/index.js
@@ -339,6 +339,21 @@ const NumberCounterControl = props => {
 					})
 				}
 			/>
+			{props['number-counter-percentage-sign-status'] === true && (
+				<ToggleSwitch
+					className='number-counter-percentage-sign-position'
+					label={__('Centre percentage sign', 'maxi-blocks')}
+					selected={
+						props['number-counter-percentage-sign-position-status']
+					}
+					onChange={val =>
+						onChange({
+							'number-counter-percentage-sign-position-status':
+								val,
+						})
+					}
+				/>
+			)}
 			<ToggleSwitch
 				className='number-counter-circle-status'
 				label={__('Hide circle', 'maxi-block')}

--- a/src/blocks/number-counter-maxi/edit.js
+++ b/src/blocks/number-counter-maxi/edit.js
@@ -168,6 +168,7 @@ const NumberCounter = attributes => {
 		'number-counter-circle-status': circleStatus,
 		'number-counter-preview': preview,
 		'number-counter-percentage-sign-status': usePercentage,
+		'number-counter-percentage-sign-position-status': centeredPercentage,
 		'number-counter-start': startNumber,
 		'number-counter-end': endNumber,
 		deviceType,
@@ -317,14 +318,15 @@ const NumberCounter = attributes => {
 					</svg>
 					<span className='maxi-number-counter__box__text'>
 						{`${round((count / 360) * 100)}`}
-						{usePercentage && '%'}
+						{usePercentage &&
+							(centeredPercentage ? '%' : <sup>%</sup>)}
 					</span>
 				</div>
 			)}
 			{circleStatus && (
 				<span className='maxi-number-counter__box__text circle-hidden'>
 					{`${round((count / 360) * 100)}`}
-					{usePercentage && '%'}
+					{usePercentage && (centeredPercentage ? '%' : <sup>%</sup>)}
 				</span>
 			)}
 		</BlockResizer>

--- a/src/blocks/number-counter-maxi/edit.js
+++ b/src/blocks/number-counter-maxi/edit.js
@@ -317,14 +317,14 @@ const NumberCounter = attributes => {
 					</svg>
 					<span className='maxi-number-counter__box__text'>
 						{`${round((count / 360) * 100)}`}
-						{usePercentage && <sup>%</sup>}
+						{usePercentage && '%'}
 					</span>
 				</div>
 			)}
 			{circleStatus && (
 				<span className='maxi-number-counter__box__text circle-hidden'>
 					{`${round((count / 360) * 100)}`}
-					{usePercentage && <sup>%</sup>}
+					{usePercentage && '%'}
 				</span>
 			)}
 		</BlockResizer>

--- a/src/extensions/styles/defaults/numberCounter.js
+++ b/src/extensions/styles/defaults/numberCounter.js
@@ -23,6 +23,10 @@ const numberCounter = {
 		type: 'boolean',
 		default: false,
 	},
+	'number-counter-percentage-sign-position-status': {
+		type: 'boolean',
+		default: false,
+	},
 	'number-counter-rounded-status': {
 		type: 'boolean',
 		default: false,

--- a/src/extensions/styles/helpers/test/getNumberCounterStyles.js
+++ b/src/extensions/styles/helpers/test/getNumberCounterStyles.js
@@ -32,6 +32,7 @@ describe('getNumberCounterStyles', () => {
 			'number-counter-status': true,
 			'number-counter-preview': true,
 			'number-counter-percentage-sign-status': false,
+			'number-counter-percentage-sign-position-status': false,
 			'number-counter-rounded-status': false,
 			'number-counter-circle-status': false,
 			'number-counter-start': 0,


### PR DESCRIPTION
Removed `<sup>` from the percentage sign so it has the same size and alignment as the number. 

Fixes #4818

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
