### PR TITLE
Issue 5110 - Native blocks toggle padding 2

### DIFF
--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -336,7 +336,7 @@ body {
 					color: #232533;
 				}
 			}
-			padding: 0 8px 1px;
+			padding: 0 8px 8px;
 			background: #fff;
 
 			button:last-of-type {


### PR DESCRIPTION
Added bottom padding for the native blocks toggle

Fixes https://github.com/maxi-blocks/maxi-blocks/issues/5110
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style: Adjusted the bottom padding in the style cards of the editor. This change enhances the visual spacing and readability, providing a more comfortable user interface experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->