### PR TITLE
Issue 5775 - Add rem units to typography control

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -44,6 +44,12 @@ const AdvancedNumberControl = props => {
 			minRange: -300,
 			maxRange: 300,
 		},
+		rem: {
+			min: 0,
+			max: 999,
+			minRange: -300,
+			maxRange: 300,
+		},
 		vw: {
 			min: 0,
 			max: 999,

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -393,6 +393,10 @@ const TypographyControl = props => {
 			min: 0,
 			max: 100,
 		},
+		rem: {
+			min: 0,
+			max: 100,
+		},
 		vw: {
 			min: 0,
 			max: 100,
@@ -413,6 +417,10 @@ const TypographyControl = props => {
 			max: 30,
 		},
 		em: {
+			min: -3,
+			max: 10,
+		},
+		rem: {
 			min: -3,
 			max: 10,
 		},
@@ -699,7 +707,7 @@ const TypographyControl = props => {
 						)
 					}
 					minMaxSettings={minMaxSettings}
-					allowedUnits={['px', 'em', 'vw', '%']}
+					allowedUnits={['px', 'em', 'rem', 'vw', '%']}
 				/>
 				<AdvancedNumberControl
 					className='maxi-typography-control__line-height'
@@ -742,13 +750,13 @@ const TypographyControl = props => {
 							maxRange: 300,
 						},
 					}}
-					allowedUnits={['px', 'em', 'vw', '%', '-']}
+					allowedUnits={['px', 'em', 'rem', 'vw', '%', '-']}
 				/>
 				<AdvancedNumberControl
 					className='maxi-typography-control__letter-spacing'
 					label={__('Letter spacing', 'maxi-blocks')}
 					enableUnit
-					allowedUnits={['px', 'em', 'vw']}
+					allowedUnits={['px', 'em', 'rem', 'vw']}
 					unit={getValue('letter-spacing-unit')}
 					defaultUnit={getDefault('letter-spacing-unit')}
 					onChangeUnit={val => {
@@ -1059,6 +1067,10 @@ const TypographyControl = props => {
 							min: -99,
 							max: 99,
 						},
+						rem: {
+							min: -99,
+							max: 99,
+						},
 						vw: {
 							min: -99,
 							max: 99,
@@ -1068,7 +1080,7 @@ const TypographyControl = props => {
 							max: 100,
 						},
 					}}
-					allowedUnits={['px', 'em', 'vw', '%']}
+					allowedUnits={['px', 'em', 'rem', 'vw', '%']}
 				/>
 				<SelectControl
 					__nextHasNoMarginBottom
@@ -1167,6 +1179,10 @@ const TypographyControl = props => {
 							min: -99,
 							max: 99,
 						},
+						rem: {
+							min: -99,
+							max: 99,
+						},
 						vw: {
 							min: -99,
 							max: 99,
@@ -1176,7 +1192,7 @@ const TypographyControl = props => {
 							max: 100,
 						},
 					}}
-					allowedUnits={['px', 'em', 'vw', '%']}
+					allowedUnits={['px', 'em', 'rem', 'vw', '%']}
 				/>
 				{showBottomGap && (
 					<AdvancedNumberControl
@@ -1231,6 +1247,10 @@ const TypographyControl = props => {
 								min: -99,
 								max: 99,
 							},
+							rem: {
+								min: -99,
+								max: 99,
+							},
 							vw: {
 								min: -99,
 								max: 99,
@@ -1240,7 +1260,7 @@ const TypographyControl = props => {
 								max: 100,
 							},
 						}}
-						allowedUnits={['px', 'em', 'vw', '%']}
+						allowedUnits={['px', 'em', 'rem', 'vw', '%']}
 					/>
 				)}
 				{!hideTextShadow && (

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -346,7 +346,7 @@ body .toolbar-item__popover {
 			margin-bottom: 0;
 
 			.maxi-select-control__input {
-				min-width: 3.2rem;
+				min-width: 3.6rem;
 				max-width: 100%;
 			}
 		}


### PR DESCRIPTION
# Description
Added rem unit to typography settings.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5775 

# How Has This Been Tested?
Checked that the unit looks right on editor and frontend.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that the unit looks right on editor and frontend
-   [ ] Test responsive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced typography control with new properties for managing font size and spacing using `rem` units.
	- Updated unit selection options for font size, line height, letter spacing, text indent, and word spacing.
	- Expanded settings now allow for negative values in text indent and word spacing adjustments.
  
- **Style**
	- Increased minimum width for unit selection controls for improved layout.
	- Added styling adjustments for scrollbar handling and padding fixes in the editor interface.
	- Enhanced flexbox layout for better display control and overflow management in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->