### PR TITLE
Issue 5581 - Fix list-item-maxi double link

### DIFF
--- a/src/blocks/list-item-maxi/index.js
+++ b/src/blocks/list-item-maxi/index.js
@@ -32,7 +32,10 @@ import { textIcon } from '../../icons';
 /**
  * Migrators
  */
-import { blockMigrator } from '../../extensions/styles/migrators';
+import {
+	blockMigrator,
+	listItemDoubleLinkMigrator,
+} from '../../extensions/styles/migrators';
 
 /**
  * Block
@@ -53,6 +56,7 @@ registerBlockType(metadata, {
 		attributes,
 		save,
 		selectors: customCss.selectors,
+		migrators: [listItemDoubleLinkMigrator],
 	}),
 	customCss,
 	scProps,

--- a/src/extensions/save/index.js
+++ b/src/extensions/save/index.js
@@ -27,7 +27,6 @@ const allowedBlocks = [
 	'maxi-blocks/video-maxi',
 	'maxi-blocks/accordion-maxi',
 	'maxi-blocks/search-maxi',
-	'maxi-blocks/list-item-maxi',
 ];
 
 /**

--- a/src/extensions/styles/migrators/index.js
+++ b/src/extensions/styles/migrators/index.js
@@ -2,6 +2,7 @@ export { default as blockMigrator } from './blockMigrator';
 export { default as buttonAriaLabelMigrator } from './buttonAriaLabelMigrator';
 export { default as buttonIconTransitionMigrator } from './buttonIconTransitionMigrator';
 export { default as listBrMigrator } from './listBrMigrator';
+export { default as listItemDoubleLinkMigrator } from './listItemDoubleLinkMigrator';
 export { default as listItemMigrator } from './listItemMigrator';
 export { default as shapeDividerMigrator } from './shapeDividerMigrator';
 export { default as SVGTransitionMigrator } from './SVGTransitionMigrator';

--- a/src/extensions/styles/migrators/listItemDoubleLinkMigrator.js
+++ b/src/extensions/styles/migrators/listItemDoubleLinkMigrator.js
@@ -1,0 +1,107 @@
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getMaxiBlockAttributes,
+	MaxiBlock,
+} from '../../../components/maxi-block';
+import { WithLink } from '../../save/utils';
+
+const name = 'List item double link';
+
+const maxiVersions = [
+	'0.1',
+	'0.0.1-SC1',
+	'0.0.1-SC2',
+	'0.0.1-SC3',
+	'0.0.1-SC4',
+	'0.0.1-SC5',
+	'0.0.1-SC6',
+	'1.0.0-RC1',
+	'1.0.0-RC2',
+	'1.0.0-beta',
+	'1.0.0-beta-2',
+	'wp-directory-beta-1',
+	'1.0.0',
+	'1.0.1',
+	'1.1.0',
+	'1.1.1',
+	'1.2.0',
+	'1.2.1',
+	'1.3',
+	'1.3.1',
+	'1.4.1',
+	'1.4.2',
+	'1.5.0',
+	'1.5.1',
+	'1.5.2',
+	'1.5.3',
+	'1.5.4',
+	'1.5.5',
+	'1.5.6',
+	'1.5.7',
+	'1.5.8',
+	'1.6.0',
+	'1.6.1',
+	'1.7.0',
+	'1.7.1',
+	'1.7.2',
+	'1.7.3',
+	'1.8.0',
+	'1.8.1',
+	'1.8.2',
+	'1.8.3',
+	'1.8.4',
+];
+
+const isEligible = blockAttributes => {
+	const {
+		'maxi-version-origin': maxiVersionOrigin,
+		'maxi-version-current': maxiVersionCurrent,
+	} = blockAttributes;
+
+	return maxiVersions.includes(maxiVersionCurrent) || !maxiVersionOrigin;
+};
+
+// 1.8.4 List-item-maxi version https://github.com/maxi-blocks/maxi-blocks/blob/afb972544e9ab29a2f74aab6a42f256ae07cb081/src/blocks/list-item-maxi/save.js
+const save = props => {
+	const {
+		content,
+		listReversed,
+		listStart,
+		'dc-status': dcStatus,
+		ariaLabels = {},
+		linkSettings,
+	} = props.attributes;
+
+	const name = 'maxi-blocks/list-item-maxi';
+	const className = 'maxi-list-item-block__content';
+
+	return (
+		<WithLink linkSettings={linkSettings}>
+			<MaxiBlock.save
+				tagName='li'
+				{...getMaxiBlockAttributes({ ...props, name })}
+				aria-label={ariaLabels['list item wrapper']}
+			>
+				<RichText.Content
+					className={className}
+					value={content}
+					tagName='div'
+					aria-label={ariaLabels['list item']}
+					{...(!dcStatus && {
+						reversed: !!listReversed,
+						start: listStart,
+					})}
+				/>
+			</MaxiBlock.save>
+		</WithLink>
+	);
+};
+
+export default { name, isEligible, save };


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5581 

### NOTE: written migrator runs every time on blocks with version ≤ 1.8.4 

# How Has This Been Tested?
- Reproduced steps from issue
- Tested if migrator works:

https://github.com/maxi-blocks/maxi-blocks/assets/46112160/eb6c076a-86f6-42c0-89c5-10e924fbddc3

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test if link isn't doubles in list-item
-   [ ] Test if migrator works (create some list-item with broken(doubled) links on master and switch to this branch)

# Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] My changes generate no new warnings/errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for double linking in list items, enhancing link management within blocks.

- **Improvements**
  - Enhanced block migration capabilities, ensuring smoother transitions and better data handling for list item blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->