### PR TITLE
Fix failing fonts test

### DIFF
--- a/e2e-tests/components/font-family-selector/index.spec.js
+++ b/e2e-tests/components/font-family-selector/index.spec.js
@@ -73,8 +73,11 @@ describe('FontFamilySelector', () => {
 
 		await page.waitForTimeout(500);
 
-		const hasBeenLoaded = await page.evaluate(() =>
-			document.fonts.check('12px Montserrat')
+		const hasBeenLoaded = await page.evaluate(
+			() =>
+				!!document.querySelector(
+					'link[href*="Montserrat"][id*="maxi-blocks-styles-font"]'
+				)?.sheet?.cssRules?.length
 		);
 		expect(hasBeenLoaded).toBeTruthy();
 	});


### PR DESCRIPTION
# Description

Fix the failing fonts e2e test by changing the method that checks whether the font is loaded or not.
<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated font loading verification method in the `FontFamilySelector` component test
	- Improved stylesheet and font loading detection mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->