### PR TITLE
Issue 5203 - Hide Gutenberg's popover for Maxi blocks

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -137,6 +137,7 @@ class MaxiBlockComponent extends Component {
 		this.isTemplatePartPreview = !!getTemplatePartChooseList();
 		this.relationInstances = null;
 		this.previousRelationInstances = null;
+		this.popoverStyles = null;
 
 		dispatch('maxiBlocks').removeDeprecatedBlock(uniqueID);
 
@@ -480,6 +481,8 @@ class MaxiBlockComponent extends Component {
 				);
 			this.isReusable && this.displayStyles();
 		}
+
+		this.hideGutenbergPopover();
 
 		if (this.maxiBlockDidUpdate)
 			this.maxiBlockDidUpdate(prevProps, prevState, shouldDisplayStyles);
@@ -1161,6 +1164,25 @@ class MaxiBlockComponent extends Component {
 			parent = parent.parentNode;
 		}
 		return false;
+	}
+
+	/**
+	 * Hides Gutenberg's popover when the Maxi block is selected.
+	 */
+	hideGutenbergPopover() {
+		if (this.props.isSelected && !this.popoverStyles) {
+			this.popoverStyles = document.createElement('style');
+			this.popoverStyles.innerHTML = `
+				.block-editor-block-popover {
+					display: none !important;
+				}
+			`;
+			this.popoverStyles.id = 'maxi-blocks-hide-popover-styles';
+			document.head.appendChild(this.popoverStyles);
+		} else if (!this.props.isSelected && this.popoverStyles) {
+			this.popoverStyles.remove();
+			this.popoverStyles = null;
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5203 

# How Has This Been Tested?
Checked if gutenberg popover is hidden for maxi blocks and is available for non-maxi blocks

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if popover is hidden for maxi blocks
-   [x] Test if popover is available for non-maxi blocks

**_ Pre-Code Testing _**

-   [ ] Test if popover is hidden for maxi blocks
-   [ ] Test if popover is available for non-maxi blocks
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced style adjustments for popovers in the editor to enhance usability.

- **Enhancements**
  - Improved block selection experience by automatically hiding popovers when a block is not selected.

- **Refactor**
  - Updated component lifecycle to ensure popovers react to changes in block selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->