### PR TITLE
Issue 5041 - Repeater. Changing row scheme on nested in repeater row fix

### DIFF
--- a/src/blocks/column-maxi/edit.js
+++ b/src/blocks/column-maxi/edit.js
@@ -160,6 +160,10 @@ class edit extends MaxiBlockComponent {
 			this.context.setColumnSize(this.props.clientId, columnSize);
 	}
 
+	maxiBlockWillUnmount() {
+		this.context.removeColumnClientId(this.props.clientId);
+	}
+
 	get getStylesObject() {
 		return getStyles(
 			{

--- a/src/blocks/row-maxi/components/column-pattern/index.js
+++ b/src/blocks/row-maxi/components/column-pattern/index.js
@@ -60,11 +60,14 @@ const ColumnPattern = props => {
 	const instanceId = useInstanceId(ColumnPattern);
 
 	useEffect(() => {
+		const onlyEqualColumns =
+			repeaterStatus && clientId === repeaterRowClientId;
+
 		if (toolbar) {
-			setDisplayedTemplates(getTemplates(repeaterStatus));
+			setDisplayedTemplates(getTemplates(onlyEqualColumns));
 		} else {
 			setDisplayedTemplates(
-				getTemplates(repeaterStatus, breakpoint, numCol)
+				getTemplates(onlyEqualColumns, breakpoint, numCol)
 			);
 		}
 	}, [breakpoint, numCol]);

--- a/src/blocks/row-maxi/components/column-pattern/index.js
+++ b/src/blocks/row-maxi/components/column-pattern/index.js
@@ -23,7 +23,6 @@ import {
 } from '../../../../extensions/styles';
 import { validateRowColumnsStructure } from '../../../../extensions/repeater';
 import { getBlockPosition } from '../../../../extensions/repeater/utils';
-import { cleanInnerBlocks } from '../../../../extensions/copy-paste';
 
 /**
  * External dependencies
@@ -246,54 +245,28 @@ const ColumnPattern = props => {
 											innerBlockPositions
 										);
 
-										const { getBlock } =
-											select('core/block-editor');
-										const {
-											__unstableMarkNextChangeAsNotPersistent:
-												markNextChangeAsNotPersistent,
-											replaceInnerBlocks,
-										} = dispatch('core/block-editor');
-
-										const rowToValidateByInnerBlocks =
-											getBlock(clientId).innerBlocks;
-
 										innerBlockPositions[
 											blockPosition
 										].forEach(rowClientId => {
 											if (rowClientId === clientId)
 												return;
 
-											const oldInnerBlocks =
-												getBlock(
-													rowClientId
-												).innerBlocks;
-
-											const clonedInnerBlocks =
-												cleanInnerBlocks(
-													rowToValidateByInnerBlocks
-												);
-
-											clonedInnerBlocks.forEach(
-												(column, i) => {
-													if (
-														i >=
-														oldInnerBlocks.length
-													)
-														return;
-
-													column.clientId =
-														oldInnerBlocks[
-															i
-														].clientId;
-												}
-											);
-
-											markNextChangeAsNotPersistent();
-											replaceInnerBlocks(
+											loadColumnsTemplate(
+												newRowPattern,
 												rowClientId,
-												clonedInnerBlocks
+												breakpoint,
+												numCol,
+												repeaterStatus,
+												repeaterStatus
 											);
 										});
+
+										// Undo/redo fix
+										const {
+											__unstableMarkNextChangeAsNotPersistent:
+												markNextChangeAsNotPersistent,
+										} = dispatch('core/block-editor');
+										markNextChangeAsNotPersistent();
 									}
 								}
 

--- a/src/blocks/row-maxi/edit.js
+++ b/src/blocks/row-maxi/edit.js
@@ -157,7 +157,9 @@ class edit extends MaxiBlockComponent {
 				{...this.props}
 				repeaterStatus={repeaterContext.repeaterStatus}
 				repeaterRowClientId={repeaterContext.repeaterRowClientId}
-				getInnerBlocksPositions={this.getInnerBlocksPositions}
+				getInnerBlocksPositions={
+					repeaterContext.getInnerBlocksPositions
+				}
 			/>,
 			<RowContext.Provider
 				key={`row-content-${uniqueID}`}
@@ -181,6 +183,21 @@ class edit extends MaxiBlockComponent {
 
 						this.forceUpdate();
 					},
+					removeColumnClientId: clientId => {
+						this.columnsClientIds = this.columnsClientIds.filter(
+							val => val !== clientId
+						);
+						this.columnsSize = Object.keys(this.columnsSize).reduce(
+							(acc, key) => {
+								if (key !== clientId) {
+									acc[key] = this.columnsSize[key];
+								}
+								return acc;
+							},
+							{}
+						);
+					},
+
 					rowGapProps: getRowGapProps(attributes),
 					rowBorderRadius: getGroupAttributes(
 						attributes,


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5041 

# How Has This Been Tested?
Checked if bug from video disappeared, also created empty container with rows and columns, added rows into columns and played with them as well.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Check if the problem from issue is resolved
-   [x] Create a container with row and columns, turn on repeater for the highest row, then add row to column and play with changing row scheme
-   [x] Same 1-2 points for the toolbar
-   [x] Same 1-2 points on responsive

**_ Pre-Code Testing _**

-   [ ] Check if the problem from issue is resolved
-   [ ] Create a container with row and columns, turn on repeater for the highest row, then add row to column and play with changing row scheme
-   [ ] Same 1-2 points for the toolbar
-   [ ] Same 1-2 points on responsive
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Resolved an issue with the unmounting of the `maxiBlock` component in `src/blocks/column-maxi/edit.js`. This fix ensures that the column client ID is properly removed from the context when the component is unmounted.
- Refactor: Updated the `useEffect` hook in `src/blocks/row-maxi/components/column-pattern/index.js` to conditionally set displayed templates. This change enhances performance by reducing unnecessary rendering.
- New Feature: Added undo/redo functionality in `src/blocks/row-maxi/components/column-pattern/index.js`, improving user experience during template modifications.
- Refactor: Enhanced the `edit` class in `src/blocks/row-maxi/edit.js` to handle removal of column client IDs more efficiently, leading to improved maintainability and consistency in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->