### PR TITLE
Issue 5648 - Fix custom fonts not loading on frontend

### DIFF
--- a/src/extensions/text/fonts/test/utils.js
+++ b/src/extensions/text/fonts/test/utils.js
@@ -1,0 +1,117 @@
+import { getAllFonts } from '..';
+
+// Return mock values from style cards
+jest.mock('src/extensions/text/formats/index.js', () => ({
+	getCustomFormatValue: jest.fn(({ prop }) => {
+		switch (prop) {
+			case 'font-family':
+				return 'Roboto';
+			case 'font-weight':
+				return 400;
+			case 'font-style':
+				return 'normal';
+			default:
+				return '';
+		}
+	}),
+}));
+jest.mock('@wordpress/data', () => {
+	return {
+		select: jest.fn(() => {
+			return {
+				receiveMaxiSelectedStyleCard: jest.fn(() => {}),
+			};
+		}),
+	};
+});
+jest.mock('src/extensions/styles/index.js', () => {
+	return {
+		getGroupAttributes: jest.fn(() => {}),
+	};
+});
+jest.mock('src/extensions/maxi-block/index', () => {
+	return {
+		goThroughMaxiBlocks: jest.fn(() => {}),
+	};
+});
+
+describe('getAllFonts', () => {
+	it('Should return an object with all fonts', () => {
+		const attributes = {
+			'font-family-general': 'Arial',
+			'font-weight-general': '600',
+			'font-style-general': 'italic',
+		};
+		const result = getAllFonts(attributes);
+		expect(result).toEqual({
+			Arial: {
+				weight: '600',
+				style: 'italic',
+			},
+			Roboto: {
+				weight: '400',
+				style: 'normal',
+			},
+		});
+	});
+
+	it('Should fallback to SC when no font is set', () => {
+		const attributes = {};
+		const result = getAllFonts(attributes);
+		expect(result).toEqual({
+			Roboto: {
+				weight: '400',
+				style: 'normal',
+			},
+		});
+	});
+
+	it('Should return an object with all fonts on responsive', () => {
+		const attributes = {
+			'font-family-general': 'Arial',
+			'font-family-xxl': 'Arial Black',
+			'font-family-m': 'Roboto',
+		};
+		const result = getAllFonts(attributes);
+		expect(result).toEqual({
+			Arial: {
+				weight: '400',
+				style: 'normal',
+			},
+			'Arial Black': {
+				weight: undefined,
+				style: undefined,
+			},
+			Roboto: {
+				weight: '400',
+				style: 'normal',
+			},
+		});
+	});
+
+	it('Should work with custom formats', () => {
+		const attributes = {
+			'font-family-general': 'Railway',
+			'custom-formats': {
+				'custom-format--1': {
+					'font-family-general': 'Oswald',
+				},
+			},
+		};
+		const result = getAllFonts(attributes, 'custom-formats');
+		expect(result).toEqual({
+			Railway: {
+				weight: '400',
+				style: 'normal',
+			},
+			Oswald: {
+				weight: '400',
+				style: 'normal',
+			},
+			Roboto: {
+				weight: '400',
+				style: 'normal',
+			},
+		});
+	});
+});

--- a/src/extensions/text/fonts/utils.js
+++ b/src/extensions/text/fonts/utils.js
@@ -263,7 +263,7 @@ export const getPageFonts = (onlyBackend = false) => {
 				response = mergeDeep(
 					getAllFonts(
 						typography,
-						false,
+						'custom-formats',
 						false,
 						textLevel,
 						blockStyle,
@@ -271,7 +271,7 @@ export const getPageFonts = (onlyBackend = false) => {
 					),
 					getAllFonts(
 						typographyHover,
-						false,
+						'custom-formats',
 						true,
 						textLevel,
 						blockStyle,
@@ -281,7 +281,7 @@ export const getPageFonts = (onlyBackend = false) => {
 			else
 				response = getAllFonts(
 					typography,
-					false,
+					'custom-formats',
 					false,
 					textLevel,
 					blockStyle,


### PR DESCRIPTION
# Description
Fonts from custom formats weren't saved in block styles, fixed that.
Added tests to ensure this doesn't happen in the future.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5648 

# How Has This Been Tested?
On master checked that text maxi with font in custom format doesn't load that font,
then updated the page on this branch in editor, and checked frontend.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that fonts from custom formats load on frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a function to retrieve font attributes based on input parameters, enhancing font management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->