### PR TITLE
Issue 4899 - fix toolbar indent/outdent not working properly

### DIFF
--- a/src/components/toolbar/components/text-list-options/index.js
+++ b/src/components/toolbar/components/text-list-options/index.js
@@ -64,10 +64,7 @@ const TextListOptions = props => {
 				type: typeOfList,
 			});
 
-		if (type === 'outdent')
-			newFormat = outdentListItems(formatValue, {
-				type: typeOfList,
-			});
+		if (type === 'outdent') newFormat = outdentListItems(formatValue);
 
 		const newContent = toHTMLString({
 			value: newFormat,

--- a/src/extensions/text/lists/toTree.js
+++ b/src/extensions/text/lists/toTree.js
@@ -43,6 +43,7 @@ function restoreOnAttributes(attributes, isEditableTree) {
  *
  * @param {Object}  $1                        Named parameters.
  * @param {string}  $1.type                   The format type.
+ * @param {string}  $1.tagName                The tag name.
  * @param {Object}  $1.attributes             The format attributes.
  * @param {Object}  $1.unregisteredAttributes The unregistered format
  *                                            attributes.
@@ -56,6 +57,7 @@ function restoreOnAttributes(attributes, isEditableTree) {
  */
 function fromFormat({
 	type,
+	tagName,
 	attributes,
 	unregisteredAttributes,
 	object,
@@ -104,7 +106,7 @@ function fromFormat({
 	}
 
 	return {
-		type: formatType.tagName,
+		type: formatType.tagName === '*' ? tagName : formatType.tagName,
 		object: formatType.object,
 		attributes: restoreOnAttributes(elementAttributes, isEditableTree),
 	};
@@ -251,7 +253,8 @@ export function toTree({
 					return;
 				}
 
-				const { type, attributes, unregisteredAttributes } = format;
+				const { type, tagName, attributes, unregisteredAttributes } =
+					format;
 
 				const boundaryClass =
 					isEditableTree &&
@@ -263,6 +266,7 @@ export function toTree({
 					parent,
 					fromFormat({
 						type,
+						tagName,
 						attributes,
 						unregisteredAttributes,
 						boundaryClass,


### PR DESCRIPTION
# Description
Checked the large styles, they are added on purpose, and what they do is add width for markers of different levels in ordered lists, so since `ol`s have markers like `1 > 1.1 > 1.1.1 > ...` they need different width, it is hard to check how many levels lists have, so they are just statically generated.

Fixed the indent problem that Sasha has shared on the issue.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4899 

# How Has This Been Tested?
Checked that the issue with indenting lists in toolbar is fixed.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that the issue with indenting lists in toolbar is fixed.

**_Pre-Code Testing_**

-   [x] Check that the issue with indenting lists in toolbar is fixed.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
