### PR TITLE
Issue 5919: ctrl+b

### DIFF
--- a/src/extensions/text/formats/flatFormatsWithClass.js
+++ b/src/extensions/text/formats/flatFormatsWithClass.js
@@ -209,12 +209,25 @@ export const removeUnnecessaryFormats = ({
 			preserveWhiteSpace: false,
 		});
 
+	// Determine if we're dealing with a property that needs preservation
+	// Only preserve typography for specific formatting properties (bold, italic)
+	const isFontProperty =
+		value &&
+		(value['font-weight'] || // Bold
+			value['font-style']); // Italic
+
+	// If it's a font property we want to preserve, merge with original typography
+	// Otherwise, use the original behavior (just changedTypography)
+	const finalTypography = isFontProperty
+		? {
+				...typography, // Preserve original typography
+				...changedTypography, // Apply changes on top
+		  }
+		: changedTypography; // Use original behavior for other properties
+
 	return {
 		formatValue: newFormatValue,
-		typography: {
-			...typography,
-			...changedTypography,
-		},
+		typography: finalTypography,
 		content: newContent,
 	};
 };

--- a/src/extensions/text/formats/flatFormatsWithClass.js
+++ b/src/extensions/text/formats/flatFormatsWithClass.js
@@ -211,7 +211,10 @@ export const removeUnnecessaryFormats = ({
 
 	return {
 		formatValue: newFormatValue,
-		typography: changedTypography,
+		typography: {
+			...typography,
+			...changedTypography,
+		},
 		content: newContent,
 	};
 };

--- a/src/extensions/text/formats/test/flatFormatsWithClass.js
+++ b/src/extensions/text/formats/test/flatFormatsWithClass.js
@@ -698,7 +698,7 @@ describe('flatFormatsWithClass', () => {
 			textLevel,
 		});
 		const expectResult = {
-			typography: { 'custom-formats': {} },
+			typography: { 'custom-formats': {}, 'font-weight-general': '400' },
 			content: 'Testing Text Maxi',
 		};
 

--- a/src/extensions/text/formats/test/setFormatWithClass.js
+++ b/src/extensions/text/formats/test/setFormatWithClass.js
@@ -2474,6 +2474,7 @@ describe('setFormatWithClass', () => {
 		});
 
 		const expectedResult = {
+			'font-weight-general': '800',
 			'custom-formats': {
 				'maxi-text-block__custom-format--1': {
 					'font-style-general': 'italic',
@@ -2581,6 +2582,7 @@ describe('setFormatWithClass', () => {
 		});
 
 		const expectedResult = {
+			'font-weight-general': '800',
 			'custom-formats': {},
 			content: 'Testing Text Maxi',
 		};


### PR DESCRIPTION
# Description

Fixes Ctrl+b and Ctrl+i for Text block

Fixes #5919 

# How Has This Been Tested?

Make sure that you can select text and apply bold and italic with keys Ctrl+b and Ctrl+i  (same as on lists) without losing the text colour. Check on backend and frontend, with different colours and text styles.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how typography formatting is preserved when applying bold or italic styles, ensuring original font properties are retained where relevant.

- **Tests**
  - Updated test cases to reflect the enhanced handling of typography properties, ensuring expected results now include explicit font-weight values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->