### PR TITLE
Issue 4807 - consistent DC random content on editor

### DIFF
--- a/src/extensions/DC/getDCContent.js
+++ b/src/extensions/DC/getDCContent.js
@@ -28,8 +28,8 @@ const nameDictionary = {
 	tags: 'post_tag',
 };
 
-const getDCContent = async dataRequest => {
-	const data = await getDCEntity(dataRequest);
+const getDCContent = async (dataRequest, clientId) => {
+	const data = await getDCEntity(dataRequest, clientId);
 
 	if (!data) return null;
 

--- a/src/extensions/DC/getDCLink.js
+++ b/src/extensions/DC/getDCLink.js
@@ -3,8 +3,8 @@
  */
 import getDCEntity from './getDCEntity';
 
-const getDCContent = async dataRequest => {
-	const data = await getDCEntity(dataRequest);
+const getDCContent = async (dataRequest, clientId) => {
+	const data = await getDCEntity(dataRequest, clientId);
 
 	const contentValue = data?.link;
 

--- a/src/extensions/DC/getDCMedia.js
+++ b/src/extensions/DC/getDCMedia.js
@@ -10,8 +10,8 @@ import { isNil } from 'lodash';
 import getDCEntity from './getDCEntity';
 import { getACFFieldContent } from './getACFData';
 
-const getDCMedia = async dataRequest => {
-	const data = await getDCEntity(dataRequest);
+const getDCMedia = async (dataRequest, clientId) => {
+	const data = await getDCEntity(dataRequest, clientId);
 
 	const { field, source } = dataRequest;
 

--- a/src/extensions/DC/withMaxiDC.js
+++ b/src/extensions/DC/withMaxiDC.js
@@ -30,7 +30,7 @@ import { isNil } from 'lodash';
 const withMaxiDC = createHigherOrderComponent(
 	WrappedComponent =>
 		pure(ownProps => {
-			const { attributes, name, setAttributes } = ownProps;
+			const { attributes, name, setAttributes, clientId } = ownProps;
 
 			const contextLoop = useContext(LoopContext)?.contextLoop;
 
@@ -130,7 +130,10 @@ const withMaxiDC = createHigherOrderComponent(
 					const newLinkSettings =
 						ownProps.attributes.linkSettings ?? {};
 					let updateLinkSettings = false;
-					const dcLink = await getDCLink(lastDynamicContentProps);
+					const dcLink = await getDCLink(
+						lastDynamicContentProps,
+						clientId
+					);
 					const isSameLink = dcLink === newLinkSettings.url;
 
 					if (
@@ -152,7 +155,8 @@ const withMaxiDC = createHigherOrderComponent(
 
 					if (!isImageMaxi) {
 						let newContent = await getDCContent(
-							lastDynamicContentProps
+							lastDynamicContentProps,
+							clientId
 						);
 						const newContainsHTML =
 							postTaxonomyLinksStatus &&
@@ -184,7 +188,8 @@ const withMaxiDC = createHigherOrderComponent(
 						}
 					} else {
 						const mediaContent = await getDCMedia(
-							lastDynamicContentProps
+							lastDynamicContentProps,
+							clientId
 						);
 
 						if (isNil(mediaContent)) {


### PR DESCRIPTION
# Description
Changed `getDCEntity` to return the same random entity for each block until page reload, or entity type changed.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4807

# How Has This Been Tested?
Checked that blocks with random DC content don't change entity when editing.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check that blocks with random DC content don't change entity when editing.
-   [x] Check that after page reload, entity can change.

**_Pre-Code Testing_**

-   [x] Check that blocks with random DC content don't change entity when editing.
-   [x] Check that after page reload, entity can change.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
