### PR TITLE
SC - Hide settings instead until customising

### DIFF
--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -137,8 +137,7 @@ body {
 	border: 1px solid rgb(var(--maxi-light-color-4)) !important;
 }
 .maxi-style-card-settings-disabled {
-	opacity: 0.6;
-	pointer-events: none;
+	display: none;
 }
 .maxi-style-cards__active-edit-title {
 	padding-bottom: 10px;


### PR DESCRIPTION
We had settings set to opacity 0.6 before, now settings are hidden until you click the button to customise.


# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test the component in normal state in sidebar
-   [x] Test the component in hover state in sidebar (if hover exists)
-   [x] Check that the settings work on frontend
-   [x] Check that backend works and saves the settings after the editor reload
-   [x] Same 1-4 points for the toolbar
-   [x] Same 1-4 points on responsive
-   [x] Test the block inside the grid (Container + Row + Column)
-   [x] Test the block as a standalone block
-   [x] Duplicate the block, test that the settings of the first do not affect the second
-   [x] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [X] Test the component in normal state in sidebar
-   [X] Test the component in hover state in sidebar (if hover exists)
-   [X] Check that the settings work on frontend
-   [X] Check that backend works and saves the settings after the editor reload
-   [X] Same 1-4 points for the toolbar
-   [X] Same 1-4 points on responsive
-   [X] Test the block inside the grid (Container + Row + Column)
-   [X] Test the block as a standalone block
-   [X] Duplicate the block, test that the settings of the first do not affect the second
-   [X] Test with 2 blocks of the same type
-   [X] Check no commented code and no unnecessary imports
-   [X] Standards of the project have been followed
-   [X]  No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes
