### PR TITLE
Issue 5162 - Fix Dimension size on frontend

### DIFF
--- a/core/blocks/class-image-maxi-block.php
+++ b/core/blocks/class-image-maxi-block.php
@@ -423,6 +423,7 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
 
         public static function get_image_object($props)
         {
+            $fit_parent_size = $props['fitParentSize'] ?? false;
             $image_ratio = $props['imageRatio'];
             $img_width = $props['imgWidth'];
             $use_init_size = $props['useInitSize'] ?? false;
@@ -467,7 +468,7 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
                 'obj' => get_group_attributes($props, 'clipPath'),
             ]);
 
-            if ($img_width) {
+            if ($img_width && !$fit_parent_size) {
                 $response['imgWidth'] = [
                     'general' => [
                         'width' => !$use_init_size ? "$img_width%" : $media_width . "px",

--- a/core/blocks/class-image-maxi-block.php
+++ b/core/blocks/class-image-maxi-block.php
@@ -476,7 +476,7 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
                 ];
             }
 
-            if ($fit_parent_size && !$is_first_on_hierarchy) {
+            if (!$is_first_on_hierarchy) {
                 $response['fitParentSize'] = self::get_image_fit_wrapper($props);
             }
 

--- a/core/blocks/class-image-maxi-block.php
+++ b/core/blocks/class-image-maxi-block.php
@@ -180,7 +180,6 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
         public static function get_wrapper_object($props)
         {
             $block_style = $props['blockStyle'];
-            $fit_parent_size = $props['fitParentSize'] ?? false;
 
             $response =
                 [
@@ -368,18 +367,27 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
 
         public static function get_image_fit_wrapper($props)
         {
+            $fit_parent_size = $props['fitParentSize'] ?? false;
+
             $response = [];
 
-            $breakpoints = ['general', 'sm', 'md', 'lg', 'xl', 'xxl'];
+            $breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
             foreach ($breakpoints as $breakpoint) {
                 $response[$breakpoint] = [];
 
-                $object_size = get_last_breakpoint_attribute([
+                $object_size = $fit_parent_size ? get_last_breakpoint_attribute([
                     'target' => 'object-size',
                     'breakpoint' => $breakpoint,
                     'attributes' => $props,
-                ]);
+                ]) : get_default_attribute('object-size-general');
+                $size = round($object_size * 100, 2);
+                $displacement_coefficient = 100 - $size;
+
+                if ($fit_parent_size) {
+                    $response[$breakpoint]['height'] = "{$size}%";
+                    $response[$breakpoint]['width'] = "{$size}%";
+                }
 
                 $horizontal_position = get_last_breakpoint_attribute([
                     'target' => 'object-position-horizontal',
@@ -392,14 +400,6 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
                     'breakpoint' => $breakpoint,
                     'attributes' => $props,
                 ]);
-
-                $size = round($object_size * 100, 2);
-
-                $response[$breakpoint]['height'] = "{$size}%";
-                $response[$breakpoint]['width'] = "{$size}%";
-
-
-                $displacement_coefficient = 100 - $size;
 
                 $horizontal_displacement = round(
                     ($displacement_coefficient * $horizontal_position) / 100,
@@ -427,7 +427,6 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
             $img_width = $props['imgWidth'];
             $use_init_size = $props['useInitSize'] ?? false;
             $media_width = $props['mediaWidth'];
-            $fit_parent_size = $props['fitParentSize'] ?? false;
             $is_first_on_hierarchy = $props['isFirstOnHierarchy'];
             $svg_element = $props['SVGElement'] ?? '';
 

--- a/core/blocks/class-image-maxi-block.php
+++ b/core/blocks/class-image-maxi-block.php
@@ -393,7 +393,7 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
                     'attributes' => $props,
                 ]);
 
-                $size = $object_size * 100;
+                $size = round($object_size * 100, 2);
 
                 $response[$breakpoint]['height'] = "{$size}%";
                 $response[$breakpoint]['width'] = "{$size}%";
@@ -401,11 +401,15 @@ if (!class_exists('MaxiBlocks_Image_Maxi_Block')):
 
                 $displacement_coefficient = 100 - $size;
 
-                $horizontal_displacement =
-                    ($displacement_coefficient * $horizontal_position) / 100;
+                $horizontal_displacement = round(
+                    ($displacement_coefficient * $horizontal_position) / 100,
+                    2
+                );
 
-                $vertical_isplacement =
-                    ($displacement_coefficient * $vertical_position) / 100;
+                $vertical_isplacement = round(
+                    ($displacement_coefficient * $vertical_position) / 100,
+                    2
+                );
 
                 $response[$breakpoint]['left'] = "$horizontal_displacement%";
                 $response[$breakpoint]['top'] = "$vertical_isplacement%";

--- a/src/blocks/image-maxi/components/dimension-tab/index.js
+++ b/src/blocks/image-maxi/components/dimension-tab/index.js
@@ -137,74 +137,82 @@ const DimensionTab = props => {
 					)}
 				</>
 			)}
-			<ToggleSwitch
-				label={__('Use original size', 'maxi-blocks')}
-				className='maxi-image-inspector__initial-size'
-				selected={useInitSize}
-				onChange={val =>
-					maxiSetAttributes({
-						useInitSize: val,
-					})
-				}
-			/>
-			{!useInitSize && (
-				<RangeControl
-					className='maxi-image-inspector__dimension-width'
-					label={__('Width', 'maxi-blocks')}
-					value={attributes.imgWidth}
-					onChange={val => {
-						if (!isNil(val)) {
+			{!fitParentSize && (
+				<>
+					<ToggleSwitch
+						label={__('Use original size', 'maxi-blocks')}
+						className='maxi-image-inspector__initial-size'
+						selected={useInitSize}
+						onChange={val =>
 							maxiSetAttributes({
-								imgWidth: val,
-							});
+								useInitSize: val,
+							})
+						}
+					/>
+					{!useInitSize && (
+						<RangeControl
+							className='maxi-image-inspector__dimension-width'
+							label={__('Width', 'maxi-blocks')}
+							value={attributes.imgWidth}
+							onChange={val => {
+								if (!isNil(val)) {
+									maxiSetAttributes({
+										imgWidth: val,
+									});
 
-							resizableObject &&
-								resizableObject.updateSize({
-									width: `${val}%`,
-								});
-						} else {
-							const defaultAttribute = getDefaultAttribute(
+									resizableObject &&
+										resizableObject.updateSize({
+											width: `${val}%`,
+										});
+								} else {
+									const defaultAttribute =
+										getDefaultAttribute(
+											'imgWidth',
+											clientId
+										);
+
+									maxiSetAttributes({
+										imgWidth: defaultAttribute,
+									});
+
+									resizableObject &&
+										resizableObject.updateSize({
+											width: `${defaultAttribute}%`,
+										});
+								}
+							}}
+							max={100}
+							allowReset
+							initialPosition={getDefaultAttribute(
 								'imgWidth',
 								clientId
-							);
-
+							)}
+						/>
+					)}
+					<AspectRatioControl
+						className='maxi-image-inspector__ratio'
+						label={__('Image ratio', 'maxi-blocks')}
+						value={imageRatio}
+						additionalOptions={[
+							{
+								label: __('Original size', 'maxi-blocks'),
+								value: 'original',
+							},
+						]}
+						onChange={imageRatio =>
 							maxiSetAttributes({
-								imgWidth: defaultAttribute,
-							});
-
-							resizableObject &&
-								resizableObject.updateSize({
-									width: `${defaultAttribute}%`,
-								});
+								imageRatio,
+							})
 						}
-					}}
-					max={100}
-					allowReset
-					initialPosition={getDefaultAttribute('imgWidth', clientId)}
-				/>
+						onReset={() =>
+							maxiSetAttributes({
+								imageRatio: getDefaultAttribute('imageRatio'),
+								isReset: true,
+							})
+						}
+					/>
+				</>
 			)}
-			<AspectRatioControl
-				className='maxi-image-inspector__ratio'
-				label={__('Image ratio', 'maxi-blocks')}
-				value={imageRatio}
-				additionalOptions={[
-					{
-						label: __('Original size', 'maxi-blocks'),
-						value: 'original',
-					},
-				]}
-				onChange={imageRatio =>
-					maxiSetAttributes({
-						imageRatio,
-					})
-				}
-				onReset={() =>
-					maxiSetAttributes({
-						imageRatio: getDefaultAttribute('imageRatio'),
-						isReset: true,
-					})
-				}
-			/>
 			{!isFirstOnHierarchy && (
 				<>
 					<ToggleSwitch

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -118,7 +118,11 @@ class edit extends MaxiBlockComponent {
 				this.resizableObject.current.state.width
 			);
 
-			if (imgWidth !== resizableWidth) {
+			if (this.props.attributes.fitParentSize && resizableWidth !== 100) {
+				this.resizableObject.current.updateSize({
+					width: '100%',
+				});
+			} else if (imgWidth !== resizableWidth) {
 				this.resizableObject.current.updateSize({
 					width: `${imgWidth}%`,
 				});

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -215,7 +215,13 @@ class edit extends MaxiBlockComponent {
 				attributes,
 			});
 
-			if (useInitSize && !isNumber(maxWidth)) return `${mediaWidth}px`;
+			if (useInitSize && !isNumber(maxWidth)) {
+				if (fitParentSize) {
+					return '100%';
+				}
+
+				return `${mediaWidth}px`;
+			}
 
 			const maxWidthUnit = getLastBreakpointAttribute({
 				target: 'image-max-width-unit',

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -118,7 +118,11 @@ class edit extends MaxiBlockComponent {
 				this.resizableObject.current.state.width
 			);
 
-			if (this.props.attributes.fitParentSize && resizableWidth !== 100) {
+			if (
+				(this.props.attributes.fitParentSize ||
+					this.props.attributes.useInitSize) &&
+				resizableWidth !== 100
+			) {
 				this.resizableObject.current.updateSize({
 					width: '100%',
 				});

--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -392,7 +392,10 @@ class edit extends MaxiBlockComponent {
 								}%`,
 							}}
 							showHandle={
-								isSelected && !fullWidth && !useInitSize
+								isSelected &&
+								!fullWidth &&
+								!useInitSize &&
+								!fitParentSize
 							}
 							maxWidth={getMaxWidth()}
 							enable={{

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -33,7 +33,7 @@ import data from './data';
 /**
  * External dependencies
  */
-import { isNil } from 'lodash';
+import { isNil, round } from 'lodash';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
@@ -270,17 +270,21 @@ const getImageFitWrapper = props => {
 			attributes: props,
 		});
 
-		const size = objectSize * 100;
+		const size = round(objectSize * 100, 2);
 
 		response[breakpoint].height = `${size}%`;
 		response[breakpoint].width = `${size}%`;
 
 		const displacementCoefficient = 100 - size;
 
-		const horizontalDisplacement =
-			(displacementCoefficient * horizontalPosition) / 100;
-		const verticalDisplacement =
-			(displacementCoefficient * verticalPosition) / 100;
+		const horizontalDisplacement = round(
+			(displacementCoefficient * horizontalPosition) / 100,
+			2
+		);
+		const verticalDisplacement = round(
+			(displacementCoefficient * verticalPosition) / 100,
+			2
+		);
 
 		response[breakpoint].left = `${horizontalDisplacement}%`;
 		response[breakpoint].top = `${verticalDisplacement}%`;

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import {
+	getDefaultAttribute,
 	getGroupAttributes,
 	getLastBreakpointAttribute,
 	styleProcessor,
@@ -249,16 +250,13 @@ const getImageWrapperObject = props => {
 };
 
 const getImageFitWrapper = props => {
+	const { fitParentSize } = props;
+
 	const response = {};
 
 	breakpoints.forEach(breakpoint => {
 		response[breakpoint] = {};
 
-		const objectSize = getLastBreakpointAttribute({
-			target: 'object-size',
-			breakpoint,
-			attributes: props,
-		});
 		const horizontalPosition = getLastBreakpointAttribute({
 			target: 'object-position-horizontal',
 			breakpoint,
@@ -270,12 +268,20 @@ const getImageFitWrapper = props => {
 			attributes: props,
 		});
 
+		const objectSize = fitParentSize
+			? getLastBreakpointAttribute({
+					target: 'object-size',
+					breakpoint,
+					attributes: props,
+			  })
+			: getDefaultAttribute('object-size-general');
 		const size = round(objectSize * 100, 2);
-
-		response[breakpoint].height = `${size}%`;
-		response[breakpoint].width = `${size}%`;
-
 		const displacementCoefficient = 100 - size;
+
+		if (fitParentSize) {
+			response[breakpoint].height = `${size}%`;
+			response[breakpoint].width = `${size}%`;
+		}
 
 		const horizontalDisplacement = round(
 			(displacementCoefficient * horizontalPosition) / 100,

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -305,11 +305,12 @@ const getImageFitWrapper = props => {
 
 const getImageObject = props => {
 	const {
+		fitParentSize,
 		imageRatio,
 		imgWidth,
-		useInitSize,
-		mediaWidth,
 		isFirstOnHierarchy,
+		mediaWidth,
+		useInitSize,
 	} = props;
 
 	return {
@@ -352,13 +353,16 @@ const getImageObject = props => {
 				...getGroupAttributes(props, 'clipPath'),
 			},
 		}),
-		...(imgWidth && {
-			imgWidth: {
-				general: {
-					width: !useInitSize ? `${imgWidth}%` : `${mediaWidth}px`,
+		...(imgWidth &&
+			!fitParentSize && {
+				imgWidth: {
+					general: {
+						width: !useInitSize
+							? `${imgWidth}%`
+							: `${mediaWidth}px`,
+					},
 				},
-			},
-		}),
+			}),
 		...(!isFirstOnHierarchy && {
 			fitParentSize: getImageFitWrapper(props),
 		}),


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5162 

# How Has This Been Tested?
Checked if dimension size works from now on frontend. Also, I've hidden options like `Use original size` and dimension size when `fit wrapper` is on, it is different between backend and frontend (image width change on backend don't work on frontend), so as MVP I've removed this options when toggle in on (so image width with toggle is always 100%), and if you need this toggles to be fixed and returned, then write it in #3828 👍 


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if dimension size works on frontend and backend
-   [x] Play with fit on wrapper, ensure it has same look on frontend and backend

**_ Pre-Code Testing _**

-   [ ] Test if dimension size works on frontend and backend
-   [ ] Play with fit on wrapper, ensure it has same look on frontend and backend
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes for Pull Request**

- New Feature: Added "Use original size" toggle to the `DimensionTab` component, allowing users to maintain the original image dimensions.
- New Feature: Introduced an `AspectRatioControl` component for customizing the image ratio.
- Refactor: Updated logic in `get_image_fit_wrapper` and `get_styles` functions for better handling of image sizing and fitting.
- Refactor: Enhanced `edit` class with additional conditions for updating resizable object's width based on `fitParentSize` and `useInitSize` attributes.
- Bug Fix: Fixed issue where the handle was shown even when `fitParentSize` was true in the `ResizableImage` component.
- Style: Improved code readability by renaming variables in `class-image-maxi-block.php`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->