### PR TITLE
PHP warnings fix

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -1169,7 +1169,7 @@ class MaxiBlocks_DynamicContent
     {
         $term = get_term($id);
 
-		// Check if $term is a WP_Error
+        // Check if $term is a WP_Error
         if (is_wp_error($term)) {
             return '';
         }

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -1169,6 +1169,11 @@ class MaxiBlocks_DynamicContent
     {
         $term = get_term($id);
 
+		// Check if $term is a WP_Error
+        if (is_wp_error($term)) {
+            return '';
+        }
+
         if ($term) {
             return $term->slug;
         }

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1154,7 +1154,7 @@ class MaxiBlocks_Styles
                                 if (isset($array['relations'])) {
                                     $meta_to_pass = array_merge($meta_to_pass, $array['relations']);  // Add the 'relations' value to the new array
                                 }
-                             }
+                            }
                         }
                     } else {
                         $meta_to_pass = array_merge($meta_to_pass, $meta[$block_name]);

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1149,10 +1149,12 @@ class MaxiBlocks_Styles
                     }
                     if($script === 'relations') {
                         foreach ($meta[$block_name] as $json) {
-                            $array = json_decode($json, true);  // Decode the JSON string into an array
-                            if (isset($array['relations'])) {
-                                $meta_to_pass = array_merge($meta_to_pass, $array['relations']);  // Add the 'relations' value to the new array
-                            }
+                            if (is_string($json)) {
+                                $array = json_decode($json, true);  // Decode the JSON string into an array
+                                if (isset($array['relations'])) {
+                                    $meta_to_pass = array_merge($meta_to_pass, $array['relations']);  // Add the 'relations' value to the new array
+                                }
+                             }
                         }
                     } else {
                         $meta_to_pass = array_merge($meta_to_pass, $meta[$block_name]);


### PR DESCRIPTION
# Description
Fixes php warning

```[31-Jan-2024 14:14:24 UTC] PHP Warning:  Undefined property: WP_Error::$slug in /home/elzadj/Work/Gutenberg/dev/wp-content/plugins/maxi-blocks/core/class-maxi-dynamic-content.php on line 1173```

that was making debug.log massive. 

Also adds another check for relations json to remove a potential php fatal error.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that there is no warning any more (editing pages, frontend)
-   [ ] Test patterns with relations, new and from the cloud, on frontend.

**_ Pre-Code Testing _**

-   [ ] Check that there is no warning any more (editing pages, frontend)
-   [ ] Test patterns with relations, new and from the cloud, on frontend.
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in dynamic content retrieval to ensure stability.
	- Enhanced data processing safety by verifying data types before decoding, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->