### PR TITLE
Issue 5457 - Fix insert button disappearing when using DC link in icon maxi

### DIFF
--- a/src/components/toolbar/components/media-upload/index.js
+++ b/src/components/toolbar/components/media-upload/index.js
@@ -53,16 +53,15 @@ const ToolbarMediaUpload = props => {
 		uniqueID,
 		'dc-status': dcStatus,
 	} = attributes;
+	const isIcon = blockName === 'maxi-blocks/svg-icon-maxi';
 
 	if (
 		!ALLOWED_BLOCKS.includes(blockName) ||
-		dcStatus ||
+		(dcStatus && !isIcon) ||
 		playerType === 'video' ||
 		hideImage
 	)
 		return null;
-
-	const isIcon = blockName === 'maxi-blocks/svg-icon-maxi';
 
 	return (
 		<div className='toolbar-item toolbar-item__replace-image'>


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5457

# How Has This Been Tested?
Checked that icon-maxi with DC link enabled still has 'Insert' option in toolbar.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that icon-maxi with DC link enabled still has 'Insert' option in toolbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering behavior for the media upload component, allowing icons to display even when a specific status is present.
  
- **Bug Fixes**
	- Refined conditional logic to enhance user interface consistency across different block types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->