### PR TITLE
remove is_admin for registration hook

### DIFF
--- a/core/class-maxi-db.php
+++ b/core/class-maxi-db.php
@@ -38,12 +38,10 @@ if (!class_exists('MaxiBlocks_DB')):
          */
         public function __construct()
         {
-            if (is_admin()) {
-                register_activation_hook(MAXI_PLUGIN_DIR_FILE, [
-                    $this,
-                    'add_maxi_tables',
-                ]);
-            }
+            register_activation_hook(MAXI_PLUGIN_DIR_FILE, [
+                $this,
+                'add_maxi_tables',
+            ]);
         }
 
         public function add_maxi_tables()


### PR DESCRIPTION
# Description

Should fix Maxi tables creation on Maxi activation.

Fixes #5048 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Destroy your wp-env
-   [x] Pull this branch, npm start
-   [x] Start your env
-   [x] Check that there are no DB tables bugs now
-   [x] Check the plugin in general

**_ Pre-Code Testing _**

-   [x] Destroy your wp-env
-   [x] Pull this branch, npm start
-   [x] Start your env
-   [x] Check that there are no DB tables bugs now
-   [x] Check the plugin in general
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Removed unnecessary admin check in `core/class-maxi-db.php`. The `register_activation_hook` function is now called unconditionally, simplifying the code.

> Hop, hop, hooray! 🎉
> No more checks in our way. 🚀
> Code's clean and lean, 🧹
> Like a coding machine! 💻🐇
<!-- end of auto-generated comment: release notes by coderabbit.ai -->