### PR TITLE
FSE patterns previews

### DIFF
--- a/e2e-tests/blocks/column-maxi/index.spec.js
+++ b/e2e-tests/blocks/column-maxi/index.spec.js
@@ -32,6 +32,8 @@ describe('Column Maxi', () => {
 		await page.$eval('.maxi-row-block__template button', button =>
 			button.click()
 		);
+		await page.waitForTimeout(300);
+
 		await page.waitForSelector('.maxi-column-block');
 
 		await updateAllBlockUniqueIds(page);
@@ -127,8 +129,7 @@ describe('Column Maxi', () => {
 		await page.$$eval('.maxi-row-block__template button', button =>
 			button[6].click()
 		);
-		await page.waitForTimeout(200);
-
+		await page.waitForTimeout(300);
 		await page.waitForSelector('.maxi-column-block');
 
 		await updateAllBlockUniqueIds(page);
@@ -221,6 +222,7 @@ describe('Column Maxi', () => {
 		expect(await getBlockStyle(page)).toMatchSnapshot();
 
 		// check last column
+		await page.waitForTimeout(300);
 		await page.waitForSelector('.maxi-container-block .maxi-column-block');
 		await page.waitForTimeout(500);
 

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -235,6 +235,93 @@ class MaxiBlockComponent extends Component {
 	}
 
 	componentDidMount() {
+		// If the block is a pattern preview, we need to replace the iframe with an image
+		const previewIframes = getSiteEditorPreviewIframes();
+
+		if (previewIframes.length > 0) {
+			this.isPatternsPreview = true;
+			const disconnectTimeout = 10000; // 10 seconds
+			const timeouts = {};
+			let imgPath =
+				'/wp-content/plugins/maxi-blocks/img/pattern-preview.jpg';
+
+			const linkElement = document.querySelector(
+				'#maxi-blocks-block-css'
+			);
+			const href = linkElement?.getAttribute('href');
+			const pluginsPath = href?.substring(0, href?.lastIndexOf('/build'));
+
+			if (pluginsPath) imgPath = `${pluginsPath}/img/pattern-preview.jpg`;
+			previewIframes.forEach(iframe => {
+				if (!iframe || !iframe.parentNode) return;
+
+				if (
+					this.hasParentWithClass(
+						iframe.parentNode,
+						'maxiblocks-custom-pattern'
+					)
+				)
+					return;
+
+				const replaceIframeWithImage = (iframe, observer) => {
+					const iframeDocument = iframe.contentDocument;
+					if (!iframeDocument) return;
+					const iframeBody = iframeDocument.body;
+					if (!iframeBody) return;
+
+					// Clear the timeout when the iframe mutates
+					clearTimeout(timeouts[iframe]);
+					timeouts[iframe] = setTimeout(() => {
+						observer.disconnect();
+						delete timeouts[iframe];
+					}, disconnectTimeout);
+					// Check if the iframe content is fully loaded
+					const containsMaxiBlocksContainer =
+						iframeBody.querySelector(
+							'.is-root-container .maxi-block'
+						);
+
+					if (!containsMaxiBlocksContainer) return; // If not found, skip this iframe
+
+					// Add the pattern preview class to the iframe's parent element
+					iframe.parentNode.classList.add(
+						'maxi-blocks-pattern-preview'
+					);
+
+					const img = document.createElement('img');
+					img.src = imgPath;
+					img.alt = __(
+						'Preview for pattern with MaxiBlocks',
+						'maxi-blocks'
+					);
+					img.style.width = '100%';
+					img.style.height = 'auto';
+
+					iframe.parentNode.replaceChild(img, iframe);
+					// Disconnect the observer
+					observer.disconnect();
+				};
+
+				// Create a new MutationObserver
+				const observer = new MutationObserver(
+					(mutationsList, observer) => {
+						for (const mutation of mutationsList) {
+							replaceIframeWithImage(mutation.target, observer);
+						}
+					}
+				);
+
+				// Configure the observer with the iframe and desired attributes
+				observer.observe(iframe, {
+					attributes: true,
+					childList: true,
+					subtree: true,
+				});
+			});
+			return;
+		}
+		if (this.isPatternsPreview) return;
+
 		// As we can't use a migrator to update relations as we don't have access to other blocks attributes,
 		// setting this snippet here that should act the same way as a migrator
 		const blocksIBRelations = select(
@@ -393,6 +480,7 @@ class MaxiBlockComponent extends Component {
 	 * Prevents rendering
 	 */
 	shouldComponentUpdate(nextProps, nextState) {
+		if (this.isPatternsPreview) return false;
 		// Force rendering the block when SC related values change
 		if (this.scProps) {
 			const SC = select(
@@ -1072,92 +1160,6 @@ class MaxiBlockComponent extends Component {
 
 		this.rootSlot = this.getRootEl(iframe);
 
-		// If the block is a pattern preview, we need to replace the iframe with an image
-		const previewIframes = getSiteEditorPreviewIframes();
-
-		if (previewIframes.length > 0) {
-			this.isPatternsPreview = true;
-			const disconnectTimeout = 10000; // 10 seconds
-			const timeouts = {};
-			let imgPath =
-				'/wp-content/plugins/maxi-blocks/img/pattern-preview.jpg';
-
-			const linkElement = document.querySelector(
-				'#maxi-blocks-block-css'
-			);
-			const href = linkElement?.getAttribute('href');
-			const pluginsPath = href?.substring(0, href?.lastIndexOf('/build'));
-
-			if (pluginsPath) imgPath = `${pluginsPath}/img/pattern-preview.jpg`;
-			previewIframes.forEach(iframe => {
-				if (!iframe || !iframe.parentNode) return;
-
-				if (
-					this.hasParentWithClass(
-						iframe.parentNode,
-						'maxiblocks-custom-pattern'
-					)
-				)
-					return;
-
-				const replaceIframeWithImage = (iframe, observer) => {
-					const iframeDocument = iframe.contentDocument;
-					if (!iframeDocument) return;
-					const iframeBody = iframeDocument.body;
-					if (!iframeBody) return;
-
-					// Clear the timeout when the iframe mutates
-					clearTimeout(timeouts[iframe]);
-					timeouts[iframe] = setTimeout(() => {
-						observer.disconnect();
-						delete timeouts[iframe];
-					}, disconnectTimeout);
-					// Check if the iframe content is fully loaded
-					const containsMaxiBlocksContainer =
-						iframeBody.querySelector(
-							'.is-root-container .maxi-block'
-						);
-
-					if (!containsMaxiBlocksContainer) return; // If not found, skip this iframe
-
-					// Add the pattern preview class to the iframe's parent element
-					iframe.parentNode.classList.add(
-						'maxi-blocks-pattern-preview'
-					);
-
-					const img = document.createElement('img');
-					img.src = imgPath;
-					img.alt = __(
-						'Preview for pattern with MaxiBlocks',
-						'maxi-blocks'
-					);
-					img.style.width = '100%';
-					img.style.height = 'auto';
-
-					iframe.parentNode.replaceChild(img, iframe);
-					// Disconnect the observer
-					observer.disconnect();
-				};
-
-				// Create a new MutationObserver
-				const observer = new MutationObserver(
-					(mutationsList, observer) => {
-						for (const mutation of mutationsList) {
-							replaceIframeWithImage(mutation.target, observer);
-						}
-					}
-				);
-
-				// Configure the observer with the iframe and desired attributes
-				observer.observe(iframe, {
-					attributes: true,
-					childList: true,
-					subtree: true,
-				});
-			});
-			return;
-		}
-
 		let obj;
 		let breakpoints;
 		let customDataRelations;
@@ -1182,7 +1184,7 @@ class MaxiBlockComponent extends Component {
 		if (document.body.classList.contains('maxi-blocks--active')) {
 			const isSiteEditor = getIsSiteEditor();
 
-			if (this.rootSlot && !this.isPatternsPreview) {
+			if (this.rootSlot) {
 				const styleComponent = (
 					<StyleComponent
 						uniqueID={uniqueID}


### PR DESCRIPTION
# Description

Optimizes FSE image previews and navigation on FSE preview pages.

![307823044-81d0ba55-e75a-47af-80f3-ba999030202d](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/e511c348-d951-4ceb-9fe5-0d5b71055aa2)

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

 -   [ ] Test Patterns preview page
-   [ ]  Navigate back and forth in the Editor
-   [ ]  Check that the FSE still works as expected
-   [ ]  Check that only patterns with maxi blocks inside have the image as the preview
-   [ ]  Check that the Patterns page with the preview is not freezing 
-   [ ] Check that Pattern Duplicate and Remove works

**_ Pre-Code Testing _**

 -   [ ] Test Patterns preview page
-   [ ]  Navigate back and forth in the Editor
-   [ ]  Check that the FSE still works as expected
-   [ ]  Check that only patterns with maxi blocks inside have the image as the preview
-   [ ]  Check that the Patterns page with the preview is not freezing 
-   [ ] Check that Pattern Duplicate and Remove works
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced efficiency in handling pattern previews within the MaxiBlock component, now replacing iframes with images for better resource management.
    - Adjusted rendering behavior based on pattern preview status for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->