### PR TITLE
Issue 5542 - block style bug

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -569,6 +569,7 @@ class MaxiBlockComponent extends Component {
 		}
 
 		this.hideGutenbergPopover();
+		this.getCurrentBlockStyle();
 
 		if (this.maxiBlockDidUpdate)
 			this.maxiBlockDidUpdate(prevProps, prevState, shouldDisplayStyles);

--- a/src/extensions/styles/getBlockStyle.js
+++ b/src/extensions/styles/getBlockStyle.js
@@ -16,13 +16,13 @@ const getBlockStyle = clientId => {
 		getSelectedBlockClientId() ||
 		getFirstMultiSelectedBlockClientId();
 
-	if (getBlockAttributes(id)?.blockStyle)
-		return getBlockAttributes(id).blockStyle;
-
 	const rootClientId = getBlockHierarchyRootClientId(id);
 	const rootAttributes = getBlockAttributes(rootClientId);
 
 	if (getBlockAttributes(id)?.blockStyle) return rootAttributes?.blockStyle;
+
+	if (getBlockAttributes(id)?.blockStyle)
+		return getBlockAttributes(id).blockStyle;
 
 	return 'light';
 };

--- a/src/extensions/styles/getBlockStyle.js
+++ b/src/extensions/styles/getBlockStyle.js
@@ -19,7 +19,7 @@ const getBlockStyle = clientId => {
 	const rootClientId = getBlockHierarchyRootClientId(id);
 	const rootAttributes = getBlockAttributes(rootClientId);
 
-	if (getBlockAttributes(id)?.blockStyle) return rootAttributes?.blockStyle;
+	if (rootAttributes?.blockStyle) return rootAttributes?.blockStyle;
 
 	if (getBlockAttributes(id)?.blockStyle)
 		return getBlockAttributes(id).blockStyle;


### PR DESCRIPTION
# Description
The style saved in block attributes was prioritized over the parent block's style. 
Since we can't change block style of children blocks, the parent's block style should be prioritized, which is the fix I did here.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5542 

# How Has This Been Tested?
Checked with creating new blocks, moving blocks between containers.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check creating new blocks in dark container.
-   [x] Check moving blocks from container to container.

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] My changes generate no new warnings/errors
-   [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Reordered conditional checks for `blockStyle` retrieval to prioritize root block attributes before falling back to current block's attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->