### PR TITLE
Issue 5663 - Fix tab labels wrapping on second line when selected

### DIFF
--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -68,6 +68,7 @@
 			color: var(--maxi-grey-11-color);
 			background-color: #fff;
 			text-align: center;
+			white-space: nowrap;
 
 			&:last-child {
 				border-right: none;


### PR DESCRIPTION
# Description
Fixed the issue but to reproduce currently had to play with size of the page, seems on normal (laptop) sizes this problem doesn't appear anymore.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5663 

# How Has This Been Tested?
Checked that selected tab in accordion title settings doesn't wrap.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Check that selected tab in accordion title settings doesn't wrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved text layout in the editor by ensuring text remains on a single line, enhancing readability and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->