### PR TITLE
Issue 5423 - SC save button not becoming active

### DIFF
--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -122,12 +122,12 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 
 	const canBeSaved = keySC => {
 		const currentSC = {
-			...styleCards[keySC].light.styleCard,
-			...styleCards[keySC].dark.styleCard,
+			light: styleCards[keySC].light.styleCard,
+			dark: styleCards[keySC].dark.styleCard,
 		};
 		const savedSC = {
-			...savedStyleCards[keySC]?.light.styleCard,
-			...savedStyleCards[keySC]?.dark.styleCard,
+			light: savedStyleCards[keySC]?.light.styleCard,
+			dark: savedStyleCards[keySC]?.dark.styleCard,
 		};
 
 		if (


### PR DESCRIPTION
# Description

So the only way I could reproduce this was: 
when I changed some settings in dark mode, saved, and then changed those same settings in light mode.

It was happening because we were not differentiating light and dark attributes in a function that checks if anything was changed.

Fixes #5423 

# How Has This Been Tested?
Tried to reproduce like I wrote higher, save button lit up.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check if it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal handling of light and dark properties in the MaxiStyleCardsEditor for better performance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->