### PR TITLE
Fix: colour opacity

### DIFF
--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -956,10 +956,10 @@ class MaxiBlocks_Styles
                 );
             }
 
-            // Replaces all ,1)),1) to ,1)
+            // Replaces all ,NUMBER)),SECOND_NUMBER) to ,SECOND_NUMBER) where SECOND_NUMBER can be a decimal
             $new_style = preg_replace(
-                '/,1\)\),1\)/',
-                ',1)',
+                '/,\d+\)\),(\d+(\.\d+)?\))/',
+                ',$1',
                 $new_style
             );
 


### PR DESCRIPTION
# Description

Fixes broken colour opacity for some instances, when our php generates something like this on frontend:

``` color: var(--maxi-light-button-color-hover,rgba(var(--maxi-light-color-1,255,255,255),1)),0));```

What results in opacity on frontend not working:

![Screenshot from 2024-02-07 14-39-44](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/2ac0edf5-4563-45dd-890d-974b98fb5443)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test colour opacity for different blocks
-   [ ] Test colour opacity for bg
-   [ ] Test colour opacity for SC
-   [ ] Test colour opacity for items from cloud
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test colour opacity for different blocks
-   [ ] Test colour opacity for bg
-   [ ] Test colour opacity for SC
-   [ ] Test colour opacity for items from cloud
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of color palette backups to support decimal values more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->