### PR TITLE
Issue 4883 - Fix full-size dropping

### DIFF
--- a/src/extensions/styles/migrators/fullWidthAttributeMigrator.js
+++ b/src/extensions/styles/migrators/fullWidthAttributeMigrator.js
@@ -17,6 +17,7 @@ const versions = [
 	'1.0.0',
 	'1.0.1',
 	'1.1.0',
+	'1.1.1',
 ];
 
 const prefixes = ['button-', 'image-', 'video-'];


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4883 

After some researching, found out that version `1.1.1` is missed in `fullWidthAttributeMigrator.isEligible`
So when we had the block on version `1.1.1` and before #4625 - we had this problem.

# How Has This Been Tested?
Created this simple [code editor](https://github.com/maxi-blocks/maxi-blocks/files/11745223/full-size-migrator-edge-case.txt) which has container with full-width row from version `1.1.1`. So checked if on this branch row remains full-width after migration.

master:
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/5cfca0dd-74b6-44a8-acac-c078af123981)

this branch:
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/67f09550-54da-4b31-83f0-7477e7a97f7a)




<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the code editor to see if migrator works correct with `1.1.1` version blocks

**_ Pre-Code Testing _**

-   [ ] Test the code editor to see if migrator works correct with `1.1.1` version blocks
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors
