### PR TITLE
Issue 5660 - fix wrong `RangeControl` value for 0

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -223,8 +223,7 @@ const AdvancedNumberControl = props => {
 		? rawPreferredValues.map(transformRangePreferredValue)
 		: rawPreferredValues;
 
-	const rangeValue =
-		+preferredValues.find(val => /\d/.test(val) && +val !== 0) || 0;
+	const rangeValue = +preferredValues.find(val => /\d/.test(val)) || 0;
 
 	const [showHelpContent, setShowHelpContent] = useState(false);
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5660 

# How Has This Been Tested?
Checked that in transition control, range slider looks right. Also tested that https://github.com/maxi-blocks/maxi-blocks/issues/4052 doesn't appear because this PR removes part of the fix for it.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check that in transition control, range slider looks right
-   [x] Test https://github.com/maxi-blocks/maxi-blocks/issues/4052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `AdvancedNumberControl` component to accept a broader range of values for `rangeValue`, including zero.
- **Impact**
	- This change may affect scenarios where zero was previously excluded, enhancing flexibility in value selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->