### PR TITLE
Issue 4881 - BG scale shape removed double settings

### DIFF
--- a/src/components/image-shape/index.js
+++ b/src/components/image-shape/index.js
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	AdvancedNumberControl,
-	ResponsiveTabsControl,
 	SelectControl,
 	ToggleSwitch,
 } from '../../components';
@@ -146,115 +145,78 @@ const ImageShape = props => {
 					icon={icon}
 				/>
 			)}
-			{icon && (
+			{icon && breakpoint === 'general' && (
 				<>
-					{breakpoint === 'general' && (
-						<>
-							{!disableImageRatio && (
-								<SelectControl
-									label={__('Image ratio', 'maxi-blocks')}
-									value={shapeRatio || ''}
-									options={[
-										{
-											label: __('Fit', 'maxi-blocks'),
-											value: 'meet',
-										},
-										{
-											label: __('Fill', 'maxi-blocks'),
-											value: 'slice',
-										},
-									]}
-									onChange={val =>
-										onChange({
-											SVGElement: setSVGRatio(icon, val),
-										})
-									}
-								/>
-							)}
-							{!disableImagePosition && (
-								<SelectControl
-									label={__('Image position', 'maxi-blocks')}
-									value={shapePosition || 'xMidYMid'}
-									options={[
-										{
-											label: __(
-												'Center center',
-												'maxi-blocks'
-											),
-											value: 'xMidYMid',
-										},
-										{
-											label: __(
-												'Left center',
-												'maxi-blocks'
-											),
-											value: 'xMinYMid',
-										},
-										{
-											label: __(
-												'Right center',
-												'maxi-blocks'
-											),
-											value: 'xMaxYMid',
-										},
-										{
-											label: __(
-												'Center top',
-												'maxi-blocks'
-											),
-											value: 'xMidYMax',
-										},
-										{
-											label: __(
-												'Center bottom',
-												'maxi-blocks'
-											),
-											value: 'xMidYMin',
-										},
-										{
-											label: __(
-												'Left bottom',
-												'maxi-blocks'
-											),
-											value: 'xMinYMin',
-										},
-										{
-											label: __(
-												'Right bottom',
-												'maxi-blocks'
-											),
-											value: 'xMaxYMin',
-										},
-										{
-											label: __(
-												'Left top',
-												'maxi-blocks'
-											),
-											value: 'xMinYMax',
-										},
-										{
-											label: __(
-												'Right top',
-												'maxi-blocks'
-											),
-											value: 'xMaxYMax',
-										},
-									]}
-									onChange={val =>
-										onChange({
-											SVGElement: setSVGPosition(
-												icon,
-												val
-											),
-										})
-									}
-								/>
-							)}
-						</>
+					{!disableImageRatio && (
+						<SelectControl
+							label={__('Image ratio', 'maxi-blocks')}
+							value={shapeRatio || ''}
+							options={[
+								{
+									label: __('Fit', 'maxi-blocks'),
+									value: 'meet',
+								},
+								{
+									label: __('Fill', 'maxi-blocks'),
+									value: 'slice',
+								},
+							]}
+							onChange={val =>
+								onChange({
+									SVGElement: setSVGRatio(icon, val),
+								})
+							}
+						/>
 					)}
-					<ResponsiveTabsControl breakpoint={breakpoint}>
-						<ImageShapeResponsiveSettings {...props} />
-					</ResponsiveTabsControl>
+					{!disableImagePosition && (
+						<SelectControl
+							label={__('Image position', 'maxi-blocks')}
+							value={shapePosition || 'xMidYMid'}
+							options={[
+								{
+									label: __('Center center', 'maxi-blocks'),
+									value: 'xMidYMid',
+								},
+								{
+									label: __('Left center', 'maxi-blocks'),
+									value: 'xMinYMid',
+								},
+								{
+									label: __('Right center', 'maxi-blocks'),
+									value: 'xMaxYMid',
+								},
+								{
+									label: __('Center top', 'maxi-blocks'),
+									value: 'xMidYMax',
+								},
+								{
+									label: __('Center bottom', 'maxi-blocks'),
+									value: 'xMidYMin',
+								},
+								{
+									label: __('Left bottom', 'maxi-blocks'),
+									value: 'xMinYMin',
+								},
+								{
+									label: __('Right bottom', 'maxi-blocks'),
+									value: 'xMaxYMin',
+								},
+								{
+									label: __('Left top', 'maxi-blocks'),
+									value: 'xMinYMax',
+								},
+								{
+									label: __('Right top', 'maxi-blocks'),
+									value: 'xMaxYMax',
+								},
+							]}
+							onChange={val =>
+								onChange({
+									SVGElement: setSVGPosition(icon, val),
+								})
+							}
+						/>
+					)}
 				</>
 			)}
 		</>


### PR DESCRIPTION
We had double shape settings. Looks like we had settings in one file and then the same* settings were added at some point in a different file.

*Not really the same as the new settings work with responsive.

Fixes #4881 

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test shape settings (scale, position and others).
- 

**_ Pre-Code Testing _**

-   [ ] Test shape settings (scale, position and others).
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
