### PR TITLE
Issue 5702 - update pagination items per page with column count

### DIFF
--- a/src/components/context-loop/index.js
+++ b/src/components/context-loop/index.js
@@ -93,7 +93,7 @@ const ContextLoop = props => {
 		'cl-accumulator': accumulator,
 		'cl-grandchild-accumulator': grandchildAccumulator = false,
 		'cl-acf-group': acfGroup,
-		'cl-pagination': pagination,
+		'cl-pagination': paginationEnabled,
 		'cl-pagination-per-page': paginationPerPage,
 		'cl-pagination-total': paginationTotal,
 		'cl-pagination-total-all': paginationTotalAll,
@@ -266,9 +266,16 @@ const ContextLoop = props => {
 	);
 
 	useEffect(() => {
-		if (!paginationPerPage)
+		if (!paginationPerPage && paginationEnabled)
 			changeProps({ 'cl-pagination-per-page': usePaginationPerPage });
-	}, [usePaginationPerPage]);
+	}, [usePaginationPerPage, paginationEnabled]);
+
+	// Until there is a value for paginationPerPage, set it to the number of child blocks
+	useEffect(() => {
+		if (childBlocksCount && !paginationPerPage) {
+			setUsePaginationPerPage(childBlocksCount);
+		}
+	}, [childBlocksCount]);
 
 	useEffect(() => {
 		const postTypes = getTypes(source === 'wp' ? contentType : source);
@@ -601,7 +608,7 @@ const ContextLoop = props => {
 												'Pagination',
 												'maxi-blocks'
 											)}
-											selected={pagination}
+											selected={paginationEnabled}
 											onChange={value =>
 												changeProps({
 													'cl-pagination': value,
@@ -609,7 +616,7 @@ const ContextLoop = props => {
 											}
 										/>
 									)}
-									{!isToolbar && pagination && (
+									{!isToolbar && paginationEnabled && (
 										<>
 											<AdvancedNumberControl
 												label={__(

--- a/src/components/context-loop/index.js
+++ b/src/components/context-loop/index.js
@@ -265,17 +265,17 @@ const ContextLoop = props => {
 		paginationPerPage || childBlocksCount
 	);
 
-	useEffect(() => {
-		if (!paginationPerPage && paginationEnabled)
-			changeProps({ 'cl-pagination-per-page': usePaginationPerPage });
-	}, [usePaginationPerPage, paginationEnabled]);
-
 	// Until there is a value for paginationPerPage, set it to the number of child blocks
 	useEffect(() => {
-		if (childBlocksCount && !paginationPerPage) {
-			setUsePaginationPerPage(childBlocksCount);
+		if (!isNil(paginationPerPage)) {
+			if (childBlocksCount) {
+				setUsePaginationPerPage(childBlocksCount);
+				if (paginationEnabled) {
+					changeProps({ 'cl-pagination-per-page': childBlocksCount });
+				}
+			}
 		}
-	}, [childBlocksCount]);
+	}, [childBlocksCount, paginationEnabled, paginationPerPage, changeProps]);
 
 	useEffect(() => {
 		const postTypes = getTypes(source === 'wp' ? contentType : source);

--- a/src/components/context-loop/index.js
+++ b/src/components/context-loop/index.js
@@ -267,7 +267,7 @@ const ContextLoop = props => {
 
 	// Until there is a value for paginationPerPage, set it to the number of child blocks
 	useEffect(() => {
-		if (!isNil(paginationPerPage)) {
+		if (isNil(paginationPerPage)) {
 			if (childBlocksCount) {
 				setUsePaginationPerPage(childBlocksCount);
 				if (paginationEnabled) {


### PR DESCRIPTION
# Description
Until pagination is enabled for a block, "Items per page" will be updated to be equal to number of columns. 
After pagination is enabled, it can only be changed manually by user.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5702 

# How Has This Been Tested?
Checked that when pagination is enabled, it has correct "Items per page".
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that when pagination is enabled, it has correct "Items per page".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced pagination handling within the ContextLoop component.
  
- **Bug Fixes**
	- Improved logic for dynamic adjustment of pagination settings based on child block count.

- **Style**
	- Updated comments and formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->