### PR TITLE
Issue 5703 - Fix DC blocks breaking when no tags are found

### DIFF
--- a/src/extensions/DC/getDCContent.js
+++ b/src/extensions/DC/getDCContent.js
@@ -179,11 +179,7 @@ const getDCContent = async (dataRequest, clientId) => {
 		'product_categories',
 	].includes(field);
 
-	if (
-		isCustomTaxonomyField &&
-		!isNil(contentValue) &&
-		!isEmpty(contentValue)
-	) {
+	if (isCustomTaxonomyField) {
 		contentValue = await getTaxonomyContent(
 			contentValue,
 			delimiterContent,


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5703 

# How Has This Been Tested?
Inserted blog pro-03 on the page and checked that the blocks with tags DC don't break.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Insert blog pro-03 on the page and checked that the blocks with tags DC don't break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified logic for processing content in the taxonomy, which may improve handling of custom taxonomy fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->