### PR TITLE
Issue 5051 - Fix FSE page mode fonts saving

### DIFF
--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 
@@ -13,7 +13,8 @@ import Button from '../../components/button';
 import Icon from '../../components/icon';
 import MaxiStyleCardsEditorPopUp from '../style-cards';
 import { setScreenSize } from '../../extensions/styles';
-import { getSiteEditorIframeBody } from '../../extensions/fse';
+import { getIsSiteEditor, getSiteEditorIframeBody } from '../../extensions/fse';
+import { goThroughMaxiBlocks } from '../../extensions/maxi-block';
 import { getPageFonts, loadFonts } from '../../extensions/text/fonts';
 
 /**
@@ -356,7 +357,28 @@ const ResponsiveSelector = props => {
 	});
 
 	const addCloudLibrary = () => {
-		insertBlock(createBlock('maxi-blocks/maxi-cloud'));
+		let rootClientId;
+
+		if (getIsSiteEditor()) {
+			const { postType, postId } =
+				select('core/edit-site').getEditedPostContext();
+
+			if (postType && postId) {
+				goThroughMaxiBlocks(block => {
+					if (block.name === 'core/post-content') {
+						rootClientId = block.clientId;
+						return true;
+					}
+					return false;
+				});
+			}
+		}
+
+		insertBlock(
+			createBlock('maxi-blocks/maxi-cloud'),
+			undefined,
+			rootClientId
+		);
 	};
 
 	const classes = classnames('maxi-responsive-selector', className);

--- a/src/editor/toolbar-buttons/editor.scss
+++ b/src/editor/toolbar-buttons/editor.scss
@@ -35,6 +35,11 @@ body.maxi-blocks--active .edit-post-header-toolbar {
 	}
 	.edit-site-layout__header {
 		z-index: 3;
+
+		// To make SC popup appear on click even after FSE template switch
+		&:has(.maxi-style-cards__popover) {
+			transform: none !important;
+		}
 	}
 	.maxi-toolbar-layout__button {
 		position: absolute;
@@ -44,7 +49,7 @@ body.maxi-blocks--active .edit-post-header-toolbar {
 	}
 }
 
-@media only screen and (max-width: 781px){
+@media only screen and (max-width: 781px) {
 	.edit-site {
 		.maxi-toolbar-layout__button {
 			left: 125px;

--- a/src/extensions/maxi-block/goThroughMaxiBlocks.js
+++ b/src/extensions/maxi-block/goThroughMaxiBlocks.js
@@ -40,6 +40,21 @@ const goThroughMaxiBlocks = (
 				}
 			}
 
+			if (block.name === 'core/post-content') {
+				const { postType, postId } =
+					select('core/edit-site').getEditedPostContext();
+
+				const { blocks } = select('core').getEditedEntityRecord(
+					'postType',
+					postType,
+					postId
+				);
+
+				if (blocks?.length) {
+					innerBlocks = blocks;
+				}
+			}
+
 			if (block.name === 'core/block') {
 				const blocks = select('core/block-editor').getBlocks(
 					block.clientId

--- a/src/extensions/maxi-block/goThroughMaxiBlocks.js
+++ b/src/extensions/maxi-block/goThroughMaxiBlocks.js
@@ -41,6 +41,11 @@ const goThroughMaxiBlocks = (
 			}
 
 			if (block.name === 'core/post-content') {
+				const callbackResult = callback(block);
+				if (callbackResult) {
+					return callbackResult;
+				}
+
 				const { postType, postId } =
 					select('core/edit-site').getEditedPostContext();
 

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -853,7 +853,7 @@ class MaxiBlockComponent extends Component {
 	}
 
 	uniqueIDChecker(idToCheck) {
-		const { name: blockName, attributes } = this.props;
+		const { clientId, name: blockName, attributes } = this.props;
 		const { customLabel } = attributes;
 
 		if (!getIsIDTrulyUnique(idToCheck)) {


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5051 

UPD:
**IMPORTANT**: deactivate and activate the plugin after switching to the branch, need it to create new DB tables.

**IMPORTANT**: Saving a page takes some time (depends on the amount of blocks on the page), please w8 for it to finish before checking the frontend (look on the Update button). This is for tests only, later we will plug that php function to archives, FSE, maxi dashboard, etc. to work without user waiting for it on each page saving.

This branch is a modified copy of #4967, where fonts saving on FSE page mode was fixed.
And this branch is going to be merged into #4967 👍 , btw, also fixed problem after merging master, which crashes blocks 👍 

# How Has This Been Tested?
https://github.com/maxi-blocks/maxi-blocks/assets/46112160/37ccb9bf-2611-42af-9c5e-3ba75efc7672

On video, you can see that there's no problem with saving styles on #4967 branch, but there are problems with saving custom fonts, which were fixed on this branch 👍 

Demonstration of a before/after fix for a SC popup issue and maxi library insertion:

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/617bd99e-76d2-4170-861f-40e46863660e


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if styles and fonts are saving correctly for you in FSE page mode
-   [x] Test if it's possible to paste template library with this button in FSE page mode
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/3f5565d3-dc38-4ace-84e7-14a4904813ab)
-   [x] Test if it's still possible to paste template library in other FSE mods, in post editor
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/3f5565d3-dc38-4ace-84e7-14a4904813ab)
-   [x] Test if after switching to other page, it's still possible to open SC popup


**_ Pre-Code Testing _**

-   [x] Test if styles and fonts are saving correctly for you in FSE page mode
-   [x] Test if it's possible to paste template library with this button in FSE page mode
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/3f5565d3-dc38-4ace-84e7-14a4904813ab)
-   [x] Test if it's still possible to paste template library in other FSE mods, in post editor
![image](https://github.com/maxi-blocks/maxi-blocks/assets/46112160/3f5565d3-dc38-4ace-84e7-14a4904813ab)
-   [x] Test if after switching to other page, it's still possible to open SC popup
-   [x] Check no commented code and no unnecessary imports
-   [x] Standards of the project have been followed
-   [x] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

Release Notes:

- New Feature: Added support for handling specific logic when encountering the `'core/post-content'` block in the `goThroughMaxiBlocks` function of `src/extensions/maxi-block/goThroughMaxiBlocks.js`.
- Refactor: Updated the `uniqueIDChecker` function in `src/extensions/maxi-block/maxiBlockComponent.js` to include the `clientId` variable, which is required for the function's logic.
- Refactor: Modified `src/editor/responsive-selector/index.js` to import necessary functions and handle the site editor mode in the `addCloudLibrary` function.
- Style: Made CSS changes in `src/editor/toolbar-buttons/editor.scss` to improve the appearance and responsiveness of the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->