### PR TITLE
Issue 5486 - Hide "ACF Field" dropdown for CL

### DIFF
--- a/src/components/dynamic-content/acf-settings-control/index.js
+++ b/src/components/dynamic-content/acf-settings-control/index.js
@@ -51,20 +51,22 @@ const ACFSettingsControl = props => {
 					})
 				}
 			/>
-			<SelectControl
-				label='ACF Field'
-				value={field}
-				options={fieldsOptions}
-				newStyle
-				onChange={value =>
-					onChange({
-						[`${prefix}field`]: value,
-						[`${prefix}acf-field-type`]: fieldsOptions.find(
-							option => option.value === value
-						).type,
-					})
-				}
-			/>
+			{!isCL && (
+				<SelectControl
+					label='ACF Field'
+					value={field}
+					options={fieldsOptions}
+					newStyle
+					onChange={value =>
+						onChange({
+							[`${prefix}field`]: value,
+							[`${prefix}acf-field-type`]: fieldsOptions.find(
+								option => option.value === value
+							).type,
+						})
+					}
+				/>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
# Description
This fix is for the last comment from the issue: https://github.com/maxi-blocks/maxi-blocks/issues/5486#issuecomment-2194696223.

Removed "ACF field" dropdown for CL, because it doesn't make sense to be there. The change is purely visual, so no need to check the functionality of CL or DC here.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5486 

# How Has This Been Tested?
Checked that "ACF field" dropdown doesn't appear in CL.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that "ACF field" dropdown doesn't appear in CL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `ACFSettingsControl` component to conditionally display the "ACF Field" selection control based on specific criteria, enhancing user interaction.
  
- **Bug Fixes**
	- Improved user interface behavior by ensuring the selection control is only available when applicable, preventing potential confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->