### PR TITLE
Support ticket - Make `maxi_add_sc_native_blocks` more robust

### DIFF
--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -166,12 +166,12 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 $elements = $xpath->query('//*');
 
                 // Check if elements are found
-				if(isset($elements) && !empty($elements)) {
+                if(isset($elements) && !empty($elements)) {
                     // Pick the first element
                     $element = $elements[0];
 
                     // Check if the element is not null
-					if ($element instanceof DOMElement) {
+                    if ($element instanceof DOMElement) {
                         $classes = $element->getAttribute('class');
 
                         if(!str_contains($classes, 'maxi') || !isset($classes) || empty($classes)) {

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -176,7 +176,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
 
                         if (!isset($classes) || empty($classes)) {
                             $element->setAttribute('class', 'maxi-block--use-sc');
-                        } elseif (!str_contains($classes, 'maxi') && !str_contains($classes, 'maxi-block--use-sc')) {
+                        } elseif (!str_contains($classes, 'maxi-block--use-sc')) {
                             $element->setAttribute('class', $classes . ' maxi-block--use-sc');
                         }
                     }

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -174,14 +174,10 @@ if (!class_exists('MaxiBlocks_Blocks')):
                     if ($element instanceof DOMElement) {
                         $classes = $element->getAttribute('class');
 
-                        if(!str_contains($classes, 'maxi') || !isset($classes) || empty($classes)) {
-                            if(!str_contains($classes, 'maxi-block--use-sc')) {
-                                $element->setAttribute('class', $element->getAttribute('class') . ' maxi-block--use-sc');
-                            }
-
-                            if(!isset($classes) || empty($classes)) {
-                                $element->setAttribute('class', 'maxi-block--use-sc');
-                            }
+                        if (!isset($classes) || empty($classes)) {
+                            $element->setAttribute('class', 'maxi-block--use-sc');
+                        } elseif (!str_contains($classes, 'maxi') && !str_contains($classes, 'maxi-block--use-sc')) {
+                            $element->setAttribute('class', $classes . ' maxi-block--use-sc');
                         }
                     }
 

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -166,7 +166,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 $elements = $xpath->query('//*');
 
                 // Check if elements are found
-                if(isset($elements) && !empty($elements)) {
+                if(isset($elements) && $elements->length > 0) {
                     // Pick the first element
                     $element = $elements[0];
 

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -170,7 +170,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
                     // Pick the first element
                     $element = $elements[0];
 
-                    // Check if the element is not null
+                    // Check if the element is a DOMElement
                     if ($element instanceof DOMElement) {
                         $classes = $element->getAttribute('class');
 

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -165,24 +165,28 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 // Look for all elements
                 $elements = $xpath->query('//*');
 
-                // Pick the first element
-                $element = $elements[0];
+                // Check if elements are found
+				if(isset($elements) && !empty($elements)) {
+                    // Pick the first element
+                    $element = $elements[0];
 
-                $classes = $element->getAttribute('class');
+                    // Check if the element is not null
+					if ($element instanceof DOMElement) {
+                        $classes = $element->getAttribute('class');
 
-                if(!str_contains($classes, 'maxi') || !isset($classes) || empty($classes)) {
-                    if(!str_contains($classes, 'maxi-block--use-sc')) {
-                        $element->setAttribute('class', $element->getAttribute('class') . ' maxi-block--use-sc');
+                        if(!str_contains($classes, 'maxi') || !isset($classes) || empty($classes)) {
+                            if(!str_contains($classes, 'maxi-block--use-sc')) {
+                                $element->setAttribute('class', $element->getAttribute('class') . ' maxi-block--use-sc');
+                            }
+
+                            if(!isset($classes) || empty($classes)) {
+                                $element->setAttribute('class', 'maxi-block--use-sc');
+                            }
+                        }
                     }
 
-                    if(!isset($classes) || empty($classes)) {
-                        $element->setAttribute('class', 'maxi-block--use-sc');
-                    }
+                    $block_content = $dom->saveHTML();
                 }
-
-                $block_content = $dom->saveHTML();
-
-                return $block_content;
             }
 
             return $block_content;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

I saw https://wordpress.org/support/topic/maxi-blok-hata/. Error message shows that the problem appears from `maxi_add_sc_native_blocks`. I don't have a lot of details how to reproduce it unfortunately, but basically added more checks to at least avoid warnings, errors for users, increase robustness of that part of the code.

# How Has This Been Tested?
Checked if experimental settings work as expected on frontend

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test experimental settings frontend

**_ Pre-Code Testing _**

-   [ ] Test experimental settings frontend
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Bug Fix":
- Enhanced error handling in `maxi_add_sc_native_blocks` function to prevent potential crashes. The function now checks if elements are found before proceeding, ensuring that operations are performed on valid instances of `DOMElement`.
- Improved the logic for adding the `maxi-block--use-sc` class to an element, providing more reliable and consistent behavior.
  
These changes enhance the stability and reliability of the application, leading to a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->