### PR TITLE
Prevent infinite 'IB effects' migration

### DIFF
--- a/src/extensions/styles/migrators/IBEffectsMigrator.js
+++ b/src/extensions/styles/migrators/IBEffectsMigrator.js
@@ -51,7 +51,9 @@ const isEligible = blockAttributes =>
 	!!blockAttributes?.relations &&
 	blockAttributes.relations.some(relation => {
 		const transitionSetting = getIBDataItem(relation);
+
 		return (
+			!relation.migrated &&
 			transitionSetting &&
 			settingsToMigrate.some(({ isEligible }) =>
 				isEligible(transitionSetting, relation)
@@ -68,9 +70,11 @@ const migrate = newAttributes => {
 		if (!transitionSetting) return;
 		settingsToMigrate.forEach(
 			({ key, attributeKey, attributeValue, isEligible }) => {
-				if (isEligible(transitionSetting, relation))
+				if (isEligible(transitionSetting, relation)) {
 					relations[i].effects[attributeKey ?? key] =
 						attributeValue ?? transitionSetting[key];
+					relations[i].migrated = true;
+				} else relations[i].migrated = true;
 			}
 		);
 	});


### PR DESCRIPTION
# Description

Makes sure the 'IB effects' migrator runs only once when we load a pattern from the cloud, not each time we open an editor with blocks with relations.

# How Has This Been Tested?

1. Add a page with a lot of IB from the cloud, "About Page Pro ATP-PRO-01" is ok.
2. Note the 4 times the migrator ran in the console: 
![screenshot-private-user-images githubusercontent com-2024 04 04-19_50_14](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/2230fa51-3715-4284-a691-613d13fce2c1)
3. Save the page, check frontend
4. Edit the page again, the migrator should not run again (it runs each time on master).
5. Check the IB preview 
6. Edit something else on the page, save, check the frontend
7. Check 1-2 more pages with IB effect migrator.
8. Check on FSE, the same way.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal migration process for effects settings in relations to ensure smoother updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->