### PR TITLE
Issue 5324 - fix sidebar styles breaking after close open

### DIFF
--- a/src/blocks/button-maxi/editor.scss
+++ b/src/blocks/button-maxi/editor.scss
@@ -1,4 +1,4 @@
-body.maxi-blocks--active .maxi-controls {
+body.maxi-blocks--active .maxi-sidebar {
 	.maxi-button-default-styles {
 		display: flex;
 		flex-wrap: wrap;

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -162,13 +162,7 @@ body {
 /****************
 * Gutenberg Panel
 ****************/
-.maxi-controls {
-	background: #f5f5f5;
-
-	> div {
-		background: #f5f5f5;
-	}
-
+.maxi-sidebar {
 	.components-panel__body {
 		// This should be fix
 		border-top: none;

--- a/src/css/inserter-card.scss
+++ b/src/css/inserter-card.scss
@@ -17,7 +17,7 @@
 			max-height: 16px;
 		}
 	}
-	.block-editor-block-inspector.maxi-controls {
+	.block-editor-block-inspector {
 		.block-editor-block-card {
 			position: relative;
 			padding: 8px;

--- a/src/extensions/inspector/withMaxiInspector.js
+++ b/src/extensions/inspector/withMaxiInspector.js
@@ -22,7 +22,7 @@ const withMaxiInspector = createHigherOrderComponent(
 							const addSidebarClass = () => {
 								const editPostSidebarNode =
 									document.querySelector(
-										'.interface-complementary-area'
+										'.interface-interface-skeleton__sidebar'
 									);
 
 								if (editPostSidebarNode) {
@@ -36,22 +36,16 @@ const withMaxiInspector = createHigherOrderComponent(
 
 							addSidebarClass();
 
-							const unsubscribe = subscribe(() => {
-								const updatedSidebarClass = addSidebarClass();
-							});
-
 							return () => {
 								const editPostSidebarNode =
 									document.querySelector(
-										'.interface-complementary-area'
+										'.interface-interface-skeleton__sidebar'
 									);
 								if (editPostSidebarNode) {
 									editPostSidebarNode.classList.remove(
 										'maxi-sidebar'
 									);
 								}
-
-								unsubscribe();
 							};
 						}
 

--- a/src/extensions/inspector/withMaxiInspector.js
+++ b/src/extensions/inspector/withMaxiInspector.js
@@ -19,71 +19,39 @@ const withMaxiInspector = createHigherOrderComponent(
 					// Adds correct class to the wrapper
 					useEffect(() => {
 						if (ownProps.isSelected) {
-							const editPostSidebarNode = document.querySelector(
-								'.interface-complementary-area'
-							);
+							const addSidebarClass = () => {
+								const editPostSidebarNode =
+									document.querySelector(
+										'.interface-complementary-area'
+									);
 
-							if (editPostSidebarNode)
-								editPostSidebarNode.classList.add(
-									'maxi-sidebar'
-								);
-							else {
-								const sidebarIntervalUnsubscribe = subscribe(
-									() => {
-										const editPostSidebarNode =
-											document.querySelector(
-												'.interface-complementary-area'
-											);
+								if (editPostSidebarNode) {
+									editPostSidebarNode.classList.add(
+										'maxi-sidebar'
+									);
+								}
 
-										if (editPostSidebarNode) {
-											editPostSidebarNode.classList.add(
-												'maxi-sidebar'
-											);
+								return !!editPostSidebarNode;
+							};
 
-											sidebarIntervalUnsubscribe();
-										}
-									}
-								);
-							}
+							addSidebarClass();
 
-							const blockEditorBlockInspectorNode =
-								document.querySelector(
-									'.block-editor-block-inspector'
-								);
-
-							if (blockEditorBlockInspectorNode)
-								blockEditorBlockInspectorNode.classList.add(
-									'maxi-controls'
-								);
-							else {
-								const controlsIntervalUnsubscribe = subscribe(
-									() => {
-										const blockEditorBlockInspectorNode =
-											document.querySelector(
-												'.block-editor-block-inspector'
-											);
-
-										if (blockEditorBlockInspectorNode) {
-											blockEditorBlockInspectorNode.classList.add(
-												'maxi-controls'
-											);
-
-											controlsIntervalUnsubscribe();
-										}
-									}
-								);
-							}
+							const unsubscribe = subscribe(() => {
+								const updatedSidebarClass = addSidebarClass();
+							});
 
 							return () => {
-								if (editPostSidebarNode)
+								const editPostSidebarNode =
+									document.querySelector(
+										'.interface-complementary-area'
+									);
+								if (editPostSidebarNode) {
 									editPostSidebarNode.classList.remove(
 										'maxi-sidebar'
 									);
+								}
 
-								if (blockEditorBlockInspectorNode)
-									blockEditorBlockInspectorNode.classList.remove(
-										'maxi-controls'
-									);
+								unsubscribe();
 							};
 						}
 


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5324 

# How Has This Been Tested?
Closed and opened the sidebar and checked that the styles look right. Also checked that sidebars of Gutenberg blocks look right as well.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Close and open the sidebar and check that the styles look right.
-   [ ] Check that sidebars of Gutenberg blocks look right as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new sidebar class for improved styling in the editor interface.
	- Enhanced button hover effects and visual feedback during user interaction.

- **Bug Fixes**
	- Streamlined sidebar class management, improving stability and performance.

- **Style**
	- Updated styles for the sidebar and editor components, ensuring a cohesive visual experience.
	- Removed outdated styles associated with the previous controls class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->