### PR TITLE
Add Update notification

### DIFF
--- a/core/admin/class-maxi-dashboard.php
+++ b/core/admin/class-maxi-dashboard.php
@@ -59,12 +59,16 @@ if (!class_exists('MaxiBlocks_Dashboard')):
                 wp_register_style(
                     'maxi-admin',
                     MAXI_PLUGIN_URL_PATH . 'build/admin.css',
+                    [],
+                    MAXI_PLUGIN_VERSION,
                 );
                 wp_enqueue_style('maxi-admin');
 
                 wp_register_script(
                     'maxi-admin',
                     MAXI_PLUGIN_URL_PATH . 'build/admin.js',
+                    [],
+                    MAXI_PLUGIN_VERSION,
                 );
                 wp_enqueue_script('maxi-admin');
 

--- a/core/admin/notices.js
+++ b/core/admin/notices.js
@@ -49,5 +49,32 @@ document.addEventListener('DOMContentLoaded', function () {
 				})
 				.catch(error => console.error('Error:', error));
 		}
+
+		if (
+			event.target.closest('#maxi-plugin-update-notice .notice-dismiss')
+		) {
+			fetch(
+				maxiBlocks.rest_url.replace(
+					'dismiss-notice',
+					'dismiss-plugin-update-notice'
+				),
+				{
+					method: 'POST',
+					headers: {
+						'X-WP-Nonce': maxiBlocks.nonce,
+						'Content-Type': 'application/json',
+					},
+				}
+			)
+				.then(response => {
+					if (response.status === 204) {
+						// Successfully dismissed, hide the notice
+						document.querySelector(
+							'#maxi-plugin-update-notice'
+						).style.display = 'none';
+					}
+				})
+				.catch(error => console.error('Error:', error));
+		}
 	});
 });

--- a/core/class-maxi-blocks.php
+++ b/core/class-maxi-blocks.php
@@ -116,7 +116,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 'maxi-blocks-block-editor',
                 plugins_url($index_js, dirname(__FILE__)),
                 $script_asset['dependencies'],
-                $script_asset['version']
+                MAXI_PLUGIN_VERSION
             );
 
             $editor_css = 'build/index.css';
@@ -124,7 +124,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 'maxi-blocks-block-editor',
                 plugins_url($editor_css, dirname(__FILE__)),
                 [],
-                filemtime(MAXI_PLUGIN_DIR_PATH . "/$editor_css")
+                MAXI_PLUGIN_VERSION
             );
 
             register_block_type('maxi-blocks/block-settings', [
@@ -137,7 +137,7 @@ if (!class_exists('MaxiBlocks_Blocks')):
                 'maxi-blocks-block',
                 plugins_url($style_css, dirname(__FILE__)),
                 [],
-                filemtime(MAXI_PLUGIN_DIR_PATH . "/$style_css")
+                MAXI_PLUGIN_VERSION
             );
             wp_enqueue_style('maxi-blocks-block');
         }

--- a/core/class-maxi-core.php
+++ b/core/class-maxi-core.php
@@ -53,6 +53,7 @@ if (!class_exists('MaxiBlocks_Core')):
                             'media-editor',
                             'media-views'
                         ),
+                        MAXI_PLUGIN_VERSION,
                     );
                     wp_localize_script(
                         'maxi-media-images-filter',

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -1200,10 +1200,10 @@ class MaxiBlocks_Styles
     private function enqueue_script_per_block($script, $js_script_name, $js_script_path, $js_var_to_pass, $js_var, $meta)
     {
         if ($script === 'number-counter') {
-            wp_enqueue_script('maxi-waypoints-js', plugins_url('/js/waypoints.min.js', dirname(__FILE__)));
+            wp_enqueue_script('maxi-waypoints-js', plugins_url('/js/waypoints.min.js', dirname(__FILE__)), [], MAXI_PLUGIN_VERSION);
         }
 
-        wp_enqueue_script($js_script_name, plugins_url($js_script_path, dirname(__FILE__)));
+        wp_enqueue_script($js_script_name, plugins_url($js_script_path, dirname(__FILE__)), [], MAXI_PLUGIN_VERSION);
         wp_localize_script($js_script_name, $js_var_to_pass, $this->get_block_data($js_var, $meta));
     }
 

--- a/plugin.php
+++ b/plugin.php
@@ -148,12 +148,64 @@ function maxi_blocks_after_update($upgrader_object, $options)
             if ($plugin == plugin_basename(__FILE__)) {
                 // Reset the dismissal option
                 update_option('maxi_blocks_db_notice_dismissed', 'no');
+                update_option('maxi_plugin_update_notice_dismissed', 'no');
                 break;
             }
         }
     }
 }
 add_action('upgrader_process_complete', 'maxi_blocks_after_update', 10, 2);
+
+//======================================================================
+// Clear cache notice after plugin update
+//======================================================================
+
+add_action('admin_init', 'maxi_check_plugin_version_update');
+
+function maxi_check_plugin_version_update()
+{
+    $current_version = MAXI_PLUGIN_VERSION;
+    $stored_version = get_option('maxi_plugin_version', '0');
+
+    if (version_compare($current_version, $stored_version, '!=')) {
+        add_action('admin_notices', 'maxi_plugin_update_notice');
+        update_option('maxi_plugin_update_notice_dismissed', 'no');
+    }
+}
+
+function maxi_plugin_update_notice()
+{
+    if (get_option('maxi_plugin_update_notice_dismissed') === 'yes') {
+        return;
+    }
+
+    echo '<div class="notice notice-warning is-dismissible" id="maxi-plugin-update-notice">';
+    echo '<p>MaxiBlocks plugin has been updated. Please clear your browser and plugin caches to ensure the best performance. <a href="https://maxiblocks.com/go/clearing-caches" target="_blank">Learn more</a></p>';
+    echo '</div>';
+
+    add_action('admin_footer', 'maxi_blocks_enqueue_notice_scripts'); // Reuse the existing function to enqueue scripts
+}
+
+function maxi_blocks_register_plugin_update_notice_route()
+{
+    register_rest_route('maxi-blocks/v1', '/dismiss-plugin-update-notice', [
+        'methods' => 'POST',
+        'callback' => 'maxi_blocks_dismiss_plugin_update_notice',
+        'permission_callback' => function () {
+            return current_user_can('manage_options');
+        }
+    ]);
+}
+add_action('rest_api_init', 'maxi_blocks_register_plugin_update_notice_route');
+
+function maxi_blocks_dismiss_plugin_update_notice()
+{
+    update_option('maxi_plugin_update_notice_dismissed', 'yes');
+    // Update the stored plugin version to the current version to prevent the notice from showing again until the next update
+    update_option('maxi_plugin_version', MAXI_PLUGIN_VERSION);
+    return new WP_REST_Response(null, 204);
+}
+
 
 //======================================================================
 // Init


### PR DESCRIPTION
# Description

Adds a dismissible admin notification after each plugin update (or version change). 
Also changes the scripts and css versioning to the plugin's version.

# How Has This Been Tested?
 Notice:

![screenshot-wordpress local-2024 02 23-13_53_55](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/1446d348-8ef3-4242-810f-bff0c5460cbc)

Versioning: 

![Screenshot from 2024-02-23 14-01-26](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/e8792e3f-e245-4a44-86c8-f22bf1225ca5)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Open dashboard, you should see the notice 
-   [ ] Check the link Learn more.
-   [ ] Dismiss the notice
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Change the plugin's version to 1.7.2 in maxi-blocks/plugin.php Version
-   [ ] Open dashboard, you should see the notice again.
-   [ ] Check on another admin page, make sure you see it.
-   [ ] Dismiss it.
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Check a page's source code for the ?ver= parameter for maxi scripts and styles, it should be 1.7.2 
-   [ ] Change the plugin's version to 1.7.1 in maxi-blocks/plugin.php Version
-   [ ] Open dashboard, you should see the notice again.
-   [ ] Check on another admin page, make sure you see it.
-   [ ] Dismiss it.
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Check a page's source code for the ?ver= parameter for maxi scripts and styles, it should be 1.7.1 

**_ Pre-Code Testing _**

-   [ ] Open dashboard, you should see the notice 
-   [ ] Check the link Learn more.
-   [ ] Dismiss the notice
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Change the plugin's version to 1.7.2 in maxi-blocks/plugin.php Version
-   [ ] Open dashboard, you should see the notice again.
-   [ ] Check on another admin page, make sure you see it.
-   [ ] Dismiss it.
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Check a page's source code for the ?ver= parameter for maxi scripts and styles, it should be 1.7.2 
-   [ ] Change the plugin's version to 1.7.1 in maxi-blocks/plugin.php Version
-   [ ] Open dashboard, you should see the notice again.
-   [ ] Check on another admin page, make sure you see it.
-   [ ] Dismiss it.
-   [ ] Reload the page, make sure you don't see it.
-   [ ] Check on another admin page, make sure you don't see it.
-   [ ] Check a page's source code for the ?ver= parameter for maxi scripts and styles, it should be 1.7.1 
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to dismiss plugin update notices.
	- Added cache clearing notifications after a plugin update.

- **Refactor**
	- Simplified asset version management by using a constant for plugin version across various scripts and styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->