### PR TITLE
Issue 5034 - Switch to latest posts for DC and CL if no tags exist on the site and relation is by tag

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -300,19 +300,7 @@ class MaxiBlocks_DynamicContent
             $query = new WP_Query($args);
 
             if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
-                if ($dc_relation === 'by-category') {
-                    // Get first existing category
-                    $categories = get_categories(['hide_empty' => false]);
-                    $first_category = reset($categories);
-                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-category', 'dc-id' => $first_category->term_id]));
-                } elseif ($dc_relation === 'by-tag') {
-                    // Get first existing tag
-                    $tags = get_tags(['hide_empty' => false]);
-                    $first_tag = reset($tags);
-                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-tag', 'dc-id' => $first_tag->term_id]));
-                }
-
-                return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
+                return $this->get_post(array_replace($attributes, self::get_validated_orderby_attributes($dc_relation)));
             }
 
             return end($query->posts);
@@ -339,19 +327,7 @@ class MaxiBlocks_DynamicContent
             $query = new WP_Query($args);
 
             if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
-                if ($dc_relation === 'by-category') {
-                    // Get first existing category
-                    $categories = get_categories(['hide_empty' => false]);
-                    $first_category = reset($categories);
-                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-category', 'dc-id' => $first_category->term_id]));
-                } elseif ($dc_relation === 'by-tag') {
-                    // Get first existing tag
-                    $tags = get_tags(['hide_empty' => false]);
-                    $first_tag = reset($tags);
-                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-tag', 'dc-id' => $first_tag->term_id]));
-                }
-
-                return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
+                return $this->get_post(array_replace($attributes, self::get_validated_orderby_attributes($dc_relation)));
             }
 
             if ($is_random) {
@@ -406,6 +382,28 @@ class MaxiBlocks_DynamicContent
             return null;
         }
     }
+
+    public function get_validated_orderby_attributes($dc_relation)
+    {
+        if ($dc_relation === 'by-category') {
+            // Get first existing category
+            $categories = get_categories(['hide_empty' => false]);
+            $first_category = reset($categories);
+            if ($first_category) {
+                return ['dc-relation' => 'by-category', 'dc-id' => $first_category->term_id];
+            }
+        } elseif ($dc_relation === 'by-tag') {
+            // Get first existing tag
+            $tags = get_tags(['hide_empty' => false]);
+            $first_tag = reset($tags);
+            if ($first_tag) {
+                return ['dc-relation' => 'by-tag', 'dc-id' => $first_tag->term_id];
+            }
+        }
+
+        return ['dc-relation' => 'by-date', 'dc-order' => 'desc'];
+    }
+
 
     public function get_field_link($item, $field)
     {

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -299,6 +299,10 @@ class MaxiBlocks_DynamicContent
 
             $query = new WP_Query($args);
 
+            if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
+                return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
+            }
+
             return end($query->posts);
         } elseif ($dc_type === 'media') {
             $args = [
@@ -321,6 +325,10 @@ class MaxiBlocks_DynamicContent
             }
 
             $query = new WP_Query($args);
+
+            if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
+                return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
+            }
 
             if ($is_random) {
                 $posts = $query->posts;

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -300,6 +300,18 @@ class MaxiBlocks_DynamicContent
             $query = new WP_Query($args);
 
             if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
+                if ($dc_relation === 'by-category') {
+                    // Get first existing category
+                    $categories = get_categories(['hide_empty' => false]);
+                    $first_category = reset($categories);
+                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-category', 'dc-id' => $first_category->term_id]));
+                } elseif ($dc_relation === 'by-tag') {
+                    // Get first existing tag
+                    $tags = get_tags(['hide_empty' => false]);
+                    $first_tag = reset($tags);
+                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-tag', 'dc-id' => $first_tag->term_id]));
+                }
+
                 return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
             }
 
@@ -314,7 +326,7 @@ class MaxiBlocks_DynamicContent
             if ($dc_relation == 'by-id') {
                 $args['p'] = $dc_id;
             } elseif ($is_random) {
-                $args= [
+                $args = [
                     'post_type' => 'attachment',
                     'post_status' => 'inherit',
                     'posts_per_page' => -1
@@ -327,6 +339,18 @@ class MaxiBlocks_DynamicContent
             $query = new WP_Query($args);
 
             if (empty($query->posts) && in_array($dc_relation, self::$order_by_relations)) {
+                if ($dc_relation === 'by-category') {
+                    // Get first existing category
+                    $categories = get_categories(['hide_empty' => false]);
+                    $first_category = reset($categories);
+                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-category', 'dc-id' => $first_category->term_id]));
+                } elseif ($dc_relation === 'by-tag') {
+                    // Get first existing tag
+                    $tags = get_tags(['hide_empty' => false]);
+                    $first_tag = reset($tags);
+                    return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-tag', 'dc-id' => $first_tag->term_id]));
+                }
+
                 return $this->get_post(array_replace($attributes, ['dc-relation' => 'by-date', 'dc-order' => 'desc']));
             }
 

--- a/src/extensions/DC/getDCOptions.js
+++ b/src/extensions/DC/getDCOptions.js
@@ -108,15 +108,17 @@ const getDCOptions = async (
 	if (!isEqual(newPostIdOptions, postIdOptions)) {
 		// Ensures first post id is selected
 		if (isEmpty(find(newPostIdOptions, { value: id }))) {
-			if (
-				orderByRelations.includes(relation) &&
-				!newPostIdOptions.length
-			) {
-				newValues[`${prefix}relation`] = 'by-date';
-				newValues[`${prefix}order`] = 'desc';
-			} else if (!contextLoop?.['cl-status']) {
-				newValues[`${prefix}id`] = Number(data[0].id);
-				idFields.current = data[0].id;
+			if (!contextLoop?.['cl-status']) {
+				if (
+					orderByRelations.includes(relation) &&
+					!newPostIdOptions.length
+				) {
+					newValues[`${prefix}relation`] = 'by-date';
+					newValues[`${prefix}order`] = 'desc';
+				} else {
+					newValues[`${prefix}id`] = Number(data[0].id);
+					idFields.current = data[0].id;
+				}
 			} else {
 				newValues[`${prefix}id`] = undefined;
 			}

--- a/src/extensions/DC/getDCOptions.js
+++ b/src/extensions/DC/getDCOptions.js
@@ -108,7 +108,13 @@ const getDCOptions = async (
 	if (!isEqual(newPostIdOptions, postIdOptions)) {
 		// Ensures first post id is selected
 		if (isEmpty(find(newPostIdOptions, { value: id }))) {
-			if (!contextLoop?.['cl-status']) {
+			if (
+				orderByRelations.includes(relation) &&
+				!newPostIdOptions.length
+			) {
+				newValues[`${prefix}relation`] = 'by-date';
+				newValues[`${prefix}order`] = 'desc';
+			} else if (!contextLoop?.['cl-status']) {
 				newValues[`${prefix}id`] = Number(data[0].id);
 				idFields.current = data[0].id;
 			} else {

--- a/src/extensions/DC/withMaxiContextLoop.js
+++ b/src/extensions/DC/withMaxiContextLoop.js
@@ -125,7 +125,7 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				if (
 					wasRelationValidated.current ||
 					!orderByRelations.includes(
-						memoizedValue.contextLoop['cl-relation']
+						contextLoopAttributes['cl-relation']
 					)
 				)
 					return () => null;
@@ -135,14 +135,14 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				const updateRelationIds = async () => {
 					const dataRequest = Object.fromEntries(
 						Object.entries(
-							getCLAttributes(memoizedValue.contextLoop)
+							getCLAttributes(contextLoopAttributes)
 						).map(([key, value]) => [key.replace('cl-', ''), value])
 					);
 
 					const { newValues } =
 						(await getDCOptions(
 							dataRequest,
-							memoizedValue.contextLoop['cl-id'],
+							contextLoopAttributes['cl-id'],
 							undefined,
 							true
 						)) ?? {};
@@ -165,7 +165,7 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				return () => {
 					isCancelled = true;
 				};
-			}, [setAttributes, memoizedValue]);
+			}, [setAttributes, contextLoopAttributes]);
 
 			return (
 				<LoopContext.Provider value={memoizedValue}>

--- a/src/extensions/DC/withMaxiContextLoop.js
+++ b/src/extensions/DC/withMaxiContextLoop.js
@@ -122,7 +122,9 @@ const withMaxiContextLoop = createHigherOrderComponent(
 			// Check if category or tag by which the post is filtered exists
 			useEffect(() => {
 				if (!orderByRelations.includes(contextLoop['cl-relation']))
-					return;
+					return () => null;
+
+				let isCancelled = false;
 
 				const updateRelationIds = async () => {
 					const dataRequest = Object.fromEntries(
@@ -139,7 +141,7 @@ const withMaxiContextLoop = createHigherOrderComponent(
 							true
 						)) ?? {};
 
-					if (!isEmpty(newValues)) {
+					if (!isEmpty(newValues) && !isCancelled) {
 						const {
 							__unstableMarkNextChangeAsNotPersistent:
 								markNextChangeAsNotPersistent,
@@ -151,6 +153,10 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				};
 
 				updateRelationIds();
+
+				return () => {
+					isCancelled = true;
+				};
 			}, []);
 
 			return (


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5034 

Replaces https://github.com/maxi-blocks/maxi-blocks/pull/5042

# How Has This Been Tested?
Inserted [PBGL-PRO-55.txt](https://github.com/maxi-blocks/maxi-blocks/files/12362427/PBGL-PRO-55.txt) on local and checked if it switches to another category. Also changed its relation to by-tag, deleted all tags on my local and checked if it switches to by-date.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Insert [PBGL-PRO-55.txt](https://github.com/maxi-blocks/maxi-blocks/files/12362427/PBGL-PRO-55.txt) on local and check if it switches to another category.
-   [x] Change relation to by-tag, delete all tags on local and check if it switches to by-date.

**_ Pre-Code Testing _**

-   [ ] Insert [PBGL-PRO-55.txt](https://github.com/maxi-blocks/maxi-blocks/files/12362427/PBGL-PRO-55.txt) on local and check if it switches to another category.
-   [ ] Change relation to by-tag, delete all tags on local and check if it switches to by-date.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Bug Fix:**
- Enhanced the `get_post` function in `core/class-maxi-dynamic-content.php` to handle cases where no posts are returned from the query. The function now falls back to a different order-by relation, improving reliability.
- Improved handling of empty result sets when retrieving random posts, applying the same fallback mechanism.

**New Feature:**
- Introduced a new function `get_validated_orderby_attributes` in `core/class-maxi-dynamic-content.php` for validating and returning order-by attributes based on the given relation.
- Updated `src/extensions/DC/getDCOptions.js` to adjust the `relation` and `order` values based on the `orderByRelations` array and the `newPostIdOptions` array, enhancing functionality.
- Added a new `useEffect` hook in `src/extensions/DC/withMaxiContextLoop.js` to validate the relation and update the attributes accordingly, improving data integrity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->