### PR TITLE
Issue 5194 - fix opacity control wrong value when 0

### DIFF
--- a/src/components/opacity-control/index.js
+++ b/src/components/opacity-control/index.js
@@ -63,7 +63,6 @@ const OpacityControl = props => {
 				return onChange({ [getOpacityAttributeKey()]: val });
 			}}
 			min={0}
-			placeholder={100}
 			max={100}
 			onReset={() => {
 				if (isFunction(onReset)) return onReset();


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5194

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)

**_ Pre-Code Testing _**


-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the Opacity Control component in the user interface. The input field for opacity control will no longer display a default placeholder value of 100. This change simplifies the user experience by removing potentially confusing pre-filled values, allowing users to input their desired opacity level directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->