### PR TITLE
Fix php warnings

### DIFF
--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -442,7 +442,10 @@ if (!class_exists('MaxiBlocks_API')):
                     $fonts_arr[$key] = json_decode($font, true) ?? [];
                 }
             }
-            $fonts = json_encode(array_merge_recursive(...$fonts_arr));
+            $fonts = '';
+            if (!empty($fonts_arr)) {
+                $fonts = json_encode(array_merge_recursive(...$fonts_arr));
+            }
 
             ['table' => $table, 'where_clause' => $where_clause] = $this->get_query_params('maxi_blocks_styles_blocks');
 
@@ -519,7 +522,7 @@ if (!class_exists('MaxiBlocks_API')):
 
             $updated_meta = [];
 
-            if($id) {
+            if(isset($id) && $id) {
                 $updated_meta = (array)$wpdb->get_results(
                     $wpdb->prepare(
                         "SELECT * FROM $table WHERE $where_clause",

--- a/core/class-maxi-api.php
+++ b/core/class-maxi-api.php
@@ -433,9 +433,8 @@ if (!class_exists('MaxiBlocks_API')):
         {
             global $wpdb;
 
-            $meta = $is_json ? json_decode($data['meta'], true) : $data['meta'];
-            $styles_arr = $is_json ? json_decode($data['styles'], true) : $data['styles'];
-
+            $meta = $is_json && isset($data['meta']) ? json_decode($data['meta'], true) : ($data['meta'] ?? []);
+            $styles_arr = $is_json && isset($data['styles']) ? json_decode($data['styles'], true) : ($data['styles'] ?? []);
             $fonts_arr = $meta['fonts'] ?? [];
             if ($is_json) {
                 foreach ($fonts_arr as $key => $font) {

--- a/core/class-maxi-styles.php
+++ b/core/class-maxi-styles.php
@@ -997,14 +997,18 @@ class MaxiBlocks_Styles
 
             $api = new MaxiBlocks_API();
 
+            $styles = isset($home_content['css_value']) && is_string($home_content['css_value']) ? $home_content['css_value'] : '';
+            $fonts_value = isset($home_content['fonts_value']) && is_string($home_content['fonts_value']) ? json_decode($home_content['fonts_value'], true) : [];
+            $template_parts = isset($home_content['template_parts']) && is_array($home_content['template_parts']) ? $home_content['template_parts'] : [];
+
             $api->post_maxi_blocks_styles([
                 'id' => $front_page_id,
                 'meta' => [
-                    'styles' => $home_content['css_value'],
-                    'fonts' => [json_decode($home_content['fonts_value'], true)],
+                    'styles' => $styles,
+                    'fonts' => [$fonts_value],
                 ],
                 'isTemplate' => true,
-                'templateParts' => $home_content['template_parts'],
+                'templateParts' => $template_parts,
                 'update' => true,
             ], false);
 


### PR DESCRIPTION
# Description

Fixes PHP Warnings and Errors:

PHP Warning:  Undefined variable $id in /maxi-blocks/core/class-maxi-api.php on line 522
PHP Warning:  Undefined array key "styles" in /maxi-blocks/core/class-maxi-api.php on line 437
PHP Fatal error:  Uncaught TypeError: array_merge_recursive(): Argument #1 must be of type array, null given in /maxi-blocks/core/class-maxi-api.php:445
PHP Warning:  Trying to access array offset on value of type bool in /maxi-blocks/core/class-maxi-styles.php on line 1007
PHP Deprecated:  json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in class-maxi-styles.php on line 1004
PHP Warning:  Trying to access array offset on value of type bool in class-maxi-styles.php on line 1004
PHP Warning:  Trying to access array offset on value of type bool in class-maxi-styles.php on line 1003


# How Has This Been Tested?

The warnings are hard to re-create, just make sure they are not present when you are saving, editing, opening frontend, and especially working with FSE. And that styles and scripts, IB, DC works.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved JSON decoding and handling of fonts in the API to prevent errors with empty arrays.
  
- **Refactor**
	- Enhanced code readability and efficiency in setting the home page styles, ensuring smoother styling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->