### PR TITLE
Fix ACF image not loading on frontend

### DIFF
--- a/core/blocks/class-maxi-block.php
+++ b/core/blocks/class-maxi-block.php
@@ -97,7 +97,6 @@ if (!class_exists('MaxiBlocks_Block')):
             ],
             'dc-source' => [
                 'type' => 'string',
-                'default' => 'wp',
             ],
             'dc-type' => [
                 'type' => 'string',

--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -968,7 +968,18 @@ if (!class_exists('MaxiBlocks_API')):
                 return null;
             }
 
-            return json_encode(get_field_object($request['field_id'], $request['post_id'])['value']);
+            $field = get_field_object($request['field_id'], $request['post_id']);
+
+            if ($field['type'] === 'image') {
+                return json_encode(
+                    [
+                        'value' => $field['value'],
+                        'return_format' => $field['return_format']
+                    ]
+                );
+            }
+
+            return json_encode($field['value']);
         }
 
         public function get_maxi_blocks_pro_status()

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -750,7 +750,9 @@ class MaxiBlocks_DynamicContent
 
         // Get media ID
         if ($dc_source === 'acf') {
-            $media_id = self::get_acf_content($attributes);
+            $image = self::get_acf_content($attributes);
+            $media_id = $image['id'] ?? '';
+            $media_src = $image['url'] ?? '';
         } elseif (in_array($dc_type, array_merge(['posts', 'pages'], $this->get_custom_post_types()))) { // Post or page
             $post = $this->get_post($attributes);
 
@@ -1615,10 +1617,16 @@ class MaxiBlocks_DynamicContent
                 }, $acf_value));
                 break;
             case 'image':
-                if (is_array($acf_value) && isset($acf_value['id'])) {
-                    $content = $acf_value['id'];
+                if ($acf_data['return_format'] === 'url') {
+                    $content = [
+                        'url' => $acf_value,
+                    ];
+                } elseif ($acf_data['return_format'] === 'id') {
+                    $content = [
+                        'id' => $acf_value,
+                    ];
                 } else {
-                    $content = '';
+                    $content = $acf_value;
                 }
                 break;
             default:

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -1615,7 +1615,11 @@ class MaxiBlocks_DynamicContent
                 }, $acf_value));
                 break;
             case 'image':
-                $content = $acf_value['id'];
+                if (is_array($acf_value) && isset($acf_value['id'])) {
+                    $content = $acf_value['id'];
+                } else {
+                    $content = '';
+                }
                 break;
             default:
                 $content = $acf_value;

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -750,8 +750,7 @@ class MaxiBlocks_DynamicContent
 
         // Get media ID
         if ($dc_source === 'acf') {
-            $image = self::get_acf_content($attributes);
-            $media_id = is_array($image) && $image['id'];
+            $media_id = self::get_acf_content($attributes);
         } elseif (in_array($dc_type, array_merge(['posts', 'pages'], $this->get_custom_post_types()))) { // Post or page
             $post = $this->get_post($attributes);
 
@@ -1614,6 +1613,9 @@ class MaxiBlocks_DynamicContent
                 $content = implode("$dc_delimiter ", array_map(function ($item) {
                     return is_array($item) ? $item['label'] : $item;
                 }, $acf_value));
+                break;
+            case 'image':
+                $content = $acf_value['id'];
                 break;
             default:
                 $content = $acf_value;


### PR DESCRIPTION
# Description

From support: On a local install I have dynamic content with ACF and picture field. On the editor the pictures load fine. On front end they are blank spaces. 
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

# How to reproduce?
If you add ACF image, it doesn't load on frontend on master:
![image](https://github.com/maxi-blocks/maxi-blocks/assets/53875005/a8b8e73d-b7cc-4e63-a38e-99362b275c2c)
On this branch, it should load:
![image](https://github.com/maxi-blocks/maxi-blocks/assets/53875005/2faf3d39-9b7b-47c3-ad1f-de7da6ace73e)

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that DC image from ACF loads on frontend on this branch

# Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings/errors
-   [x] I have added/updated tests that prove my fix is effective or that my feature works
-   [x]  New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified the process of obtaining media IDs for dynamic content sources.
	- Enhanced handling for image type content in dynamic content retrieval.
	- Improved flexibility and clarity in media retrieval logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->