### PR TITLE
Issue 5512 - ensure text remains visible during webfont load

### DIFF
--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -210,11 +210,9 @@ class MaxiBlocks_Local_Fonts
                 }
             }
 
-            // Add display=swap to the font URL
             $font_url .= '&display=swap';
         } else {
-            // Add display=swap to the font URL
-            $font_url .= '&display=swap';
+            $font_url .= 'display=swap';
             $font_url = rtrim($font_url, ':');
         }
 

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -209,7 +209,12 @@ class MaxiBlocks_Local_Fonts
                     $font_url .= 'wght@400';
                 }
             }
+
+            // Add display=swap to the font URL
+            $font_url .= '&display=swap';
         } else {
+            // Add display=swap to the font URL
+            $font_url .= '&display=swap';
             $font_url = rtrim($font_url, ':');
         }
 

--- a/src/extensions/text/fonts/loadFonts.js
+++ b/src/extensions/text/fonts/loadFonts.js
@@ -85,10 +85,6 @@ const loadFonts = (font, backendOnly = true, target = document) => {
 						: fontName
 				).replaceAll("''", "'");
 
-				fontDataNew = {
-					...fontDataNew,
-				};
-
 				const fontLoad = new FontFace(
 					cleanFontName,
 					`url(${url})`,

--- a/src/extensions/text/fonts/loadFonts.js
+++ b/src/extensions/text/fonts/loadFonts.js
@@ -46,6 +46,11 @@ const loadFonts = (font, backendOnly = true, target = document) => {
 				fontDataNew = { ...fontData, ...{ weight: fontWeight } };
 			}
 
+			fontDataNew = {
+				...fontDataNew,
+				...{ display: 'swap' },
+			};
+
 			let fontStyleArr = [];
 
 			if (Array.isArray(fontStyle) && !isEmpty(fontStyle)) {
@@ -79,6 +84,10 @@ const loadFonts = (font, backendOnly = true, target = document) => {
 						? `'${fontName}'`
 						: fontName
 				).replaceAll("''", "'");
+
+				fontDataNew = {
+					...fontDataNew,
+				};
 
 				const fontLoad = new FontFace(
 					cleanFontName,


### PR DESCRIPTION
# Description
Added `display: swap` to fonts on editor and frontend. 
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5512

# How Has This Been Tested?
Checked that there is display swap in font load link on frontend, you can search by `maxi-blocks-styles-font` to find it, also lighthouse should show that the accessibility issue is fixed, but it doesn't show up for me there neither on master nor on this brunch.

![image](https://github.com/maxi-blocks/maxi-blocks/assets/53875005/2ec73741-45f5-4210-96d4-b52a70fc1493)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check if font load link has display swap
-   [ ] Check accessibility in lighthouse

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved font data management for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->