### PR TITLE
Issue 5020 - fix IB transform target select not working

### DIFF
--- a/src/components/transform-control/utils.js
+++ b/src/components/transform-control/utils.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getBgLayersSelectorsCss } from '../custom-css-control/utils';
-
+import { prefixes as searchPrefixes } from '../../blocks/search-maxi/data';
 /**
  * External dependencies
  */
@@ -79,10 +79,15 @@ export const getTransformSelectors = (selectors, attributes = {}) => {
 	};
 };
 
-export const getTransformCategories = (categories, attributes) => {
+export const getTransformCategories = (categories, attributes, blockName) => {
 	const {
 		'background-layers': bgLayers = [],
 		'background-layers-hover': bgLayersHover = [],
+		'shape-divider-top-status': shapeDividerTopStatus,
+		'shape-divider-bottom-status': shapeDividerBottomStatus,
+		'icon-content': iconContent,
+		[`${searchPrefixes.closeIconPrefix}icon-content`]: closeIconContent,
+		skin,
 	} = attributes;
 
 	const bgLayersSelectors = getBgLayersSelectorsCss(
@@ -97,6 +102,16 @@ export const getTransformCategories = (categories, attributes) => {
 				getKey(key)
 			),
 		],
-		isEmpty(bgLayers) && isEmpty(bgLayersHover) && 'background'
+		isEmpty(bgLayers) && isEmpty(bgLayersHover) && 'background',
+		...(blockName === 'container-maxi' && [
+			!shapeDividerTopStatus && 'top shape divider',
+			!shapeDividerBottomStatus && 'bottom shape divider',
+		]),
+		...(blockName === 'button-maxi' && [isEmpty(iconContent) && 'icon']),
+		...(blockName === 'search-maxi' && [
+			isEmpty(iconContent) && 'icon',
+			isEmpty(closeIconContent) && 'close icon',
+			skin !== 'icon-reveal' && 'close icon',
+		])
 	);
 };

--- a/src/components/transform-control/utils.js
+++ b/src/components/transform-control/utils.js
@@ -3,6 +3,7 @@
  */
 import { getBgLayersSelectorsCss } from '../custom-css-control/utils';
 import { prefixes as searchPrefixes } from '../../blocks/search-maxi/data';
+
 /**
  * External dependencies
  */

--- a/src/extensions/relations/getAdvancedSettings.js
+++ b/src/extensions/relations/getAdvancedSettings.js
@@ -21,6 +21,7 @@ import {
 	getTransformSelectors,
 } from '../../components/transform-control/utils';
 import { getGroupAttributes, getLastBreakpointAttribute } from '../styles';
+import { getBlockNameFromUniqueID } from '../styles/migrators/utils';
 
 /**
  * External dependencies
@@ -48,8 +49,12 @@ const getTransformControl = ({ categories, selectors }) => ({
 			{...props}
 			uniqueID={props.attributes.uniqueID}
 			depth={2}
-			selectors={getTransformSelectors(selectors, props.attributes)}
-			categories={getTransformCategories(categories, props.attributes)}
+			selectors={getTransformSelectors(selectors, props.blockAttributes)}
+			categories={getTransformCategories(
+				categories,
+				props.blockAttributes,
+				getBlockNameFromUniqueID(props.blockAttributes.uniqueID)
+			)}
 			disableHover
 		/>
 	),

--- a/src/extensions/relations/getIBStylesObj.js
+++ b/src/extensions/relations/getIBStylesObj.js
@@ -38,7 +38,7 @@ const getIBStylesObj = ({
 				clientId,
 			}),
 		},
-	}).target.result;
+	})?.target?.result;
 };
 
 export default getIBStylesObj;

--- a/src/extensions/style-cards/test/updateSCOnEditor.js
+++ b/src/extensions/style-cards/test/updateSCOnEditor.js
@@ -18,6 +18,7 @@ jest.mock('@wordpress/blocks', () => {
 jest.mock('src/components/block-inserter/index.js', () => jest.fn());
 jest.mock('../../styles/transitions/getTransitionData.js', () => jest.fn());
 jest.mock('../../attributes/getBlockData.js', () => jest.fn());
+jest.mock('src/components/transform-control/utils.js', () => jest.fn());
 
 describe('getSCVariablesObject', () => {
 	it('Return an object with variables ready to update on `document.documentElement`', () => {

--- a/src/extensions/styles/test/styleProcessor.js
+++ b/src/extensions/styles/test/styleProcessor.js
@@ -3,6 +3,9 @@ import styleProcessor from '../styleProcessor';
 jest.mock('@wordpress/blocks', () => jest.fn());
 jest.mock('src/components/block-inserter/index.js', () => jest.fn());
 jest.mock('../../attributes/getBlockData.js', () => jest.fn());
+jest.mock('src/components/transform-control/utils.js', () => ({
+	getTransformSelectors: jest.fn(),
+}));
 
 describe('styleCleaner', () => {
 	it('Returns cleaned styles obj', () => {

--- a/src/extensions/text/formats/test/flatFormatsWithClass.js
+++ b/src/extensions/text/formats/test/flatFormatsWithClass.js
@@ -18,6 +18,7 @@ jest.mock('../../../styles/getBlockStyle', () => {
 	});
 });
 jest.mock('../../../attributes/getBlockData.js', () => jest.fn());
+jest.mock('src/components/transform-control/utils.js', () => jest.fn());
 jest.mock('../../../style-cards/getActiveStyleCard', () => {
 	return jest.fn(() => {
 		return {

--- a/src/extensions/text/formats/test/getCustomFormatValue.js
+++ b/src/extensions/text/formats/test/getCustomFormatValue.js
@@ -9,6 +9,7 @@ jest.mock('@wordpress/blocks', () => {
 jest.mock('src/components/block-inserter/index.js', () => jest.fn());
 jest.mock('../../../styles/transitions/getTransitionData.js', () => jest.fn());
 jest.mock('../../../attributes/getBlockData.js', () => jest.fn());
+jest.mock('src/components/transform-control/utils.js', () => jest.fn());
 
 describe('getCustomFormatValue', () => {
 	it('Returns SC value', () => {

--- a/src/extensions/text/formats/test/setFormatWithClass.js
+++ b/src/extensions/text/formats/test/setFormatWithClass.js
@@ -20,6 +20,7 @@ jest.mock('../../../styles/getBlockStyle', () => {
 	});
 });
 jest.mock('../../../attributes/getBlockData.js', () => jest.fn());
+jest.mock('src/components/transform-control/utils.js', () => jest.fn());
 
 const styleCard = {
 	name: 'Maxi (Default)',


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5020

# How Has This Been Tested?
Checked if I can select transform target in IB.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check if you can select transform target in IB.

**_Pre-Code Testing_**

-   [x] Check if you can select transform target in IB.
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:

- Bug Fix: Fixed potential errors in `getIBStylesObj.js` by adding optional chaining operators.
- New Feature: Added additional logic and conditions to `getTransformCategories` in `utils.js` for different block names.
- New Feature: Imported and used `getBlockNameFromUniqueID` function in `getAdvancedSettings.js`.
- New Feature: Added `disableHover` prop to `TransformControl` component in `getAdvancedSettings.js`.
- Test: Mocked `utils.js` module in multiple test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->