### PR TITLE
Issue 4862 - Disallowed new bg layer on hover

### DIFF
--- a/src/components/background-control/backgroundLayersControl.js
+++ b/src/components/background-control/backgroundLayersControl.js
@@ -595,7 +595,7 @@ const BackgroundLayersControl = ({
 						})}
 					</ListControl>
 				)}
-				{!disableAddLayer && (
+				{!disableAddLayer && !isHover && (
 					<SelectControl
 						className='maxi-background-control__add-layer'
 						value='Add new layer'


### PR DESCRIPTION
Fixes #4862


**_ Front/Back Testing _**

-   [ ] Check that you can't new bg layer on the hover tab.

**_ Pre-Code Testing _**

-   [ ] Check that you can't new bg layer on the hover tab.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
