### PR TITLE
Issue 5902: Fix google local fonts

### DIFF
--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -46,6 +46,8 @@ class MaxiBlocks_Local_Fonts
             return false;
         }
 
+        error_log($font_name);
+
         $font_name_sanitized = $this->sanitize_font_name($font_name);
         $font_dir = $this->fonts_upload_dir . '/' . $font_name_sanitized;
 
@@ -62,6 +64,8 @@ class MaxiBlocks_Local_Fonts
         // Use the original font name for the URL to maintain proper capitalization
         $font_url =
             $font_api_url . '/css2?family=' . str_replace(' ', '+', $font_name);
+
+        error_log($font_url);
 
         // Generate complete font URL with weights/styles
         $font_url = $this->generate_font_url($font_url, $font_data);

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -60,6 +60,11 @@ class MaxiBlocks_Local_Fonts
             ? 'https://fonts.bunny.net'
             : 'https://fonts.googleapis.com';
         // Use the original font name for the URL to maintain proper capitalization
+        if (!$use_bunny_fonts) {
+            $font_name = str_replace('+', ' ', $font_name);
+            $font_name = ucwords($font_name);
+            $font_name = str_replace(' ', '+', $font_name);
+        }
         $font_url =
             $font_api_url . '/css2?family=' . str_replace(' ', '+', $font_name);
 

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -59,12 +59,7 @@ class MaxiBlocks_Local_Fonts
         $font_api_url = $use_bunny_fonts
             ? 'https://fonts.bunny.net'
             : 'https://fonts.googleapis.com';
-        // Use the original font name for the URL to maintain proper capitalization
-        if (!$use_bunny_fonts) {
-            $font_name = str_replace('+', ' ', $font_name);
-            $font_name = ucwords($font_name);
-            $font_name = str_replace(' ', '+', $font_name);
-        }
+
         $font_url =
             $font_api_url . '/css2?family=' . str_replace(' ', '+', $font_name);
 

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -46,8 +46,6 @@ class MaxiBlocks_Local_Fonts
             return false;
         }
 
-        error_log($font_name);
-
         $font_name_sanitized = $this->sanitize_font_name($font_name);
         $font_dir = $this->fonts_upload_dir . '/' . $font_name_sanitized;
 
@@ -64,8 +62,6 @@ class MaxiBlocks_Local_Fonts
         // Use the original font name for the URL to maintain proper capitalization
         $font_url =
             $font_api_url . '/css2?family=' . str_replace(' ', '+', $font_name);
-
-        error_log($font_url);
 
         // Generate complete font URL with weights/styles
         $font_url = $this->generate_font_url($font_url, $font_data);

--- a/core/class-maxi-local-fonts.php
+++ b/core/class-maxi-local-fonts.php
@@ -59,7 +59,7 @@ class MaxiBlocks_Local_Fonts
         $font_api_url = $use_bunny_fonts
             ? 'https://fonts.bunny.net'
             : 'https://fonts.googleapis.com';
-
+        // Use the original font name for the URL to maintain proper capitalization
         $font_url =
             $font_api_url . '/css2?family=' . str_replace(' ', '+', $font_name);
 

--- a/src/components/font-family-selector/index.js
+++ b/src/components/font-family-selector/index.js
@@ -74,8 +74,7 @@ const FontFamilySelector = props => {
 	const classes = classnames('maxi-font-family-selector', className);
 
 	return (
-		<BaseControl
-					__nextHasNoMarginBottom>
+		<BaseControl __nextHasNoMarginBottom>
 			<Select
 				className={classes}
 				classNamePrefix='maxi-font-family-selector__control'

--- a/src/extensions/text/fonts/loadFonts.js
+++ b/src/extensions/text/fonts/loadFonts.js
@@ -332,24 +332,9 @@ const currentlyLoadingIds = [];
 const loadFontsInEditor = (objFont, setShowLoader) => {
 	const iframeEditor = document.querySelector('iframe[name="editor-canvas"]');
 
-	const setIsLoading = (isLoading, fontId) => {
-		if (isLoading) {
-			currentlyLoadingIds.push(fontId);
-		} else {
-			const index = currentlyLoadingIds.indexOf(fontId);
-			if (index > -1) {
-				currentlyLoadingIds.splice(index, 1);
-			}
-		}
-
-		if (setShowLoader) {
-			setShowLoader(currentlyLoadingIds.length > 0);
-		}
-	};
-
 	if (iframeEditor) {
 		loadFonts(objFont, true, iframeEditor.contentDocument);
-	} else loadFonts(objFont, true, undefined, setIsLoading);
+	} else loadFonts(objFont, true, undefined);
 };
 
 export { loadFontsInEditor, loadFonts };

--- a/src/extensions/text/fonts/loadFonts.js
+++ b/src/extensions/text/fonts/loadFonts.js
@@ -23,7 +23,9 @@ const buildFontUrl = async (fontName, fontData = {}) => {
 		);
 
 		const response = await fetch(
-			`/wp-json/maxi-blocks/v1.0/get-font-url/${encodedFontName}`,
+			`${
+				window.wpApiSettings?.root ?? '/wp-json/'
+			}maxi-blocks/v1.0/get-font-url/${encodedFontName}`,
 			{
 				credentials: 'same-origin',
 				headers: {
@@ -328,7 +330,6 @@ const loadFonts = (
 	return null;
 };
 
-const currentlyLoadingIds = [];
 const loadFontsInEditor = (objFont, setShowLoader) => {
 	const iframeEditor = document.querySelector('iframe[name="editor-canvas"]');
 

--- a/src/extensions/text/store/resolvers.js
+++ b/src/extensions/text/store/resolvers.js
@@ -38,16 +38,6 @@ const resolvers = {
 	getFontUrl:
 		(fontName, fontData) =>
 		async ({ dispatch }) => {
-			const requestKey = `${fontName}-${JSON.stringify(fontData)}`;
-
-			// Try to get from cache first
-			const cached =
-				fontUrlCache.get(requestKey) || getStorageCache(requestKey);
-			if (cached) {
-				dispatch.setFontUrl(fontName, fontData, cached);
-				return cached;
-			}
-
 			const encodedFontName = encodeURIComponent(fontName).replace(
 				/%20/g,
 				'+'
@@ -56,10 +46,6 @@ const resolvers = {
 			const promise = (async () => {
 				try {
 					const fontUrl = await fetchFontUrl(encodedFontName);
-
-					// Cache the successful response
-					fontUrlCache.set(requestKey, fontUrl);
-					setStorageCache(requestKey, fontUrl);
 
 					dispatch.setFontUrl(fontName, fontData, fontUrl);
 					return fontUrl;

--- a/src/extensions/text/store/resolvers.js
+++ b/src/extensions/text/store/resolvers.js
@@ -1,16 +1,13 @@
 /**
  * Internal dependencies
  */
-import {
-	fontUrlCache,
-	getStorageCache,
-	setStorageCache,
-	cleanUrl,
-} from '@extensions/text/fonts/fontCacheUtils';
+import { cleanUrl } from '@extensions/text/fonts/fontCacheUtils';
 
 const fetchFontUrl = async encodedFontName => {
 	const response = await fetch(
-		`/wp-json/maxi-blocks/v1.0/get-font-url/${encodedFontName}`,
+		`${
+			window.wpApiSettings?.root ?? '/wp-json/'
+		}maxi-blocks/v1.0/get-font-url/${encodedFontName}`,
 		{
 			credentials: 'same-origin',
 			headers: {


### PR DESCRIPTION
# Description

Looks like google changed the url requirements for the style.css files - now the font name case must exactly match to the one in url.

https://fonts.googleapis.com/css2?family=m+plus+1p&display=swap returns 404
https://fonts.googleapis.com/css2?family=M+PLUS+1p&display=swap works

Note: please clean your local site cache completely from the browser settings before testing. Your local site should ask you to re-login after cleaning all the site data. Also, please remove all your local font files before testing.

Fixes #5902 

# How Has This Been Tested?

Test google local fonts, bunny local font, google and bunny external. Backend and frontend. Especially test fonts with complex names, like PT Sans, M PLUS 1p, Nano Sans JP, etc.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the font loading process by reducing complexity and redundant logic.
  - Optimized the construction and validation of font resources for more robust and efficient text rendering.
  - Enhanced error handling for font URL fetching and validation.
  - Improved code formatting in the FontFamilySelector component for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->