### PR TITLE
Issue 5825 - Add "Keep only text content" switch

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -1931,6 +1931,7 @@ class MaxiBlocks_DynamicContent
             'dc-post-taxonomy-links-status' => $dc_post_taxonomy_links_status,
             'dc-link-status' => $dc_link_status,
             'dc-accumulator' => $dc_accumulator,
+            'dc-keep-only-text-content' => $dc_keep_only_text_content,
         ] = $attributes;
 
         $post = $this->get_post($attributes);
@@ -1979,7 +1980,7 @@ class MaxiBlocks_DynamicContent
             }
 
             // Limit content
-            if (isset($dc_limit) && $dc_limit > 0) {
+            if (isset($dc_limit) && ($dc_limit > 0 || $dc_keep_only_text_content)) {
                 $post_data = wp_strip_all_tags($post_data);
 
                 // Ensures no double or more line breaks

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -723,7 +723,7 @@ const DynamicContent = props => {
 										{limit === 0 && field === 'content' && (
 											<ToggleSwitch
 												label={__(
-													'Keep only text content',
+													'Display as plain text',
 													'maxi-blocks'
 												)}
 												selected={keepOnlyTextContent}

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -140,6 +140,7 @@ const DynamicContent = props => {
 		customFormat,
 		acfGroup,
 		mediaSize,
+		keepOnlyTextContent,
 	} = dcValues;
 
 	const dcValuesForDate = {
@@ -678,45 +679,63 @@ const DynamicContent = props => {
 									(showSubField &&
 										limitFields.includes(subField))) &&
 								!error && (
-									<div className='maxi-info'>
-										<AdvancedNumberControl
-											label={__(
-												'Character limit',
-												'maxi-blocks'
-											)}
-											value={limit}
-											showHelp
-											helpContent={
-												<UnlimitedCharacterPopover message='Type 0 for unlimited' />
-											}
-											onChangeValue={value =>
-												changeProps({
-													'dc-limit': Number(value),
-												})
-											}
-											disableReset={
-												limitOptions.disableReset
-											}
-											step={limitOptions.steps}
-											withInputField={
-												limitOptions.withInputField
-											}
-											onReset={() =>
-												changeProps({
-													'dc-limit':
-														getDefaultAttribute(
-															'dc-limit'
-														),
-												})
-											}
-											min={limitOptions.min}
-											max={limitOptions.max}
-											initialPosition={
-												limit ||
-												limitOptions.defaultValue
-											}
-										/>
-									</div>
+									<>
+										<div className='maxi-info'>
+											<AdvancedNumberControl
+												label={__(
+													'Character limit',
+													'maxi-blocks'
+												)}
+												value={limit}
+												showHelp
+												helpContent={
+													<UnlimitedCharacterPopover message='Type 0 for unlimited' />
+												}
+												onChangeValue={value =>
+													changeProps({
+														'dc-limit':
+															Number(value),
+													})
+												}
+												disableReset={
+													limitOptions.disableReset
+												}
+												step={limitOptions.steps}
+												withInputField={
+													limitOptions.withInputField
+												}
+												onReset={() =>
+													changeProps({
+														'dc-limit':
+															getDefaultAttribute(
+																'dc-limit'
+															),
+													})
+												}
+												min={limitOptions.min}
+												max={limitOptions.max}
+												initialPosition={
+													limit ||
+													limitOptions.defaultValue
+												}
+											/>
+										</div>
+										{limit === 0 && field === 'content' && (
+											<ToggleSwitch
+												label={__(
+													'Keep only text content',
+													'maxi-blocks'
+												)}
+												selected={keepOnlyTextContent}
+												onChange={value =>
+													changeProps({
+														'dc-keep-only-text-content':
+															value,
+													})
+												}
+											/>
+										)}
+									</>
 								)}
 							{field === 'date' && !error && (
 								<DateFormatting

--- a/src/extensions/styles/defaults/dynamicContent.js
+++ b/src/extensions/styles/defaults/dynamicContent.js
@@ -163,6 +163,10 @@ const dynamicContent = {
 		type: 'number',
 		default: 0,
 	},
+	'dc-keep-only-text-content': {
+		type: 'boolean',
+		default: false,
+	},
 	...dynamicContentLink,
 };
 


### PR DESCRIPTION
# Description
Added the switch, to choose whether to copy the content with tags from the post or strip all tags and leave only text.
Set to `false` by default, so that old patterns stay the same.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5825 

# How Has This Been Tested?
Checked that with the switch enabled, text has correct styles. When disabled, there should be all content from the post, like images SVGs.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Checked that with the switch enabled, text has correct styles
-   [ ] When disabled, there should be all content from the post, like images SVGs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a toggle option for users to limit content to only text when no character limit is applied.
	- Added a new parameter to enhance content management capabilities.

- **Bug Fixes**
	- Improved logic for handling post content to ensure proper formatting and stripping of HTML tags.

- **Documentation**
	- Updated comments for clarity in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->