### PR TITLE
Issue 5045 - Gutenberg Tablet and Mobile preview fix

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -690,7 +690,28 @@ class MaxiBlockComponent extends Component {
 				'maxi-blocks-responsive',
 				document.querySelector('.is-tablet-preview') ? 's' : 'xs'
 			);
-		} else wrapper = getStylesWrapper(document.head);
+			if (!select('maxiBlocks').getIsIframeObserverSet()) {
+				dispatch('maxiBlocks').setIsIframeObserverSet(true);
+				const iframeObserver = new MutationObserver(() => {
+					if (
+						!iframe.contentDocument.body.classList.contains(
+							'maxi-blocks--active'
+						)
+					) {
+						iframe.contentDocument.body.classList.add(
+							'maxi-blocks--active'
+						);
+					}
+				});
+				iframeObserver.observe(iframe.contentDocument.body, {
+					attributes: true,
+					attributeFilter: ['class'],
+				});
+			}
+		} else {
+			dispatch('maxiBlocks').setIsIframeObserverSet(false);
+			wrapper = getStylesWrapper(document.head);
+		}
 
 		if (
 			this.rootSlot &&

--- a/src/extensions/store/actions.js
+++ b/src/extensions/store/actions.js
@@ -153,5 +153,11 @@ const actions = {
 			isPageLoaded,
 		};
 	},
+	setIsIframeObserverSet(isIframeObserverSet = true) {
+		return {
+			type: 'SET_IS_IFRAME_OBSERVER_SET',
+			isIframeObserverSet,
+		};
+	},
 };
 export default actions;

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -107,6 +107,7 @@ const reducer = (
 		deprecatedBlocks: {},
 		blocksToRender: [],
 		isPageLoaded: false,
+		isIframeObserverSet: false,
 		blockName: {},
 		uniqueID: {},
 	},
@@ -226,6 +227,11 @@ const reducer = (
 				...state,
 				isPageLoaded: action.isPageLoaded,
 				blocksToRender: [],
+			};
+		case 'SET_IS_IFRAME_OBSERVER_SET':
+			return {
+				...state,
+				isIframeObserverSet: action.isIframeObserverSet,
 			};
 		default:
 			return state;

--- a/src/extensions/store/selectors.js
+++ b/src/extensions/store/selectors.js
@@ -80,6 +80,11 @@ const selectors = {
 
 		return false;
 	},
+	getIsIframeObserverSet(state) {
+		if (state) return state.isIframeObserverSet;
+
+		return false;
+	},
 };
 
 export default selectors;


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5045 

# How Has This Been Tested?
Tested if maxi blocks display correct in Gutenberg tablet and mobile preview mode.

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if maxi blocks display correct in Gutenberg tablet and mobile preview mode.
-   [x] Switch a few times between different breakpoints with use of maxi and gutenberg responsive switchers(mixed)

**_ Pre-Code Testing _**

-   [ ] Test if maxi blocks display correct in Gutenberg tablet and mobile preview mode.
-   [ ] Switch a few times between different breakpoints with use of maxi and gutenberg responsive switchers(mixed)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] My changes generate no new warnings/errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Implemented a new state property `isIframeObserverSet` to track if an observer is set on the iframe. This helps in managing the addition of the class `maxi-blocks--active` to the body element more efficiently.
- New Feature: Added two new selectors, `getIsIframeObserverSet` and `getIsPageLoaded`, for better state management and data retrieval.
- Refactor: Updated the `MaxiBlockComponent` class to use the new state property and selectors, improving code readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->