### PR TITLE
Fix looping Transition migrator

### DIFF
--- a/src/extensions/styles/migrators/transitionMigrator.js
+++ b/src/extensions/styles/migrators/transitionMigrator.js
@@ -13,7 +13,7 @@ import { isNil } from 'lodash';
 /**
  * This migrator is used to ensure transition objects are complete
  */
-const name = 'Transition migrator';
+const name = 'Transition attributes';
 
 const attributes = breakpointAttributesCreator({
 	obj: {
@@ -44,7 +44,8 @@ const isEligible = blockAttributes => {
 
 	const defaultTransitionByBlock =
 		data?.transition ||
-		transitionAttributesCreator({ selectors: data?.customCss?.selectors });
+		transitionAttributesCreator({ selectors: data?.customCss?.selectors })
+			?.transition?.default;
 
 	// Check if all transition keys exist on each transition selector object
 	const allSelectorHasAllTransitions = Object.entries(


### PR DESCRIPTION
# Description

Fixes Transition migrator running every time on editor load.

# How Has This Been Tested?

Test on something like 'Services Page SSP-PRO-07'.
Master: you are going to see at least 3 Transition migrators for groups running in the editor each time you open it.
This branch: should see it once or not at all. Also please check that the transitions still work the same as on master.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the naming and assignment logic in the transition attributes handling for clearer functionality and better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->