### PR TITLE
Issue 4936 - marker size migrator

### DIFF
--- a/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
+++ b/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
@@ -38,10 +38,9 @@ const migrate = newAttributes => {
 
 	return {
 		...newAttributes,
-		listStyleCustom: listStyleCustom.replace(
-			/(height|width)=('|").*?('|")/g,
-			''
-		),
+		listStyleCustom: listStyleCustom
+			.replace(/(height|width)=('|").*?('|")/g, '')
+			.replace(/\s+/g, ' '),
 	};
 };
 

--- a/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
+++ b/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
@@ -1,0 +1,48 @@
+const name = 'SVG marker size';
+
+const versions = [
+	'0.0.1-SC1',
+	'0.0.1-SC2',
+	'0.0.1-SC3',
+	'0.0.1-SC4',
+	'0.0.1-SC5',
+	'0.0.1-SC6',
+	'1.0.0-RC1',
+	'1.0.0-RC2',
+	'1.0.0-beta',
+	'1.0.0-beta-2',
+	'wp-directory-beta-1',
+	'1.0.0',
+	'1.0.1',
+	'1.1.0',
+	'1.1.1',
+	'1.2.0',
+];
+
+const isEligible = blockAttributes => {
+	const {
+		'maxi-version-origin': maxiVersionOrigin,
+		'maxi-version-current': maxiVersionCurrent,
+		listStyleCustom,
+	} = blockAttributes;
+
+	return (
+		(versions.includes(maxiVersionCurrent) || !maxiVersionOrigin) &&
+		listStyleCustom &&
+		listStyleCustom.includes('</svg>')
+	);
+};
+
+const migrate = newAttributes => {
+	const { listStyleCustom } = newAttributes;
+
+	return {
+		...newAttributes,
+		listStyleCustom: listStyleCustom.replace(
+			/(height|width)=('|").*?('|")/g,
+			''
+		),
+	};
+};
+
+export default { name, isEligible, migrate };

--- a/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
+++ b/src/extensions/styles/migrators/SVGMarkerSizeMigrator.js
@@ -17,6 +17,7 @@ const versions = [
 	'1.1.0',
 	'1.1.1',
 	'1.2.0',
+	'1.2.1',
 ];
 
 const isEligible = blockAttributes => {

--- a/src/extensions/styles/migrators/blockMigrator.js
+++ b/src/extensions/styles/migrators/blockMigrator.js
@@ -25,6 +25,7 @@ import bottomGapMigrator from './bottomGapMigrator';
 import transitionMigrator from './transitionMigrator';
 import fullWidthAttributeMigrator from './fullWidthAttributeMigrator';
 import IBLabelToIDMigrator from './IBLabelToIDMigrator';
+import SVGMarkerSizeMigrator from './SVGMarkerSizeMigrator';
 
 /**
  * External dependencies
@@ -124,6 +125,7 @@ const blockMigrator = blockMigratorProps => {
 		transitionMigrator,
 		fullWidthAttributeMigrator,
 		IBLabelToIDMigrator,
+		SVGMarkerSizeMigrator,
 		...(blockMigratorProps.migrators ?? []),
 	];
 


### PR DESCRIPTION
# Description
Added migrator that removes height and width that were saved in SVG content string.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4936 

# How Has This Been Tested?
Checked that marker size on PTL-02 can be changed.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that marker size on PTL-02 or any other pattern with markers can be changed.

**_ Pre-Code Testing _**

-   [x] Check that marker size on PTL-02 or any other pattern with markers can be changed.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
