### PR TITLE
Issue 5701 - add limit option to all text fields

### DIFF
--- a/src/extensions/DC/constants.js
+++ b/src/extensions/DC/constants.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { select } from '@wordpress/data';
 
 /**
  * Source constants
@@ -658,6 +657,10 @@ export const limitTypes = [
 	'products',
 	'product_categories',
 	'product_tags',
+	'users',
+	'media',
+	'settings',
+	'archive',
 ];
 
 export const limitFields = [
@@ -665,6 +668,11 @@ export const limitFields = [
 	'content',
 	'description',
 	'short_description',
+	'title',
+	'tagline',
+	'caption',
+	'alt_text',
+	'name',
 ];
 
 export const limitOptions = {

--- a/src/extensions/DC/getWCContent.js
+++ b/src/extensions/DC/getWCContent.js
@@ -47,6 +47,7 @@ const getProductsContent = async (dataRequest, entityData) => {
 
 	switch (field) {
 		case 'name':
+			return limitString(data[field]?.toString(), limit);
 		case 'slug':
 		case 'review_count':
 		case 'average_rating':


### PR DESCRIPTION
# Description
Added limit input to all text fields which need it. Let me know if I missed anything.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5701

# How Has This Been Tested?
Checked that all the text fields that need limit option have one. Checked that limit works for all of them.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that all the text fields that need limit option have one
-   [ ] Check that limit works for all of them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the range of limit types with new entries: `users`, `media`, `settings`, and `archive`.
	- Introduced additional limit fields: `title`, `tagline`, `caption`, `alt_text`, and `name`.
	- Enhanced handling of the 'name' field to ensure data consistency by applying a character limit.

These updates improve the application's flexibility in data processing and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->