### PR TITLE
Issue 4810 - Hidden the $text-to-replace content when Maxi is disabled

### DIFF
--- a/src/blocks/text-maxi/save.js
+++ b/src/blocks/text-maxi/save.js
@@ -32,6 +32,7 @@ const save = props => {
 			{...getMaxiBlockAttributes({ ...props, name })}
 		>
 			<RichText.Content
+				style={dcStatus && { display: 'none' }}
 				className={className}
 				value={dcStatus ? '$text-to-replace' : value}
 				// TODO: avoid DC for lists


### PR DESCRIPTION
Fixes 4810 


<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Try adding a dynamic content and then deactivate Maxi. On the Master branch a string '$text-to-replace' is displayed.  Now it should be hidden,

**_ Pre-Code Testing _**

-   [ ] Try adding a dynamic content and then deactivate Maxi. On the Master branch a string '$text-to-replace' is displayed. 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
