### PR TITLE
Issue 5074 - Disable autocomplete in date formatting input

### DIFF
--- a/src/components/dynamic-content/custom-date-formatting/index.js
+++ b/src/components/dynamic-content/custom-date-formatting/index.js
@@ -136,6 +136,7 @@ const DateFormatting = props => {
 					onChange={val => validateAnchor(val)}
 					showHelp
 					helpContent={<DateHelperPopover />}
+					autoComplete='off'
 				/>
 			</div>
 		</div>

--- a/src/components/image-url-upload/index.js
+++ b/src/components/image-url-upload/index.js
@@ -49,7 +49,7 @@ const ImageUrlUpload = ({
 				}
 				placeholder={__('Enter URL', 'maxi-blocks')}
 				newStyle={newStyle}
-				autocomplete={false}
+				autoComplete='off'
 				onChange={value => {
 					const trimmedValue = value.trim();
 

--- a/src/components/text-control/index.js
+++ b/src/components/text-control/index.js
@@ -36,7 +36,7 @@ export default function TextControl({
 	newStyle = false,
 	showHelp,
 	helpContent,
-	autocomplete,
+	autoComplete,
 	...props
 }) {
 	const instanceId = useInstanceId(TextControl);
@@ -53,7 +53,7 @@ export default function TextControl({
 
 	return (
 		<BaseControl
-					__nextHasNoMarginBottom
+			__nextHasNoMarginBottom
 			label={label}
 			hideLabelFromVision={hideLabelFromVision}
 			id={id}
@@ -76,7 +76,7 @@ export default function TextControl({
 				value={value || ''}
 				onChange={onChange}
 				aria-describedby={help ? `${id}__help` : undefined}
-				autocomplete={autocomplete}
+				autoComplete={autoComplete}
 				{...props}
 			/>
 			{validationText && (

--- a/src/components/text-input/index.js
+++ b/src/components/text-input/index.js
@@ -21,7 +21,6 @@ export default function TextInput({
 	onChange,
 	type = 'text',
 	value,
-	autocomplete,
 	...props
 }) {
 	const [inputValue, setInputValue] = useState(value);
@@ -50,7 +49,6 @@ export default function TextInput({
 			type={type}
 			value={inputValue}
 			onChange={valueChange}
-			{...(autocomplete === false ? { autoComplete: 'off' } : {})}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5074

# How Has This Been Tested?
Checked that the autocomplete tooltip doesn't appear for date formatting.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Check that the autocomplete tooltip doesn't appear for date formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Disabled browser autocomplete for date format and URL input fields.
  
- **Refactor**
	- Updated `autocomplete` prop to `autoComplete` in the `TextControl` component for consistency.
	- Removed `autocomplete` prop from `TextInput` component, simplifying its interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->