### PR TITLE
Issue 5054 - fix callout arrow position

### DIFF
--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -149,6 +149,6 @@ body.maxi-blocks--active .maxi-map-block .leaflet-bar a {
 body.maxi-blocks--active
 	*
 	:has(> .maxi-background-displayer)
-	> *:not(.maxi-background-displayer):not(.maxi-block-indicators) {
+	> *:not(.maxi-background-displayer):not(.maxi-block-indicators):not(.maxi-container-arrow) {
 	position: relative;
 }


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5054 

# How Has This Been Tested?
Checked that callout arrow position is right.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check that callout arrow position is right.

**_ Pre-Code Testing _**

-   [x] Check that callout arrow position is right.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Style: Updated CSS Selector in maxi-themes-banner.scss"
- The CSS rule for elements that are direct children of an element with the class `body.maxi-blocks--active` has been updated. It now excludes elements with the class `maxi-container-arrow`. This change refines the styling application, ensuring that elements with the `maxi-container-arrow` class maintain their intended appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->