### PR TITLE
Issue 5028 - Repeater. Set height to fit content fix.

### DIFF
--- a/e2e-tests/components/toolbar/components/link/index.spec.js
+++ b/e2e-tests/components/toolbar/components/link/index.spec.js
@@ -22,6 +22,10 @@ describe('Button link', () => {
 			button => button.click()
 		);
 
+		await page.waitForSelector(
+			'.maxi-link-control .block-editor-url-input__input'
+		);
+
 		await page.keyboard.type('test.com', { delay: 100 });
 		await page.keyboard.press('Enter');
 

--- a/e2e-tests/components/toolbar/components/link/index.spec.js
+++ b/e2e-tests/components/toolbar/components/link/index.spec.js
@@ -22,9 +22,7 @@ describe('Button link', () => {
 			button => button.click()
 		);
 
-		await page.waitForSelector(
-			'.maxi-link-control .block-editor-url-input__input'
-		);
+		await page.waitForSelector('.block-editor-url-input__input:focus');
 
 		await page.keyboard.type('test.com', { delay: 100 });
 		await page.keyboard.press('Enter');

--- a/e2e-tests/components/toolbar/components/text-link/index.spec.js
+++ b/e2e-tests/components/toolbar/components/text-link/index.spec.js
@@ -21,6 +21,10 @@ describe('Text link', () => {
 
 		await page.waitForSelector('.block-editor-url-input__input:focus');
 
+		await page.waitForSelector(
+			'.maxi-link-control .block-editor-url-input__input'
+		);
+
 		await page.keyboard.type('test.com', { delay: 100 });
 		await page.keyboard.press('Enter');
 

--- a/e2e-tests/components/toolbar/components/text-link/index.spec.js
+++ b/e2e-tests/components/toolbar/components/text-link/index.spec.js
@@ -21,10 +21,6 @@ describe('Text link', () => {
 
 		await page.waitForSelector('.block-editor-url-input__input:focus');
 
-		await page.waitForSelector(
-			'.maxi-link-control .block-editor-url-input__input'
-		);
-
 		await page.keyboard.type('test.com', { delay: 100 });
 		await page.keyboard.press('Enter');
 

--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -25,6 +25,7 @@ import {
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
 import {
+	shouldSetPreserveAspectRatio,
 	getSVGWidthHeightRatio,
 	togglePreserveAspectRatio,
 } from '../../extensions/svg';
@@ -226,15 +227,11 @@ class edit extends MaxiBlockComponent {
 			onSelect: obj => {
 				const { content } = obj;
 
-				if (content) {
-					const disableHeightFitContent = getLastBreakpointAttribute({
-						target: 'svg-width-fit-content',
-						breakpoint: deviceType,
-						attributes,
-					});
-
-					if (disableHeightFitContent)
-						obj.content = togglePreserveAspectRatio(content, true);
+				if (
+					content &&
+					shouldSetPreserveAspectRatio(attributes, 'svg-')
+				) {
+					obj.content = togglePreserveAspectRatio(content, true);
 				}
 
 				maxiSetAttributes(obj);

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -27,7 +27,10 @@ import {
 	getGroupAttributes,
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
-import { togglePreserveAspectRatio } from '../../extensions/svg';
+import {
+	shouldSetPreserveAspectRatio,
+	togglePreserveAspectRatio,
+} from '../../extensions/svg';
 import MaxiModal from '../../editor/library/modal';
 
 /**
@@ -680,13 +683,6 @@ const IconControl = props => {
 		[`${prefix}icon-content`]: iconContent,
 	} = props;
 
-	const heightFitContent = getLastBreakpointAttribute({
-		target: `${prefix}icon-width-fit-content`,
-		breakpoint,
-		attributes: props,
-		isHover,
-	});
-
 	const classes = classnames('maxi-icon-control', className);
 
 	return (
@@ -706,8 +702,15 @@ const IconControl = props => {
 							].filter(Boolean),
 						});
 
-						if (!disableHeightFitContent && heightFitContent)
+						if (
+							!disableHeightFitContent &&
+							shouldSetPreserveAspectRatio(
+								props,
+								`${prefix}icon-`
+							)
+						) {
 							icon = togglePreserveAspectRatio(icon, true);
+						}
 
 						onChange({
 							...obj,

--- a/src/components/svg-width-control/index.js
+++ b/src/components/svg-width-control/index.js
@@ -8,7 +8,10 @@ import {
 	getDefaultAttribute,
 	getLastBreakpointAttribute,
 } from '../../extensions/styles';
-import { togglePreserveAspectRatio } from '../../extensions/svg';
+import {
+	shouldSetPreserveAspectRatio,
+	togglePreserveAspectRatio,
+} from '../../extensions/svg';
 
 /**
  * Internal dependencies
@@ -141,11 +144,17 @@ const SvgWidthControl = props => {
 								prefix,
 								breakpoint
 							)]: val,
-							[getAttributeKey(
-								'content',
-								isHover,
-								contentPrefix
-							)]: togglePreserveAspectRatio(icon, val),
+							...((val ||
+								!shouldSetPreserveAspectRatio(
+									props,
+									prefix
+								)) && {
+								[getAttributeKey(
+									'content',
+									isHover,
+									contentPrefix
+								)]: togglePreserveAspectRatio(icon, val),
+							}),
 						});
 					}}
 				/>

--- a/src/extensions/repeater/updateSVG.js
+++ b/src/extensions/repeater/updateSVG.js
@@ -3,10 +3,12 @@
  */
 import { getUpdatedSVGDataAndElement } from '../attributes';
 import {
+	shouldSetPreserveAspectRatio,
 	getSVGPosition,
 	getSVGRatio,
 	setSVGPosition,
 	setSVGRatio,
+	togglePreserveAspectRatio,
 } from '../svg';
 
 /**
@@ -17,6 +19,35 @@ import {
  * @returns
  */
 const updateSVG = (updatedAttributes, blockAttributes) => {
+	const getPrefix = () => {
+		const { uniqueID } = blockAttributes;
+
+		if (uniqueID) {
+			if (uniqueID.startsWith('svg-')) return 'svg-';
+
+			if (uniqueID.startsWith('button-')) return 'icon-';
+		}
+
+		return null;
+	};
+
+	const prefix = getPrefix();
+
+	if (prefix) {
+		const contentKey = `${prefix === 'svg-' ? '' : prefix}content`;
+
+		if (
+			contentKey in blockAttributes &&
+			!(contentKey in updatedAttributes) &&
+			shouldSetPreserveAspectRatio(updatedAttributes, prefix)
+		) {
+			updatedAttributes[contentKey] = togglePreserveAspectRatio(
+				blockAttributes[contentKey],
+				true
+			);
+		}
+	}
+
 	if (!('SVGElement' in updatedAttributes)) return;
 
 	if ('SVGData' in updatedAttributes) {

--- a/src/extensions/svg/index.js
+++ b/src/extensions/svg/index.js
@@ -1,3 +1,4 @@
+export { default as shouldSetPreserveAspectRatio } from './shouldSetPreserveAspectRatio';
 export { default as getSVGHasImage } from './getSVGHasImage';
 export { default as getSVGPosition } from './getSVGPosition';
 export { default as getSVGRatio } from './getSVGRatio';

--- a/src/extensions/svg/shouldSetPreserveAspectRatio.js
+++ b/src/extensions/svg/shouldSetPreserveAspectRatio.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getAttributeKey } from '../styles';
+
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+/**
+ *
+ * @param {Object} attributes
+ * @param {string} prefix
+ * @returns {boolean} true if preserveAspectRatio is needed
+ */
+const shouldSetPreserveAspectRatio = (attributes, prefix = '') =>
+	breakpoints.some(breakpoint => {
+		const key = getAttributeKey(
+			'width-fit-content',
+			false,
+			prefix,
+			breakpoint
+		);
+
+		return key in attributes && attributes[key];
+	});
+
+export default shouldSetPreserveAspectRatio;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5028 

# How Has This Been Tested?
Checked if on repeater toggle, all icons have set height to fit content if icon from first column had, checked if on changing toggle it applies correctly to icons from all columns. 
Also checked non-repeater case:
1. Enabled toggle on general
2. Turned on lower breakpoint(L)
3. Switched back to general
4. Saw that result wrong

Video: 

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/57ddd067-c067-48f0-a9b7-4040f7ed0ff4

So fixed that bug as well 👍 

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test set height to fit content with svg-icon-maxi in repeater
-   [ ] Test set height to fit content with button-maxi icon in repeater
-   [ ] Check set height to fit content bug(which is not in repeater) disappeared(shared it in "How Has This Been Tested" section)
-   [ ] Same 1–3 points on responsive
-   [ ] Test set height to fit content on repeater toggle
-   [ ] Test set height to fit content on icon change in repeater and without

**_ Pre-Code Testing _**

-   [ ] Test set height to fit content with svg-icon-maxi in repeater
-   [ ] Test set height to fit content with button-maxi icon in repeater
-   [ ] Check set height to fit content bug(which is not in repeater) disappeared(shared it in "How Has This Been Tested" section)
-   [ ] Same 1–3 points on responsive
-   [ ] Test set height to fit content on repeater toggle
-   [ ] Test set height to fit content on icon change in repeater and without
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Added support for toggling the preserve aspect ratio of SVG icons and controls. Users can now set the preserveAspectRatio attribute based on specified breakpoints.
- Bug Fix: Fixed an issue where the heightFitContent variable was not being used correctly in the icon control component. The logic has been updated to use the shouldSetPreserveAspectRatio function instead.
- Refactor: Updated the updateSVG function in the repeater extension to handle prefix-based attribute updates and toggle preserve aspect ratio if necessary.
- Test: Enhanced test cases for button and text links in the toolbar component by adding steps to interact with UI elements, such as waiting for specific elements, entering text, and pressing keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->