### PR TITLE
Issue 5619 - fix different max allowed values for toolbar and inspector

### DIFF
--- a/src/components/toolbar/components/text-options/index.js
+++ b/src/components/toolbar/components/text-options/index.js
@@ -60,6 +60,7 @@ const TextOptionsContent = props => {
 		onChangeFormat,
 		prefix,
 		minMaxSettings,
+		minMaxSettingsLineHeight,
 		minMaxSettingsLetterSpacing,
 		breakpoint,
 		avoidXXL,
@@ -116,8 +117,16 @@ const TextOptionsContent = props => {
 						true
 					)
 				}
-				min={minMaxSettings[getValue(`${prefix}line-height-unit`)].min}
-				max={minMaxSettings[getValue(`${prefix}line-height-unit`)].max}
+				min={
+					minMaxSettingsLineHeight[
+						getValue(`${prefix}line-height-unit`)
+					].min
+				}
+				max={
+					minMaxSettingsLineHeight[
+						getValue(`${prefix}line-height-unit`)
+					].max
+				}
 			/>
 			<Icon
 				className='toolbar-item__text-size-icon'
@@ -276,6 +285,15 @@ const TextOptions = props => {
 		},
 	};
 
+	const minMaxSettingsLineHeight = {
+		...minMaxSettings,
+		'%': {
+			min: 0,
+			max: 300,
+			maxRange: 300,
+		},
+	};
+
 	const minMaxSettingsLetterSpacing = {
 		px: {
 			min: -3,
@@ -373,6 +391,9 @@ const TextOptions = props => {
 									onChangeFormat={onChangeFormat}
 									prefix={prefix}
 									minMaxSettings={minMaxSettings}
+									minMaxSettingsLineHeight={
+										minMaxSettingsLineHeight
+									}
 									minMaxSettingsLetterSpacing={
 										minMaxSettingsLetterSpacing
 									}

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -411,6 +411,15 @@ const TypographyControl = props => {
 		},
 	};
 
+	const minMaxSettingsLineHeight = {
+		...minMaxSettings,
+		'%': {
+			min: 0,
+			max: 300,
+			maxRange: 300,
+		},
+	};
+
 	const minMaxSettingsLetterSpacing = {
 		px: {
 			min: -10,
@@ -742,14 +751,7 @@ const TypographyControl = props => {
 							{ isReset: true }
 						)
 					}
-					minMaxSettings={{
-						...minMaxSettings,
-						'%': {
-							min: 0,
-							max: 300,
-							maxRange: 300,
-						},
-					}}
+					minMaxSettings={minMaxSettingsLineHeight}
 					allowedUnits={['px', 'em', 'rem', 'vw', '%', '-']}
 				/>
 				<AdvancedNumberControl


### PR DESCRIPTION
# Description
In inspector for line height with `%` unit, maximum was set to `300`, and in toolbar it was `100`, so allowed `300` in toolbar as well.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5619 

# How Has This Been Tested?
Checked that the tooltip doesn't appear for pattern from issue (Hero-PRO-61).
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [x] Check that the tooltip doesn't appear for pattern from issue (Hero-PRO-61).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable minimum and maximum settings for line height, allowing greater control over typography.
  - Enhanced typography settings with explicit definitions for line height and letter spacing.

- **Bug Fixes**
  - Updated line height control to reference new settings, improving accuracy and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->