### PR TITLE
Issue 4969 - styles on page reload

### DIFF
--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -87,7 +87,7 @@ wp.domReady(() => {
 
 	const resizeObserverSelector = '.interface-interface-skeleton__content';
 
-	const resizeObserver = new ResizeObserver(() => {
+	const setBaseBreakpoint = () => {
 		const resizeObserverTarget = document.querySelector(
 			resizeObserverSelector
 		);
@@ -97,6 +97,10 @@ wp.domReady(() => {
 				.getBoundingClientRect();
 			dispatch('maxiBlocks').setEditorContentSize({ width, height });
 		}
+	};
+
+	const resizeObserver = new ResizeObserver(() => {
+		setBaseBreakpoint();
 
 		// On changing the canvas editor size, we must update the winBreakpoint
 		// to add the necessary attributes to display styles. The observer can't
@@ -178,6 +182,7 @@ wp.domReady(() => {
 
 				isNewEditorContentObserver = false;
 				resizeObserver.observe(resizeObserverTarget);
+				setBaseBreakpoint();
 			} else if (
 				(isTemplatesListOpened || type !== currentType) &&
 				!isNewEditorContentObserver

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -386,7 +386,8 @@ class MaxiBlockComponent extends Component {
 		if (!shouldDisplayStyles)
 			this.displayStyles(
 				this.props.deviceType !== prevProps.deviceType ||
-					this.props.baseBreakpoint !== prevProps.baseBreakpoint
+					(this.props.baseBreakpoint !== prevProps.baseBreakpoint &&
+						!!prevProps.baseBreakpoint)
 			);
 
 		if (this.maxiBlockDidUpdate)

--- a/src/extensions/styles/styleGenerator.js
+++ b/src/extensions/styles/styleGenerator.js
@@ -84,7 +84,7 @@ const styleStringGenerator = (
 			}[maxi-blocks-responsive="${ALLOWED_BREAKPOINTS[breakpointPos]}"]${
 				isSiteEditor ? ' .is-root-container' : ''
 			} .maxi-block.maxi-block--backend.${target}${
-				breakpointPos ? ',' : '{'
+				breakpointPos > 0 ? ',' : '{'
 			}`;
 			breakpointPos -= 1;
 		} while (breakpointPos >= 0);


### PR DESCRIPTION
# Description
Fixed styles generating incorrectly on first render after reload on slow computers.

To reproduce, had to slow down CPU, you can do it in performance tab in devtools:
![image](https://github.com/maxi-blocks/maxi-blocks/assets/53875005/03f0ed9c-38d6-4448-959b-b786d8cd12b1)

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4969 

# How Has This Been Tested?
Added container with content to template header, checked that styles on master after page reload are wrong, and checked that they are fixed on this branch.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Slow down your CPU, check that styles in template parts on master after page reload are wrong, and check that they are fixed on this branch.

**_Pre-Code Testing_**

-   [ ] check that styles in templates on master after page reload are wrong, and check that they are fixed on this branch.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
