### PR TITLE
Issue 5577: dc content

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -610,7 +610,7 @@ class MaxiBlocks_DynamicContent
         ) = $attributes;
 
         $post = self::get_post($attributes);
-        if($post && $this->is_repeated_post(self::get_post($attributes)->ID, $dc_accumulator, $attributes)) {
+        if($post && $this->is_repeated_post(self::get_post($attributes)->ID, $dc_accumulator)) {
             return '';
         }
 
@@ -629,7 +629,7 @@ class MaxiBlocks_DynamicContent
         } elseif (array_key_exists('dc-type', $attributes) && $attributes['dc-type'] === 'settings') {
             $link = get_home_url();
         } elseif (array_key_exists('dc-type', $attributes) && in_array($attributes['dc-type'], array_merge(['categories', 'tags'], $this->get_custom_taxonomies()))) {
-            if($this->is_repeated_post($attributes['dc-id'], $dc_accumulator, $attributes)) {
+            if($this->is_repeated_post($attributes['dc-id'], $dc_accumulator)) {
                 return '';
             }
             $link = get_term_link($attributes['dc-id']);
@@ -660,7 +660,7 @@ class MaxiBlocks_DynamicContent
         } else {
             $post = self::get_post($attributes);
 
-            if($this->is_repeated_post($post->ID, $dc_accumulator, $attributes)) {
+            if($this->is_repeated_post($post->ID, $dc_accumulator)) {
                 return '';
             }
 
@@ -696,7 +696,7 @@ class MaxiBlocks_DynamicContent
 
             $post = $this->get_post($attributes);
 
-            if (is_null($post) || $this->is_repeated_post($post->ID, $dc_accumulator, $attributes)) {
+            if (is_null($post) || $this->is_repeated_post($post->ID, $dc_accumulator)) {
                 return '';
             }
 
@@ -800,7 +800,7 @@ class MaxiBlocks_DynamicContent
             $post = $this->get_post($attributes);
 
             if (!empty($post)) {
-                if($this->is_repeated_post($post->ID, $dc_accumulator, $attributes)) {
+                if($this->is_repeated_post($post->ID, $dc_accumulator)) {
                     return '';
                 }
                 if ($dc_field === 'featured_media') {
@@ -1241,7 +1241,7 @@ class MaxiBlocks_DynamicContent
             'dc-accumulator' => $dc_accumulator,
         ) = $attributes;
 
-        if($this->is_repeated_post($post_id, $dc_accumulator, $attributes)) {
+        if($this->is_repeated_post($post_id, $dc_accumulator)) {
             return '';
         }
 
@@ -1281,7 +1281,7 @@ class MaxiBlocks_DynamicContent
             return '';
         }
 
-        if($this->is_repeated_post($post->ID, $dc_accumulator, $attributes)) {
+        if($this->is_repeated_post($post->ID, $dc_accumulator)) {
             return '';
         }
 
@@ -1319,7 +1319,15 @@ class MaxiBlocks_DynamicContent
             }
 
             // Limit content
-            $post_data = self::get_limited_string($post_data, $dc_limit);
+            if(isset($dc_limit) && $dc_limit > 0) {
+                $post_data = wp_strip_all_tags($post_data);
+
+                // Ensures no double or more line breaks
+                $post_data = preg_replace("/[\r\n]+/", "\n", $post_data);
+                $post_data = preg_replace("/\n{2,}/", "\n", $post_data);
+                $post_data = nl2br($post_data);
+                $post_data = self::get_limited_string($post_data, $dc_limit);
+            }
 
         }
 
@@ -1391,7 +1399,7 @@ class MaxiBlocks_DynamicContent
         $post_id = $post->ID;
         $dc_accumulator = $attributes['dc-accumulator'];
 
-        if($this->is_repeated_post($post_id, $dc_accumulator, $attributes)) {
+        if($this->is_repeated_post($post_id, $dc_accumulator)) {
             return 0;
         }
 
@@ -1510,7 +1518,7 @@ class MaxiBlocks_DynamicContent
         }
 
         if($term) {
-            if($this->is_repeated_post($term->term_id, $dc_accumulator, $attributes)) {
+            if($this->is_repeated_post($term->term_id, $dc_accumulator)) {
                 return null;
             }
             if ($dc_field === 'link') {

--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -2153,7 +2153,7 @@ class MaxiBlocks_DynamicContent
      * @param string|null $dc_accumulator The dynamic content accumulator string.
      * @return bool True if the post is repeated, false otherwise.
      */
-    private function is_repeated_post($post_id, $dc_accumulator, $attributes)
+    private function is_repeated_post($post_id, $dc_accumulator)
     {
 
         // Check if either $post_id or $dc_accumulator is not set


### PR DESCRIPTION
# Description

A compromise: if we have a character limit for the DC content, we strip all the tags and show text only according to the limit: 

![screenshot-wordpress local-2024 05 07-17_08_46](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/73c8e8e1-83e6-4ff3-ac63-093013811501)

If we don't have the character limit (or it's 0 to show all), we keep the tags (headers, links, etc.) and show everything. This is mostly for Post templates:

![screenshot-wordpress local-2024 05 07-17_17_40](https://github.com/maxi-blocks/maxi-blocks/assets/2401618/a7c186e0-752b-459a-8518-19efbfbd638c)

Fixes #5577

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified method calls by removing unnecessary parameters across various content rendering functions.
- **New Features**
  - Enhanced content manipulation in the `get_post_or_page_content` method to include limits and formatting, improving content presentation and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->