### PR TITLE
Issue 5030 - Repeater. Move bug.

### DIFF
--- a/src/extensions/repeater/handleBlockMove.js
+++ b/src/extensions/repeater/handleBlockMove.js
@@ -52,7 +52,10 @@ const handleBlockMove = (
 
 	const modifiedNextPosition = [...nextPosition];
 
-	if (prevPosition.length < nextPosition.length) {
+	if (
+		prevPosition.length < nextPosition.length &&
+		prevBlockIndex <= nextPosition[prevPosition.length - 1]
+	) {
 		modifiedNextPosition[prevPosition.length - 1] += 1;
 	}
 

--- a/src/extensions/repeater/handleBlockMove.js
+++ b/src/extensions/repeater/handleBlockMove.js
@@ -24,7 +24,12 @@ const handleBlockMove = (
 	nextPosition,
 	innerBlockPositions
 ) => {
-	if (isEqual(prevPosition, nextPosition)) return;
+	if (
+		isEqual(prevPosition, nextPosition) ||
+		(prevPosition.length === nextPosition.length &&
+			prevPosition.at(-1) === nextPosition.at(-1) + 1)
+	)
+		return;
 
 	const { getBlock } = select('core/block-editor');
 

--- a/src/extensions/repeater/handleBlockMove.js
+++ b/src/extensions/repeater/handleBlockMove.js
@@ -18,6 +18,12 @@ import {
  */
 import { isEqual } from 'lodash';
 
+const isBlockMovedDeeper = (prevPosition, nextPosition) =>
+	prevPosition.length < nextPosition.length &&
+	prevPosition
+		.slice(0, -1)
+		.every((value, index) => value === nextPosition[index]);
+
 const handleBlockMove = (
 	clientId,
 	prevPosition,
@@ -26,7 +32,7 @@ const handleBlockMove = (
 ) => {
 	if (
 		isEqual(prevPosition, nextPosition) ||
-		(prevPosition.length === nextPosition.length &&
+		(isBlockMovedDeeper(prevPosition, nextPosition) &&
 			prevPosition.at(-1) === nextPosition.at(-1) + 1)
 	)
 		return;
@@ -59,12 +65,7 @@ const handleBlockMove = (
 	 * the inner block index by 1 to get the correct next parent
 	 */
 	if (
-		prevPosition.length < nextPosition.length &&
-		prevPosition.every(
-			(value, index) =>
-				index === prevPosition.length - 1 ||
-				value === nextPosition[index]
-		) &&
+		isBlockMovedDeeper(prevPosition, nextPosition) &&
 		prevBlockIndex <= nextPosition[prevPosition.length - 1]
 	) {
 		modifiedNextPosition[prevPosition.length - 1] += 1;

--- a/src/extensions/repeater/handleBlockMove.js
+++ b/src/extensions/repeater/handleBlockMove.js
@@ -18,8 +18,8 @@ import {
  */
 import { isEqual } from 'lodash';
 
-const isBlockMovedDeeper = (prevPosition, nextPosition) =>
-	prevPosition.length < nextPosition.length &&
+const isPositionExtendedToPenultimate = (prevPosition, nextPosition) =>
+	prevPosition.length <= nextPosition.length &&
 	prevPosition
 		.slice(0, -1)
 		.every((value, index) => value === nextPosition[index]);
@@ -32,7 +32,7 @@ const handleBlockMove = (
 ) => {
 	if (
 		isEqual(prevPosition, nextPosition) ||
-		(isBlockMovedDeeper(prevPosition, nextPosition) &&
+		(isPositionExtendedToPenultimate(prevPosition, nextPosition) &&
 			prevPosition.at(-1) === nextPosition.at(-1) + 1)
 	)
 		return;
@@ -65,7 +65,8 @@ const handleBlockMove = (
 	 * the inner block index by 1 to get the correct next parent
 	 */
 	if (
-		isBlockMovedDeeper(prevPosition, nextPosition) &&
+		prevPosition.length < nextPosition.length &&
+		isPositionExtendedToPenultimate(prevPosition, nextPosition) &&
 		prevBlockIndex <= nextPosition[prevPosition.length - 1]
 	) {
 		modifiedNextPosition[prevPosition.length - 1] += 1;

--- a/src/extensions/repeater/handleBlockMove.js
+++ b/src/extensions/repeater/handleBlockMove.js
@@ -52,8 +52,19 @@ const handleBlockMove = (
 
 	const modifiedNextPosition = [...nextPosition];
 
+	/**
+	 * If the block has been moved to an inner block,
+	 * which is inside the same parent, and the moved block
+	 * is higher than the inner block, we need to increase
+	 * the inner block index by 1 to get the correct next parent
+	 */
 	if (
 		prevPosition.length < nextPosition.length &&
+		prevPosition.every(
+			(value, index) =>
+				index === prevPosition.length - 1 ||
+				value === nextPosition[index]
+		) &&
 		prevBlockIndex <= nextPosition[prevPosition.length - 1]
 	) {
 		modifiedNextPosition[prevPosition.length - 1] += 1;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5030 

# How Has This Been Tested?
Found 3 cases (one from video and 2 by myself), in each there's block moves, after which repeater structure was broken.
Tested if on this branch moving blocks in repeater by different ways works as expected and didn't break structure

### Cases:

#### 1. Bug from issue's video 

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/e15b44b4-48fa-425c-8de1-8a3c4dbca845

[5030_code_editor_from_video.txt](https://github.com/maxi-blocks/maxi-blocks/files/12437222/5030_code_editor_from_video.txt)

#### 2. Moving block inside group when there's some other block between them (button)

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/2d2a6891-ea78-4039-8eb3-973aeb35cf55

[5030_code_editor_2.txt](https://github.com/maxi-blocks/maxi-blocks/files/12437223/5030_code_editor_2.txt)

#### 3. Moving block inside group when block is lower in structure

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/c6c72f4e-0d9a-4440-8ddc-fcca3c076de9

[5030_code_editor_3.txt](https://github.com/maxi-blocks/maxi-blocks/files/12437289/5030_code_editor_3.txt)


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test first case
-   [ ] Test second case 
-   [ ] Test third case 
-   [ ] Test repeater movement in general
-   [ ] Try some repeater advanced movement ideas if you have any
-   [ ] Check if #5031 was fixed (you can use code editor from first case, important: code editor from #5031 is broken, so it's expected to be broken there)

**_ Pre-Code Testing _**

-   [x] Test first case
-   [x] Test second case 
-   [x] Test third case 
-   [x] Test repeater movement in general
-   [ ] Try some repeater advanced movement ideas if you have any
-   [ ] Check if #5031 was fixed (you can use code editor from first case, important: code editor from #5031 is broken, so it's expected to be broken there)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the `handleBlockMove` function to accurately handle block movements within the editor. The function now correctly identifies when a block is moved to an inner position within the same parent and adjusts the index accordingly.
- New Feature: Introduced two helper functions, `isBlockMovedDeeper` and `isPositionExtendedToPenultimate`, improving code readability and maintainability by isolating specific checks related to block movement.
- Refactor: Improved early return conditions in `handleBlockMove` function for better performance and reduced unnecessary computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->