### PR TITLE
Issue 5813 - Show "Switch tone" button for themes in library

### DIFF
--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -517,7 +517,9 @@ const LibraryContainer = props => {
 
 	/** Patterns / Blocks Results */
 	const patternsResults = hit => {
-		const isPattern = hit?.gutenberg_type?.[0] === 'Patterns';
+		const hasDifferentTone = ['Patterns', 'Theme'].includes(
+			hit?.gutenberg_type?.[0]
+		);
 
 		return (
 			<MasonryItem
@@ -537,7 +539,7 @@ const LibraryContainer = props => {
 				isBeta={hit.post_tag?.includes('Beta')}
 				isPro={hit.cost?.[0] === 'Pro'}
 				taxonomies={hit.category?.[0]}
-				toneUrl={isPattern ? hit.link_to_related : null}
+				toneUrl={hasDifferentTone ? hit.link_to_related : null}
 				gutenbergCode={hit.gutenberg_code}
 				isSwapChecked={isSwapChecked}
 				onSelect={onSelect}

--- a/src/editor/library/toolbar.js
+++ b/src/editor/library/toolbar.js
@@ -419,15 +419,14 @@ const LibraryToolbar = props => {
 						<h2>{title}</h2>
 						<span className='maxi-cloud-toolbar__line'>|</span>
 						<span>{cost}</span>
-						{!isNil(toneUrl) &&
-							!isEmpty(toneUrl)(
-								<ToolbarButton
-									onClick={() => {
-										openRelatedPattern();
-									}}
-									label={__('Switch tone', 'maxi-blocks')}
-								/>
-							)}
+						{!isNil(toneUrl) && !isEmpty(toneUrl) && (
+							<ToolbarButton
+								onClick={() => {
+									openRelatedPattern();
+								}}
+								label={__('Switch tone', 'maxi-blocks')}
+							/>
+						)}
 					</div>
 					<div className='maxi-cloud-toolbar__responsive-buttons'>
 						<ToolbarButton

--- a/src/editor/library/toolbar.js
+++ b/src/editor/library/toolbar.js
@@ -26,7 +26,7 @@ import { isValidEmail } from '../auth';
  */
 import classnames from 'classnames';
 import { SearchClient as TypesenseSearchClient } from 'typesense';
-import { isNil, isUndefined } from 'lodash';
+import { isNil, isEmpty } from 'lodash';
 
 /**
  * Component
@@ -419,14 +419,15 @@ const LibraryToolbar = props => {
 						<h2>{title}</h2>
 						<span className='maxi-cloud-toolbar__line'>|</span>
 						<span>{cost}</span>
-						{!isUndefined(toneUrl) && !isNil(toneUrl) && (
-							<ToolbarButton
-								onClick={() => {
-									openRelatedPattern();
-								}}
-								label={__('Switch tone', 'maxi-blocks')}
-							/>
-						)}
+						{!isNil(toneUrl) &&
+							!isEmpty(toneUrl)(
+								<ToolbarButton
+									onClick={() => {
+										openRelatedPattern();
+									}}
+									label={__('Switch tone', 'maxi-blocks')}
+								/>
+							)}
 					</div>
 					<div className='maxi-cloud-toolbar__responsive-buttons'>
 						<ToolbarButton


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5813

# How Has This Been Tested?
Checked that "Switch tone" button appears for the themes in library (only for those that have another tone).
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that "Switch tone" button appears for the themes tab in library(only for those that have another tone).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for displaying related links based on content type in the Library component.
	- Improved conditions for rendering the ToolbarButton, ensuring it only appears when appropriate.

- **Bug Fixes**
	- Refined validation logic for the toneUrl variable to improve user experience in the toolbar. 

- **Documentation**
	- Updated variable names for clarity in the Library component's functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->