### PR TITLE
Issue 5805: default block

### DIFF
--- a/e2e-tests/components/block-resizer/index.spec.js
+++ b/e2e-tests/components/block-resizer/index.spec.js
@@ -19,13 +19,14 @@ describe('BlockResizer', () => {
 		await insertMaxiBlock(page, 'Number Counter Maxi');
 		await updateAllBlockUniqueIds(page);
 
+		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 		// Remove the maxi-block-inserter__last element
-		await page.evaluate(() => {
-			const element = document.querySelector(
-				'.maxi-block-inserter__last'
-			);
-			if (element) element.remove();
-		});
+		// await page.evaluate(() => {
+		// 	const element = document.querySelector(
+		// 		'.maxi-block-inserter__last'
+		// 	);
+		// 	if (element) element.remove();
+		// });
 
 		const accordionPanel = await openSidebarTab(page, 'style', 'number');
 

--- a/e2e-tests/components/icon/index.spec.js
+++ b/e2e-tests/components/icon/index.spec.js
@@ -18,13 +18,14 @@ describe('Svg Icon Maxi default size', () => {
 		await createNewPost();
 		await insertMaxiBlock(page, 'Icon Maxi');
 
+		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 		// Remove the maxi-block-inserter__last element
-		await page.evaluate(() => {
-			const element = document.querySelector(
-				'.maxi-block-inserter__last'
-			);
-			if (element) element.remove();
-		});
+		// await page.evaluate(() => {
+		// 	const element = document.querySelector(
+		// 		'.maxi-block-inserter__last'
+		// 	);
+		// 	if (element) element.remove();
+		// });
 
 		await modalMock(page, { type: 'svg' });
 		await page.waitForTimeout(500);

--- a/e2e-tests/components/toolbar/components/delete/index.spec.js
+++ b/e2e-tests/components/toolbar/components/delete/index.spec.js
@@ -15,8 +15,6 @@ describe('Delete block', () => {
 
 		await updateAllBlockUniqueIds(page);
 
-		await page.keyboard.type('Block 1', { delay: 100 });
-
 		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 		// await page.waitForTimeout(300);
 		// Remove the maxi-block-inserter__last element content
@@ -29,7 +27,7 @@ describe('Delete block', () => {
 
 		// await page.waitForTimeout(300);
 
-		await page.keyboard.type('Block 1', { delay: 300 });
+		await page.keyboard.type('Block 1', { delay: 100 });
 
 		const textContent = await page.$eval(
 			'.is-root-container.block-editor-block-list__layout',

--- a/e2e-tests/components/toolbar/components/delete/index.spec.js
+++ b/e2e-tests/components/toolbar/components/delete/index.spec.js
@@ -15,17 +15,19 @@ describe('Delete block', () => {
 
 		await updateAllBlockUniqueIds(page);
 
-		await page.waitForTimeout(300);
+		await page.keyboard.type('Block 1', { delay: 100 });
 
+		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+		// await page.waitForTimeout(300);
 		// Remove the maxi-block-inserter__last element content
-		await page.evaluate(() => {
-			const element = document.querySelector(
-				'.maxi-block-inserter__last'
-			);
-			if (element) element.textContent = '';
-		});
+		// await page.evaluate(() => {
+		// 	const element = document.querySelector(
+		// 		'.maxi-block-inserter__last'
+		// 	);
+		// 	if (element) element.textContent = '';
+		// });
 
-		await page.waitForTimeout(300);
+		// await page.waitForTimeout(300);
 
 		await page.keyboard.type('Block 1', { delay: 300 });
 
@@ -48,14 +50,14 @@ describe('Delete block', () => {
 		);
 
 		await page.waitForTimeout(500);
-
+		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 		// Remove the maxi-block-inserter__last element content
-		await page.evaluate(() => {
-			const element = document.querySelector(
-				'.maxi-block-inserter__last'
-			);
-			if (element) element.textContent = '';
-		});
+		// await page.evaluate(() => {
+		// 	const element = document.querySelector(
+		// 		'.maxi-block-inserter__last'
+		// 	);
+		// 	if (element) element.textContent = '';
+		// });
 		// check block not exist
 		const textContentBeforeDelete = await page.$eval(
 			'.is-root-container.block-editor-block-list__layout',

--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -114,24 +114,25 @@
 			}
 		}
 	}
-	&__last {
-		.maxi-block-inserter__button,
-		.maxi-block-inserter__button.is-next-40px-default-size {
-			width: 25px;
-			height: 25px;
-			margin: auto;
-			background: var(--maxi-black-1-color) !important;
-			border: 1px solid var(--maxi-white-3-color);
-			svg {
-				width: 24px;
-				height: 24px;
-			}
-			&:hover,
-			&:focus {
-				background: var(--maxi-secondary-color) !important;
-			}
-		}
-	}
+	// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+	// &__last {
+	// 	.maxi-block-inserter__button,
+	// 	.maxi-block-inserter__button.is-next-40px-default-size {
+	// 		width: 25px;
+	// 		height: 25px;
+	// 		margin: auto;
+	// 		background: var(--maxi-black-1-color) !important;
+	// 		border: 1px solid var(--maxi-white-3-color);
+	// 		svg {
+	// 			width: 24px;
+	// 			height: 24px;
+	// 		}
+	// 		&:hover,
+	// 		&:focus {
+	// 			background: var(--maxi-secondary-color) !important;
+	// 		}
+	// 	}
+	// }
 }
 
 .maxi-wrapper-block-inserter {

--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -143,11 +143,13 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 			setDefaultBlockName('maxi-blocks/text-maxi');
 		} else if (blockName === 'maxi-blocks/container-maxi') {
 			setDefaultBlockName('maxi-blocks/container-maxi');
-		} else if (isPostEditor()) {
-			setDefaultBlockName('maxi-blocks/text-maxi');
-		} else {
-			setDefaultBlockName('maxi-blocks/container-maxi');
 		}
+		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+		// } else if (isPostEditor()) {
+		// 	setDefaultBlockName('maxi-blocks/text-maxi');
+		// } else {
+		// 	setDefaultBlockName('maxi-blocks/container-maxi');
+		// }
 	}
 
 	// Gets if the block has to be disabled due to the device type

--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -141,10 +141,11 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 	if (isSelected) {
 		if (blockName === 'maxi-blocks/text-maxi') {
 			setDefaultBlockName('maxi-blocks/text-maxi');
-		} else if (blockName === 'maxi-blocks/container-maxi') {
-			setDefaultBlockName('maxi-blocks/container-maxi');
 		}
 		// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+		// } else if (blockName === 'maxi-blocks/container-maxi') {
+		// 	setDefaultBlockName('maxi-blocks/container-maxi');
+		// }
 		// } else if (isPostEditor()) {
 		// 	setDefaultBlockName('maxi-blocks/text-maxi');
 		// } else {

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -609,14 +609,14 @@ body.maxi-blocks--active .edit-post-visual-editor {
 	width: 100%;
 	min-width: calc(100vw - var(--maxi-blocks-scrollbar-width, 15px));
 }
+// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+// body.maxi-blocks--active
+// 	.editor-styles-wrapper
+// 	.block-editor-block-list__layout.is-root-container.is-desktop-preview {
+// 	padding-bottom: 40vh;
+// }
 
-body.maxi-blocks--active
-	.editor-styles-wrapper
-	.block-editor-block-list__layout.is-root-container.is-desktop-preview {
-	padding-bottom: 40vh;
-}
-
-body.maxi-blocks--active
-	.editor-styles-wrapper.block-editor-writing-flow:after {
-	display: none;
-}
+// body.maxi-blocks--active
+// 	.editor-styles-wrapper.block-editor-writing-flow:after {
+// 	display: none;
+// }

--- a/src/extensions/dom/dom.js
+++ b/src/extensions/dom/dom.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { select, dispatch, subscribe, resolveSelect } from '@wordpress/data';
-import { setDefaultBlockName } from '@wordpress/blocks';
+// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+// import { setDefaultBlockName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -23,7 +24,8 @@ import {
 	showHideHamburgerNavigation,
 	removeNavigationHoverUnderline,
 } from '../../editor/style-cards/utils';
-import isPostEditor from './isPostEditor';
+// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+// import isPostEditor from './isPostEditor';
 
 /**
  * External dependencies
@@ -512,11 +514,12 @@ wp.domReady(() => {
 		}
 	});
 
-	setTimeout(() => {
-		if (isPostEditor()) {
-			setDefaultBlockName('maxi-blocks/text-maxi');
-		} else {
-			setDefaultBlockName('maxi-blocks/container-maxi');
-		}
-	}, 100);
+	// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+	// setTimeout(() => {
+	// 	if (isPostEditor()) {
+	// 		setDefaultBlockName('maxi-blocks/text-maxi');
+	// 	} else {
+	// 		setDefaultBlockName('maxi-blocks/container-maxi');
+	// 	}
+	// }, 100);
 });

--- a/src/extensions/maxi-block/withMaxiProps.js
+++ b/src/extensions/maxi-block/withMaxiProps.js
@@ -79,7 +79,8 @@ const withMaxiProps = createHigherOrderComponent(
 				isTyping,
 				blockIndex,
 				blockRootClientId,
-				isLastBlock,
+				// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+				// isLastBlock,
 			} = useSelect(select => {
 				const { receiveMaxiDeviceType, receiveBaseBreakpoint } =
 					select('maxiBlocks');
@@ -88,11 +89,13 @@ const withMaxiProps = createHigherOrderComponent(
 					isTyping,
 					getBlockIndex,
 					getBlockRootClientId,
-					getBlocks,
+					// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+					// getBlocks,
 				} = select('core/block-editor');
 
 				const currentBlockIndex = getBlockIndex(clientId);
-				const allBlocks = getBlocks();
+				// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+				// const allBlocks = getBlocks();
 
 				return {
 					deviceType: receiveMaxiDeviceType(),
@@ -101,9 +104,10 @@ const withMaxiProps = createHigherOrderComponent(
 					isTyping: isTyping(),
 					blockIndex: currentBlockIndex,
 					blockRootClientId: getBlockRootClientId(clientId),
-					isLastBlock:
-						attributes?.isFirstOnHierarchy &&
-						currentBlockIndex === allBlocks.length - 1,
+					// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
+					// isLastBlock:
+					// 	attributes?.isFirstOnHierarchy &&
+					// 	currentBlockIndex === allBlocks.length - 1,
 				};
 			});
 
@@ -351,9 +355,10 @@ const withMaxiProps = createHigherOrderComponent(
 							{...ownProps}
 						/>
 					)}
-					{isLastBlock && (
+					{/* TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806 */}
+					{/* {isLastBlock && (
 						<BlockInserter className='maxi-block-inserter maxi-block-inserter__last' />
-					)}
+					)} */}
 				</>
 			);
 		}),


### PR DESCRIPTION
# Description

Reverts the default block back to Gutenberg paragraph. Keeps Text split functionality.
Note: the code was commented out for the future https://github.com/maxi-blocks/maxi-blocks/issues/5806 fix.

Fixes #[5805](https://github.com/maxi-blocks/maxi-blocks/issues/5805)

# How Has This Been Tested?

- Text Block on Enter splits to a new text block
- Empty post / page should have Gutenberg paragraph by default
- Removed all blocks - you should see a Gutenberg paragraph
- Tested on a new page and a new post

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted end-to-end tests for the `BlockResizer`, `Svg Icon Maxi`, and delete functionality to improve interaction with the DOM.
	- Commented out code that previously removed elements from the DOM, indicating potential issues being addressed.

- **Style**
	- Temporarily removed styles related to the `maxi-block-inserter` component, affecting button dimensions and hover states.

- **Refactor**
	- Commented out logic in the `MaxiBlockContent` and `withMaxiProps` components, affecting default block naming and rendering behavior. 

- **Chores**
	- Organized and commented out existing styles in various SCSS files to address potential layout issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->