### PR TITLE
Issue 5411 - Fix font-style Array to string conversion warning

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -757,6 +757,10 @@ class MaxiBlocks_Styles
                                 $font_weight = implode('-', $font_weight);
                             }
 
+                            if(is_array($font_style)) {
+                                $font_style = implode('-', $font_style);
+                            }
+
                             if (!$use_local_fonts) {
 
                                 if ($font_url) {


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5411 

# How Has This Been Tested?
Changed font family for text-maxi and checked if warning from frontend has disappeared

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [x] Test if warning has disappeared

**_ Pre-Code Testing _**

-   [ ] Test if warning has disappeared
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling of font styles when specified as an array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->