### PR TITLE
Revert block delete combination for WP 6.8.1

### DIFF
--- a/src/components/toolbar/components/delete/index.js
+++ b/src/components/toolbar/components/delete/index.js
@@ -38,9 +38,7 @@ const Delete = props => {
 					}}
 				>
 					{__('Remove block', 'maxi-blocks')}
-					<span className='toolbar-item__delete-count'>
-						(Ctrl + Shift + &#8592;)
-					</span>
+					<span>(Shift+Alt+Z)</span>
 				</Button>
 			</div>
 		);

--- a/src/components/toolbar/components/more-settings/editor.scss
+++ b/src/components/toolbar/components/more-settings/editor.scss
@@ -17,7 +17,7 @@
 		margin: -18px 0 0 91px !important;
 	}
 	.components-popover__content {
-		width: 210px;
+		width: 185px;
 		margin-left: 0 !important;
 		margin-top: 15px;
 		transform: translate(3px, -13px);


### PR DESCRIPTION
# Description

Reverts the toolbar combination for deleting a block. 

https://make.wordpress.org/core/2025/04/28/wordpress-6-8-1-rc1-is-now-available/

- GB-69998 Keyboard Shortcuts: Revert delete shortcut to access + z 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced the width of the settings popover for a more compact appearance.

- **Refactor**
  - Updated the keyboard shortcut hint text on the delete button for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->