### PR TITLE
Move json files to build folder to resolve permissions

### DIFF
--- a/core/blocks/class-maxi-block.php
+++ b/core/blocks/class-maxi-block.php
@@ -242,12 +242,12 @@ if (!class_exists('MaxiBlocks_Block')):
             ];
             // If the block should be dynamic, use MaxiBlocks_DynamicContent
             if (in_array($this->block_name, $this->dynamic_blocks)) {
-                $this->block = register_block_type("maxi-blocks/{$this->block_name}", array_merge(json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . "src/blocks/{$this->block_name}/block.json"), true), $config));
+                $this->block = register_block_type("maxi-blocks/{$this->block_name}", array_merge(json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . "build/blocks/{$this->block_name}/block.json"), true), $config));
             } else {
                 $this->block = register_block_type(
                     "maxi-blocks/{$this->block_name}",
                     array_merge(
-                        json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . 'src/blocks/' . $this->block_name . '/block.json'), true),
+                        json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . 'build/blocks/' . $this->block_name . '/block.json'), true),
                         [ 'render_callback' => [$this, 'render_block']]
                     )
                 );
@@ -287,7 +287,7 @@ if (!class_exists('MaxiBlocks_Block')):
         {
             // If the block metadata is not yet retrieved, read it from the block.json file.
             return $this->block_metadata = (!empty($this->block_metadata) ? $this->block_metadata : json_decode(
-                file_get_contents(MAXI_PLUGIN_DIR_PATH . 'src/blocks/' . $this->block_name . '/block.json'),
+                file_get_contents(MAXI_PLUGIN_DIR_PATH . 'build/blocks/' . $this->block_name . '/block.json'),
                 true
             ));
 

--- a/core/blocks/utils/get_block_attributes.php
+++ b/core/blocks/utils/get_block_attributes.php
@@ -2,7 +2,7 @@
 
 function get_block_attributes($block_name)
 {
-    $path = MAXI_PLUGIN_DIR_PATH . './src/blocks/' . $block_name . '/block.json';
+    $path = MAXI_PLUGIN_DIR_PATH . './build/blocks/' . $block_name . '/block.json';
 
     if (!file_exists($path)) {
         return null;

--- a/core/blocks/utils/get_default_attribute.php
+++ b/core/blocks/utils/get_default_attribute.php
@@ -53,7 +53,7 @@ function get_default_attribute($prop, $block_name = null)
     ];
 
     foreach ($blocks as $block) {
-        $block_data = json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . "src/blocks/" . $block . "/block.json"), true);
+        $block_data = json_decode(file_get_contents(MAXI_PLUGIN_DIR_PATH . "build/blocks/" . $block . "/block.json"), true);
         $block_defaults = $block_data['attributes'];
 
         if (array_key_exists($prop, $block_defaults) && isset($block_defaults[$prop]['default'])) {

--- a/src/extensions/maxi-block/block-json-abstract/index.js
+++ b/src/extensions/maxi-block/block-json-abstract/index.js
@@ -67,16 +67,24 @@ const blockJsonAbstracter = async () => {
 		const blockName = maxiBlock.name.replace('maxi-blocks/', '');
 
 		// Get the block.json file path
-		const blockFolderPath = path.join(`src/blocks/${blockName}`);
+		let blockFolderPath = path.join(`src/blocks/${blockName}`);
 		const blockFile = 'block.json';
-		const blockPath = path.join(blockFolderPath, blockFile);
+		let blockPath = path.join(blockFolderPath, blockFile);
 
 		// In case the block.json file does not exist, continue to the next block
 		if (!existsSync(blockPath)) {
-			console.error('❌ block.json file does not exist for ', blockName);
+			blockFolderPath = path.join(`build/blocks/${blockName}`);
+			blockPath = path.join(blockFolderPath, blockFile);
 
-			// eslint-disable-next-line no-continue
-			continue;
+			if (!existsSync(blockPath)) {
+				console.error(
+					'❌ block.json file does not exist for ',
+					blockName
+				);
+
+				// eslint-disable-next-line no-continue
+				continue;
+			}
 		}
 
 		// Get the block.json file content as an object


### PR DESCRIPTION
# Description

We encountered a weird error when a plugin that's installed from another server can't read the /src folder, even when it exists. I've moved the block.json files that we need to the build folder and overwrote the file paths. 

Fixes a fatal error on WP update.

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated file paths in `class-maxi-block.php`, `get_block_attributes.php`, and `block-json-abstract/index.js` to accommodate changes in the directory structure or build process of the plugin. This ensures that the code can locate block metadata and attributes correctly.
- Review Needed: The changes in `class-maxi-block.php` and `block-json-abstract/index.js` require a review to ensure that the modifications are implemented correctly and do not introduce any issues.
- Skip Review: The change in `get_default_attribute.php` is a simple update to the file path used in the `file_get_contents` function and does not require a review.
- Overall Impact: These changes improve the maintainability and flexibility of the codebase, allowing for easier management of block files and their associated metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->