### PR TITLE
Issue 5137 - Styles in preview mode

### DIFF
--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -483,8 +483,8 @@ if (!class_exists('MaxiBlocks_API')):
                     } else {
                         $wpdb->insert("{$table}", $get_array([
                             'block_style_id',
-                            'css_value',
-                            'fonts_value',
+                            'prev_css_value',
+                            'prev_fonts_value',
                         ], $dictionary));
                     }
                 }

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1283,11 +1283,14 @@ class MaxiBlocks_Styles
         }
 
         // fonts
-        $fonts_json = $content_block['fonts_value'] ?? null;
-        if($fonts_json !== '' && $fonts_json !== null) {
-            $fonts_array = json_decode($fonts_json, true) ?? [];
-        } else {
-            $fonts_array = [];
+        foreach (['fonts_value', 'prev_fonts_value'] as $fonts_key) {
+            $fonts_json = $content_block[$fonts_key] ?? null;
+
+            if ($fonts_json !== '' && $fonts_json !== null) {
+                $fonts_array = json_decode($fonts_json, true) ?? [];
+            } else {
+                $fonts_array = [];
+            }
         }
 
         $fonts = array_merge($fonts, $fonts_array);

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1283,6 +1283,7 @@ class MaxiBlocks_Styles
         }
 
         // fonts
+        // TODO: split fonts and prev_fonts
         foreach (['fonts_value', 'prev_fonts_value'] as $fonts_key) {
             $fonts_json = $content_block[$fonts_key] ?? null;
 
@@ -1291,9 +1292,9 @@ class MaxiBlocks_Styles
             } else {
                 $fonts_array = [];
             }
-        }
 
-        $fonts = array_merge($fonts, $fonts_array);
+            $fonts = array_merge($fonts, $fonts_array);
+        }
 
         // Process inner blocks, if any
         if (!empty($block['innerBlocks'])) {

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1355,8 +1355,11 @@ class MaxiBlocks_Styles
         } elseif($post) {
             if(is_preview()) {
                 $revisions = wp_get_post_revisions($post->ID);
-                $latest_revision = array_shift($revisions);
-                $blocks_post = parse_blocks($latest_revision->post_content);
+
+                if (!empty($revisions)) {
+                    $latest_revision = array_shift($revisions);
+                    $blocks_post = parse_blocks($latest_revision->post_content);
+                }
             } else {
                 $blocks_post = parse_blocks($post->post_content);
             }

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1353,7 +1353,13 @@ class MaxiBlocks_Styles
         if($passed_content) {
             $blocks_post = parse_blocks($passed_content);
         } elseif($post) {
-            $blocks_post = parse_blocks($post->post_content);
+            if(is_preview()) {
+                $revisions = wp_get_post_revisions($post->ID);
+                $latest_revision = array_shift($revisions);
+                $blocks_post = parse_blocks($latest_revision->post_content);
+            } else {
+                $blocks_post = parse_blocks($post->post_content);
+            }
         } else {
             $blocks_post = [];
         }


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5137 


<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if after adding blocks, preview has styles (if open it straight away)
-   [x] Test if preview works correctly with published posts (publish post, then add or replace blocks and preview them)
-   [x] Test if styles, fonts work in publish mode as before

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `post_maxi_blocks_styles` function in `core/class-maxi-api.php` to handle previous CSS and font values, providing a more robust style management.
- Refactor: Updated the `process_block_frontend` function in `core/class-maxi-styles.php` to process two different font values, improving the flexibility of font handling.
- New Feature: Modified the `get_content_for_blocks_frontend` function in `core/class-maxi-styles.php` to support preview mode, allowing users to view the latest revision's content if available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->