### PR TITLE
Fix FSE previews render

### DIFF
--- a/src/extensions/DC/withMaxiContextLoop.js
+++ b/src/extensions/DC/withMaxiContextLoop.js
@@ -14,6 +14,7 @@ import LoopContext from './loopContext';
 import getDCOptions from './getDCOptions';
 import getCLAttributes from './getCLAttributes';
 import { getAttributesWithoutPrefix } from './utils';
+import { getSiteEditorPreviewIframes } from '../fse';
 
 /**
  * External dependencies
@@ -38,6 +39,12 @@ export const ALLOWED_ACCUMULATOR_GRANDPARENT_GRANDCHILD_MAP = {
 const withMaxiContextLoop = createHigherOrderComponent(
 	WrappedComponent =>
 		pure(ownProps => {
+			const isPreview = getSiteEditorPreviewIframes().length > 0;
+
+			if (isPreview) {
+				// If in FSE preview mode, render the wrapped component without the LoopContext.Provider
+				return <WrappedComponent {...ownProps} />;
+			}
 			const { attributes, clientId, name, setAttributes } = ownProps;
 
 			let prevContextLoopAttributes = null;
@@ -216,7 +223,7 @@ const withMaxiContextLoop = createHigherOrderComponent(
 
 			return (
 				<LoopContext.Provider value={memoizedValue}>
-					<WrappedComponent {...ownProps} />{' '}
+					<WrappedComponent {...ownProps} />
 				</LoopContext.Provider>
 			);
 		}),

--- a/src/extensions/attributes/withAttributes.js
+++ b/src/extensions/attributes/withAttributes.js
@@ -122,15 +122,17 @@ const withAttributes = createHigherOrderComponent(
 				if (!isFirstOnHierarchy) {
 					const firstMaxiParentBlock =
 						select('core/block-editor').getBlock(blockRootClientId);
-					const { blockStyle } = firstMaxiParentBlock.attributes;
+					if (firstMaxiParentBlock) {
+						const { blockStyle } = firstMaxiParentBlock.attributes;
 
-					if (blockStyle !== attributes.blockStyle) {
-						isFirstOnHierarchyUpdated = true;
-						markNextChangeAsNotPersistent();
-						setAttributes({
-							blockStyle,
-							isFirstOnHierarchy,
-						});
+						if (blockStyle !== attributes.blockStyle) {
+							isFirstOnHierarchyUpdated = true;
+							markNextChangeAsNotPersistent();
+							setAttributes({
+								blockStyle,
+								isFirstOnHierarchy,
+							});
+						}
 					}
 				}
 

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -172,6 +172,8 @@ wp.domReady(() => {
 			const siteEditorIframeBody = getSiteEditorIframeBody();
 			const siteEditorPreviewIframeBodies =
 				getSiteEditorPreviewIframesBodies();
+			const isInPatternsPreviewMode =
+				siteEditorPreviewIframeBodies.length > 0;
 
 			if (
 				!isTemplatesListOpened &&
@@ -205,11 +207,15 @@ wp.domReady(() => {
 				siteEditorIframeBody.classList.add('maxi-blocks--active');
 
 			// Need to add 'maxi-blocks--active' class to the FSE preview iframe bodies
-			siteEditorPreviewIframeBodies.forEach(body => {
-				if (body && !body.classList.contains('maxi-blocks--active')) {
-					body.classList.add('maxi-blocks--active');
-				}
-			});
+			isInPatternsPreviewMode &&
+				siteEditorPreviewIframeBodies.forEach(body => {
+					if (
+						body &&
+						!body.classList.contains('maxi-blocks--active')
+					) {
+						body.classList.add('maxi-blocks--active');
+					}
+				});
 
 			if ((getIsTemplatesListOpened() || id !== currentId) && isSCLoaded)
 				isSCLoaded = false;
@@ -227,6 +233,15 @@ wp.domReady(() => {
 						isSCLoaded = false;
 					}
 				}, 150);
+			}
+
+			if (isInPatternsPreviewMode) {
+				const SC = select(
+					'maxiBlocks/style-cards'
+				).receiveMaxiActiveStyleCard();
+				if (SC) {
+					updateSCOnEditor(SC.value);
+				}
 			}
 
 			if (getIsTemplatePart()) {

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -12,6 +12,7 @@ import {
 	getIsTemplatePart,
 	getIsTemplatesListOpened,
 	getSiteEditorIframeBody,
+	getSiteEditorPreviewIframesBodies,
 } from '../fse';
 import getWinBreakpoint from './getWinBreakpoint';
 import getEditorWrapper from './getEditorWrapper';
@@ -169,6 +170,13 @@ wp.domReady(() => {
 			const currentId = select('core/edit-site').getEditedPostId();
 			const isTemplatesListOpened = getIsTemplatesListOpened();
 			const siteEditorIframeBody = getSiteEditorIframeBody();
+			const siteEditorPreviewIframeBodies =
+				getSiteEditorPreviewIframesBodies();
+
+			console.log('siteEditorPreviewIframeBody:');
+			console.log(siteEditorPreviewIframeBodies);
+			console.log('isTemplatesListOpened:');
+			console.log(isTemplatesListOpened);
 
 			if (
 				!isTemplatesListOpened &&
@@ -200,6 +208,13 @@ wp.domReady(() => {
 				!siteEditorIframeBody.classList.contains('maxi-blocks--active')
 			)
 				siteEditorIframeBody.classList.add('maxi-blocks--active');
+
+			// Need to add 'maxi-blocks--active' class to the FSE preview iframe bodies
+			siteEditorPreviewIframeBodies.forEach(body => {
+				if (body && !body.classList.contains('maxi-blocks--active')) {
+					body.classList.add('maxi-blocks--active');
+				}
+			});
 
 			if ((getIsTemplatesListOpened() || id !== currentId) && isSCLoaded)
 				isSCLoaded = false;

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -173,11 +173,6 @@ wp.domReady(() => {
 			const siteEditorPreviewIframeBodies =
 				getSiteEditorPreviewIframesBodies();
 
-			console.log('siteEditorPreviewIframeBody:');
-			console.log(siteEditorPreviewIframeBodies);
-			console.log('isTemplatesListOpened:');
-			console.log(isTemplatesListOpened);
-
 			if (
 				!isTemplatesListOpened &&
 				isNewEditorContentObserver &&

--- a/src/extensions/fse/getSiteEditorPreviewIframes.js
+++ b/src/extensions/fse/getSiteEditorPreviewIframes.js
@@ -1,0 +1,6 @@
+const getSiteEditorPreviewIframes = () =>
+	document.querySelectorAll(
+		'.edit-site-page-content .block-editor-block-preview__container iframe'
+	);
+
+export default getSiteEditorPreviewIframes;

--- a/src/extensions/fse/getSiteEditorPreviewIframesBodies.js
+++ b/src/extensions/fse/getSiteEditorPreviewIframesBodies.js
@@ -1,0 +1,18 @@
+import getSiteEditorPreviewIframes from './getSiteEditorPreviewIframes';
+
+const getSiteEditorPreviewIframesBodies = () => {
+	const iframes = getSiteEditorPreviewIframes();
+	if (!iframes) return [];
+
+	const bodies = [];
+	iframes.forEach(iframe => {
+		const body = iframe.contentDocument.querySelector(
+			'.editor-styles-wrapper'
+		);
+		if (body) bodies.push(body);
+	});
+
+	return bodies;
+};
+
+export default getSiteEditorPreviewIframesBodies;

--- a/src/extensions/fse/index.js
+++ b/src/extensions/fse/index.js
@@ -9,3 +9,5 @@ export { default as getTemplatePartsIds } from './getTemplatePartsIds';
 export { default as getTemplatePartSlug } from './getTemplatePartSlug';
 export { default as getTemplatePartTagName } from './getTemplatePartTagName';
 export { default as getTemplateViewIframe } from './getTemplateViewIframe';
+export { default as getSiteEditorPreviewIframes } from './getSiteEditorPreviewIframes';
+export { default as getSiteEditorPreviewIframesBodies } from './getSiteEditorPreviewIframesBodies';

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -41,6 +41,7 @@ import {
 	getSiteEditorIframe,
 	getTemplatePartChooseList,
 	getTemplateViewIframe,
+	getSiteEditorPreviewIframes,
 } from '../fse';
 import { updateSCOnEditor } from '../style-cards';
 import getWinBreakpoint from '../dom/getWinBreakpoint';
@@ -1037,14 +1038,30 @@ class MaxiBlockComponent extends Component {
 	loadFonts() {
 		if (this.areFontsLoaded.current || isEmpty(this.typography)) return;
 
-		const target = getIsSiteEditor() ? getSiteEditorIframe() : document;
-		if (!target) return;
+		const siteEditorPreviewIframes = getSiteEditorPreviewIframes();
 
-		const response = getAllFonts(this.typography, 'custom-formats');
-		if (isEmpty(response)) return;
+		if (siteEditorPreviewIframes.length > 0) {
+			siteEditorPreviewIframes.forEach(iframe => {
+				const target = iframe?.contentDocument;
+				if (!target) return;
 
-		loadFonts(response, true, target);
-		this.areFontsLoaded.current = true;
+				const response = getAllFonts(this.typography, 'custom-formats');
+				if (isEmpty(response)) return;
+
+				loadFonts(response, true, target);
+			});
+			this.areFontsLoaded.current = true;
+		} else {
+			const target = getIsSiteEditor() ? getSiteEditorIframe() : document;
+
+			if (!target) return;
+
+			const response = getAllFonts(this.typography, 'custom-formats');
+			if (isEmpty(response)) return;
+
+			loadFonts(response, true, target);
+			this.areFontsLoaded.current = true;
+		}
 	}
 
 	/**

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -41,7 +41,6 @@ import {
 	getSiteEditorIframe,
 	getTemplatePartChooseList,
 	getTemplateViewIframe,
-	getSiteEditorPreviewIframes,
 } from '../fse';
 import { updateSCOnEditor } from '../style-cards';
 import getWinBreakpoint from '../dom/getWinBreakpoint';
@@ -208,6 +207,7 @@ class MaxiBlockComponent extends Component {
 		// Init
 		this.updateLastInsertedBlocks();
 		const newUniqueID = this.uniqueIDChecker(uniqueID);
+		this.originalBlockStyle = attributes?.blockStyle;
 		this.getCurrentBlockStyle();
 		this.setMaxiAttributes();
 		this.setRelations();
@@ -1066,6 +1066,12 @@ class MaxiBlockComponent extends Component {
 			this.isPatternsPreview = true;
 			previewIframes.forEach(iframe => {
 				this.rootSlot = this.getRootEl(iframe);
+				if (
+					this.originalBlockStyle &&
+					this.props.attributes.blockStyle !== this.originalBlockStyle
+				) {
+					this.props.attributes.blockStyle = this.originalBlockStyle;
+				}
 				if (this.rootSlot) {
 					const styleComponent = (
 						<StyleComponent

--- a/src/extensions/relations/updateRelationsRemotely.js
+++ b/src/extensions/relations/updateRelationsRemotely.js
@@ -24,8 +24,10 @@ const updateRelationsRemotely = ({
 	breakpoint,
 }) => {
 	// Block trigger relations
-	const { relations } =
-		select('core/block-editor').getBlockAttributes(blockTriggerClientId);
+	const relations =
+		select('core/block-editor')?.getBlockAttributes(
+			blockTriggerClientId
+		)?.relations;
 
 	if (!relations) return;
 

--- a/src/extensions/style-cards/updateSCOnEditor.js
+++ b/src/extensions/style-cards/updateSCOnEditor.js
@@ -97,6 +97,23 @@ const updateSCOnEditor = (
 		siteEditorPreviewIframes.forEach(iframe => {
 			const iframeDocument = iframe?.contentDocument;
 
+			// remove white overlay for FSE editor patterns previews
+			let overlayEl = iframeDocument.getElementById(
+				'maxi-blocks-fse-white-overlay-remove-styles'
+			);
+
+			if (!overlayEl) {
+				overlayEl = iframeDocument.createElement('style');
+				overlayEl.id = 'maxi-blocks-fse-white-overlay-remove-styles';
+				overlayEl.innerHTML =
+					'body{background-color: transparent; !important;}.is-focus-mode .block-editor-block-list__block:not(.has-child-selected){opacity: 1 !important;}';
+				const overlayHead = iframeDocument.head;
+				if (overlayHead) {
+					overlayHead.appendChild(overlayEl);
+				}
+			}
+
+			// add SC variables for FSE editor patterns previews
 			let SCVarEl = iframeDocument.getElementById(
 				'maxi-blocks-sc-vars-inline-css'
 			);
@@ -111,6 +128,7 @@ const updateSCOnEditor = (
 				}
 			}
 
+			// load SC fonts for FSE editor patterns previews
 			if (!isEmpty(allSCFonts)) {
 				loadFonts(allSCFonts, true, iframe.contentDocument);
 			}


### PR DESCRIPTION
# Description

Fixes previews for FSE when patterns have Maxi Blocks. 

For comparing: 
Master: 

![screenshot-wordpress local-2024 01 17-12_11_49](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/72bb5082-9c0d-420e-9d6a-529182001eb6)

This branch:

![screenshot-wordpress local-2024 01 17-12_05_28](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/5a749898-220e-4756-a1d3-d5bf5c97a02e)


# How Has This Been Tested?

Note, that the previews use screen size 1200px wide. 
The speed optimization is the next issue, so ignore the slow render for now.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the previews in FSE
-   [ ] Test that editing of patterns works in FSE
-   [ ] Test the same reusable patterns / templates in usual Gutenberg editor
-   [ ] Check that CL works, its code was changed

**_ Pre-Code Testing _**

-   [ ] Test the previews in FSE
-   [ ] Test that editing of patterns works in FSE
-   [ ] Test the same reusable patterns / templates in usual Gutenberg editor
-   [ ] Check that CL works, its code was changed
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Full Site Editing (FSE) preview mode with improved rendering and style updates.
	- Added conditional rendering logic to improve stability and user experience in FSE preview mode.

- **Bug Fixes**
	- Fixed an issue where attributes were accessed unsafely, potentially causing errors.
	- Implemented safer access to `relations` properties to prevent application crashes.

- **Refactor**
	- Improved handling of iframe bodies in FSE previews.
	- Optimized font loading process for multiple iframes in FSE patterns preview.

- **Style**
	- Applied new class to FSE preview iframe bodies for better visual consistency during pattern previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->