### PR TITLE
Fix xxl breakpoint styles

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -1348,7 +1348,7 @@ class MaxiBlockComponent extends Component {
 		const target = this.getStyleTarget(isSiteEditor, iframe);
 		const styleElement = this.getOrCreateStyleElement(target, uniqueID);
 
-		// Only generate new styles if it's not a breakpoint change
+		// Only generate new styles if it's not a breakpoint change or if it's a breakpoint change to XXL
 		if (!isBreakpointChange || currentBreakpoint === 'xxl') {
 			const styleContent = this.generateStyleContent(
 				uniqueID,
@@ -1360,7 +1360,6 @@ class MaxiBlockComponent extends Component {
 				iframe,
 				isSiteEditor
 			);
-
 			this.updateStyleElement(styleElement, styleContent);
 		}
 	}
@@ -1538,7 +1537,7 @@ class MaxiBlockComponent extends Component {
 				breakpoints,
 				uniqueID
 			);
-		} else if (!isBreakpointChange) {
+		} else if (!isBreakpointChange || currentBreakpoint === 'xxl') {
 			styles = this.generateStyles(
 				updatedStylesObj,
 				breakpoints,

--- a/src/extensions/relations/updateRelationsRemotely.js
+++ b/src/extensions/relations/updateRelationsRemotely.js
@@ -113,6 +113,9 @@ const updateRelationsRemotely = ({
 		editor.__unstableMarkNextChangeAsNotPersistent();
 		editor.updateBlockAttributes(blockTriggerClientId, { relations: newRelations });
 
+		const getUniqueID = clientID =>
+			blockEditor.getBlockAttributes(clientID).uniqueID;
+
 		// eslint-disable-next-line no-console
 		console.log(
 			`Relations updated for ${getUniqueID(


### PR DESCRIPTION
# Description

Fixes XXL styles on backend when switching from a lower breakpoint. 

# How Has This Been Tested?

Test styles on breakpoint switch.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced style generation logic for responsive design, particularly for the 'xxl' breakpoint
  - Added a helper function to retrieve unique block IDs, improving code readability in relation updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->