### PR TITLE
Add tests for relations and DC

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,4 +37,4 @@ jobs:
             - name: reset package-lock.json
               run: git checkout package-lock.json
             - name: Running the tests
-              run: npm test
+              run: npm test -- --verbose

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -37,4 +37,4 @@ jobs:
             - name: reset package-lock.json
               run: git checkout package-lock.json
             - name: Running the tests
-              run: npm test -- --verbose
+              run: npm test

--- a/jest/jest-unit-global.setup.js
+++ b/jest/jest-unit-global.setup.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+	process.env.TZ = 'UTC'; // Need to set timezone in global setup before Date caches the timezone
+};

--- a/jest/jest-unit.config.js
+++ b/jest/jest-unit.config.js
@@ -4,6 +4,9 @@ module.exports = {
 	rootDir: '../',
 	roots: ['<rootDir>/src'],
 
+	globalSetup: '<rootDir>/jest/jest-unit-global.setup.js',
+	setupFiles: ['<rootDir>/jest/jest-unit.setup.js'],
+
 	moduleNameMapper: {
 		'^@blocks$': '<rootDir>/src/blocks',
 		'^@blocks/(.*)$': '<rootDir>/src/blocks/$1',
@@ -19,4 +22,14 @@ module.exports = {
 		'^@maxi-icons/(.*)$': '<rootDir>/src/icons/$1',
 		'^@maxi-core/(.*)$': '<rootDir>/core/$1',
 	},
+
+	collectCoverageFrom: [
+		'src/**/*.js',
+		'!src/**/*.test.js',
+		'!src/**/test/**/*.js',
+		'!src/blocks/**/*.js',
+		'!src/components/**/*.js',
+		'!src/icons/**/*.js',
+		'!src/extensions/styles/migrators/**/*.js',
+	],
 };

--- a/jest/jest-unit.setup.js
+++ b/jest/jest-unit.setup.js
@@ -1,0 +1,5 @@
+module.exports = () => {
+	global.wp = {
+		domReady: jest.fn(),
+	};
+};

--- a/src/components/context-loop/index.js
+++ b/src/components/context-loop/index.js
@@ -22,23 +22,15 @@ import TypographyControl from '@components/typography-control';
 import ColorControl from '@components/color-control';
 import ResponsiveTabsControl from '@components/responsive-tabs-control';
 import FlexSettingsControl from '@components/flex-settings-control';
-import {
-	getDefaultAttribute,
-	getGroupAttributes,
-} from '@extensions/styles';
+import { getDefaultAttribute, getGroupAttributes } from '@extensions/styles';
 import {
 	orderByRelations,
 	orderByOptions,
 	orderOptions,
 	orderRelations,
 	relationOptions,
-	sourceOptions,
 } from '@extensions/DC/constants';
-import {
-	getCLAttributes,
-	getDCOptions,
-	LoopContext,
-} from '@extensions/DC';
+import { getCLAttributes, getDCOptions, LoopContext } from '@extensions/DC';
 import {
 	getRelationOptions,
 	validationsValues,
@@ -122,13 +114,14 @@ const ContextLoop = props => {
 
 	const clPaginationPrefix = 'cl-pagination-';
 
-	const { relationTypes, orderTypes } = useSelect(select => {
-		const { getRelationTypes, getOrderTypes } = select(
+	const { relationTypes, orderTypes, sourceOptions } = useSelect(select => {
+		const { getRelationTypes, getOrderTypes, getSourceOptions } = select(
 			'maxiBlocks/dynamic-content'
 		);
 		return {
 			relationTypes: getRelationTypes(),
 			orderTypes: getOrderTypes(),
+			sourceOptions: getSourceOptions(),
 		};
 	}, []);
 

--- a/src/components/dynamic-content/index.js
+++ b/src/components/dynamic-content/index.js
@@ -33,14 +33,12 @@ import {
 	getCurrentTemplateSlug,
 } from '@extensions/DC/utils';
 import {
-	fieldOptions,
 	limitOptions,
 	limitFields,
 	orderOptions,
 	orderByOptions,
 	orderByRelations,
 	orderRelations,
-	sourceOptions,
 	ignoreEmptyFields,
 } from '@extensions/DC/constants';
 import getDCOptions from '@extensions/DC/getDCOptions';
@@ -88,16 +86,23 @@ const DynamicContent = props => {
 	const [postTypesOptions, setPostTypesOptions] = useState(null);
 	const [isCustomTaxonomyField, setIsCustomTaxonomyField] = useState(false);
 
-	const { relationTypes, orderTypes, limitTypes } = useSelect(select => {
-		const { getRelationTypes, getOrderTypes, getLimitTypes } = select(
-			'maxiBlocks/dynamic-content'
-		);
-		return {
-			relationTypes: getRelationTypes(),
-			orderTypes: getOrderTypes(),
-			limitTypes: getLimitTypes(),
-		};
-	}, []);
+	const { relationTypes, orderTypes, limitTypes, sourceOptions } = useSelect(
+		select => {
+			const {
+				getRelationTypes,
+				getOrderTypes,
+				getLimitTypes,
+				getSourceOptions,
+			} = select('maxiBlocks/dynamic-content');
+			return {
+				relationTypes: getRelationTypes(),
+				orderTypes: getOrderTypes(),
+				limitTypes: getLimitTypes(),
+				sourceOptions: getSourceOptions(),
+			};
+		},
+		[]
+	);
 
 	const classes = classnames('maxi-dynamic-content', className);
 

--- a/src/extensions/DC/constants.js
+++ b/src/extensions/DC/constants.js
@@ -2,64 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Source constants
- */
-export const sourceOptions = [
-	{
-		label: __('WordPress', 'maxi-blocks'),
-		value: 'wp',
-	},
-];
-
-/**
- * Type constants
- */
-export const generalTypeOptions = [
-	{ label: __('Post', 'maxi-blocks'), value: 'posts' },
-	{ label: __('Page', 'maxi-blocks'), value: 'pages' },
-	{ label: __('Site', 'maxi-blocks'), value: 'settings' },
-	{ label: __('Media', 'maxi-blocks'), value: 'media' },
-	{ label: __('Author', 'maxi-blocks'), value: 'users' }, // TODO: add author support
-	{ label: __('Categories', 'maxi-blocks'), value: 'categories' },
-	{ label: __('Tags', 'maxi-blocks'), value: 'tags' },
-];
-
-export const imageTypeOptions = generalTypeOptions.filter(
-	option => !['categories', 'tags'].includes(option.value)
-);
-
-export const ACFTypeOptions = generalTypeOptions.filter(
-	option => !['settings'].includes(option.value)
-);
-
-export const WCTypeOptions = [
-	{ label: __('Product', 'maxi-blocks'), value: 'products' },
-	{ label: __('Cart', 'maxi-blocks'), value: 'cart' },
-	{
-		label: __('Product categories', 'maxi-blocks'),
-		value: 'product_categories',
-	},
-	{ label: __('Product tags', 'maxi-blocks'), value: 'product_tags' },
-];
-
-export const typeOptions = {
-	text: generalTypeOptions,
-	button: generalTypeOptions,
-	image: imageTypeOptions,
-	container: generalTypeOptions,
-	row: generalTypeOptions,
-	column: generalTypeOptions,
-	group: generalTypeOptions,
-	pane: generalTypeOptions,
-	slide: generalTypeOptions,
-	accordion: generalTypeOptions,
-	slider: generalTypeOptions,
-	acf: ACFTypeOptions,
-	divider: generalTypeOptions,
-};
 
 // Post types to show in "Standard types" section
 export const supportedPostTypes = ['post', 'page', 'attachment', 'product'];
@@ -784,41 +726,3 @@ export const attributeDefaults = {
 	},
 	accumulator: 0,
 };
-
-let haveLoadedIntegrationsOptions = false;
-
-export const getHaveLoadedIntegrationsOptions = () =>
-	haveLoadedIntegrationsOptions;
-
-const loadIntegrationsOptions = () => {
-	apiFetch({
-		path: '/maxi-blocks/v1.0/get-active-integration-plugins',
-		method: 'GET',
-	})
-		.then(response => {
-			if (response) {
-				if (response.includes('acf')) {
-					sourceOptions.push({
-						label: __('ACF', 'maxi-blocks'),
-						value: 'acf',
-					});
-				}
-
-				if (response.includes('woocommerce')) {
-					generalTypeOptions.push(...WCTypeOptions);
-					imageTypeOptions.push(
-						...WCTypeOptions.filter(option =>
-							['products'].includes(option.value)
-						)
-					);
-				}
-			}
-
-			haveLoadedIntegrationsOptions = true;
-		})
-		.catch(error => {
-			console.error('Error loading integration options:', error);
-		});
-};
-
-loadIntegrationsOptions();

--- a/src/extensions/DC/getDCContent.js
+++ b/src/extensions/DC/getDCContent.js
@@ -27,7 +27,7 @@ import { getCartContent, getProductsContent } from './getWCContent';
  */
 import { isNil, isEmpty, capitalize } from 'lodash';
 
-const handleParentField = async (contentValue, type) => {
+export const handleParentField = async (contentValue, type) => {
 	if (!contentValue || contentValue === 0)
 		return __('No parent', 'maxi-blocks');
 	const parent = await resolveSelect('core').getEntityRecords(

--- a/src/extensions/DC/getDCLink.js
+++ b/src/extensions/DC/getDCLink.js
@@ -40,14 +40,17 @@ const getUserLink = (dataRequest, data) => {
 	return data?.link;
 };
 
-const cache = {};
+// Exporting for testing purposes
+export const cache = {};
 const MAX_CACHE_SIZE = 200;
 
 const getDCLink = async (dataRequest, clientId) => {
 	const { type, linkTarget, author, relation } = dataRequest;
+
 	if (type === 'cart') {
 		return getCartUrl();
 	}
+
 	if (linkTarget.includes('author')) {
 		let userId = author;
 		if (relation === 'current') {

--- a/src/extensions/DC/getDCMedia.js
+++ b/src/extensions/DC/getDCMedia.js
@@ -53,7 +53,8 @@ const getMediaById = async (id, type) => {
 	}
 };
 
-const cache = {};
+// Exporting for testing purposes
+export const cache = {};
 const MAX_CACHE_SIZE = 200;
 
 const getDCMedia = async (dataRequest, clientId) => {

--- a/src/extensions/DC/getDCValues.js
+++ b/src/extensions/DC/getDCValues.js
@@ -13,6 +13,16 @@ const getDefaultDCValue = (target, obj) => {
 	return isFunction(defaultValue) ? defaultValue(obj) : defaultValue;
 };
 
+/**
+ * Combines dynamic content values with context loop values
+ *
+ * Note that this function should be called with group attributes of DC
+ * meaning that the missing attributes in DC object should be provided as undefined
+ *
+ * @param {Object} dynamicContent - Dynamic content object
+ * @param {Object} contextLoop    - Context loop object
+ * @returns {Object} DC values
+ */
 const getDCValues = (dynamicContent, contextLoop) => {
 	const getDCValue = (target, obj) => {
 		const contextLoopStatus = !!contextLoop?.['cl-status'];

--- a/src/extensions/DC/getTypes.js
+++ b/src/extensions/DC/getTypes.js
@@ -7,7 +7,6 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { typeOptions } from './constants';
 
 /**
  * External dependencies
@@ -58,7 +57,11 @@ const getTypes = (
 			: [];
 
 	const defaultOptions =
-		source === 'acf' ? typeOptions.acf : typeOptions[contentType];
+		source === 'acf'
+			? select('maxiBlocks/dynamic-content').getACFTypeOptions()
+			: select('maxiBlocks/dynamic-content').getTypeOptions()[
+					contentType
+			  ];
 
 	if (group) {
 		return isEmpty(customPostTypes)

--- a/src/extensions/DC/getWCContent.js
+++ b/src/extensions/DC/getWCContent.js
@@ -20,12 +20,11 @@ const getPrice = (rawPrice, data) => {
 		const separateThousands = price =>
 			price.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSeparator);
 
-		const parsedPrice =
-			price.length > minorUnit
-				? `${separateThousands(
-						price.slice(0, -minorUnit)
-				  )}${decimalSeparator}${price.slice(-minorUnit)}`
-				: price;
+		const priceWithFullLength =
+			price.length <= minorUnit ? `0${price}` : price;
+		const parsedPrice = `${separateThousands(
+			priceWithFullLength.slice(0, -minorUnit)
+		)}${decimalSeparator}${priceWithFullLength.slice(-minorUnit)}`;
 
 		return `${currencyPrefix}${parsedPrice}${currencySuffix}`;
 	};

--- a/src/extensions/DC/store/actions.js
+++ b/src/extensions/DC/store/actions.js
@@ -62,6 +62,14 @@ const actions = {
 			acfFields,
 		};
 	},
+	*loadIntegrationOptions() {
+		const integrationPluginList = yield { type: 'GET_INTEGRATION_PLUGINS' };
+
+		return {
+			type: 'SET_INTEGRATION_OPTIONS',
+			integrationPlugins: integrationPluginList,
+		};
+	},
 };
 
 export default actions;

--- a/src/extensions/DC/store/controls.js
+++ b/src/extensions/DC/store/controls.js
@@ -1,12 +1,15 @@
 import { resolveSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 let postTypesCache = null;
 let taxonomiesCache = null;
+let integrationPluginsCache = null;
 
 // Clear cache on each editor load
 const clearCache = () => {
 	postTypesCache = null;
 	taxonomiesCache = null;
+	integrationPluginsCache = null;
 };
 
 // Hook into the editor initialization
@@ -36,6 +39,23 @@ const controls = {
 		});
 		taxonomiesCache = taxonomies;
 		return taxonomies;
+	},
+	GET_INTEGRATION_PLUGINS: async () => {
+		if (integrationPluginsCache) {
+			return integrationPluginsCache;
+		}
+
+		try {
+			const response = await apiFetch({
+				path: '/maxi-blocks/v1.0/get-active-integration-plugins',
+				method: 'GET',
+			});
+			integrationPluginsCache = response || [];
+			return integrationPluginsCache;
+		} catch (error) {
+			console.error('Error loading integration plugins:', error);
+			return [];
+		}
 	},
 };
 

--- a/src/extensions/DC/store/controls.js
+++ b/src/extensions/DC/store/controls.js
@@ -6,7 +6,7 @@ let taxonomiesCache = null;
 let integrationPluginsCache = null;
 
 // Clear cache on each editor load
-const clearCache = () => {
+export const clearCache = () => {
 	postTypesCache = null;
 	taxonomiesCache = null;
 	integrationPluginsCache = null;

--- a/src/extensions/DC/store/index.js
+++ b/src/extensions/DC/store/index.js
@@ -27,5 +27,4 @@ register(store);
 
 dispatch('maxiBlocks/dynamic-content').loadCustomPostTypes();
 dispatch('maxiBlocks/dynamic-content').loadCustomTaxonomies();
-dispatch('maxiBlocks/dynamic-content').loadCustomFields();
 dispatch('maxiBlocks/dynamic-content').loadIntegrationOptions();

--- a/src/extensions/DC/store/index.js
+++ b/src/extensions/DC/store/index.js
@@ -27,3 +27,5 @@ register(store);
 
 dispatch('maxiBlocks/dynamic-content').loadCustomPostTypes();
 dispatch('maxiBlocks/dynamic-content').loadCustomTaxonomies();
+dispatch('maxiBlocks/dynamic-content').loadCustomFields();
+dispatch('maxiBlocks/dynamic-content').loadIntegrationOptions();

--- a/src/extensions/DC/store/initConstants.js
+++ b/src/extensions/DC/store/initConstants.js
@@ -1,0 +1,42 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Source constants
+ */
+export const sourceOptions = [
+	{
+		label: __('WordPress', 'maxi-blocks'),
+		value: 'wp',
+	},
+];
+
+/**
+ * Type constants
+ */
+export const generalTypeOptions = [
+	{ label: __('Post', 'maxi-blocks'), value: 'posts' },
+	{ label: __('Page', 'maxi-blocks'), value: 'pages' },
+	{ label: __('Site', 'maxi-blocks'), value: 'settings' },
+	{ label: __('Media', 'maxi-blocks'), value: 'media' },
+	{ label: __('Author', 'maxi-blocks'), value: 'users' },
+	{ label: __('Categories', 'maxi-blocks'), value: 'categories' },
+	{ label: __('Tags', 'maxi-blocks'), value: 'tags' },
+];
+
+export const imageTypeOptions = generalTypeOptions.filter(
+	option => !['categories', 'tags'].includes(option.value)
+);
+
+export const ACFTypeOptions = generalTypeOptions.filter(
+	option => !['settings'].includes(option.value)
+);
+
+export const WCTypeOptions = [
+	{ label: __('Product', 'maxi-blocks'), value: 'products' },
+	{ label: __('Cart', 'maxi-blocks'), value: 'cart' },
+	{
+		label: __('Product categories', 'maxi-blocks'),
+		value: 'product_categories',
+	},
+	{ label: __('Product tags', 'maxi-blocks'), value: 'product_tags' },
+];

--- a/src/extensions/DC/store/reducer.js
+++ b/src/extensions/DC/store/reducer.js
@@ -1,4 +1,36 @@
-import { limitTypes, orderTypes, relationTypes } from '@extensions/DC/constants';
+import {
+	limitTypes,
+	orderTypes,
+	relationTypes,
+	WCTypeOptions,
+} from '@extensions/DC/constants';
+import { __ } from '@wordpress/i18n';
+import {
+	sourceOptions,
+	generalTypeOptions,
+	imageTypeOptions,
+	ACFTypeOptions,
+} from './initConstants';
+
+const createTypeOptions = (
+	generalTypeOptions,
+	imageTypeOptions,
+	acfTypeOptions
+) => ({
+	text: generalTypeOptions,
+	button: generalTypeOptions,
+	image: imageTypeOptions,
+	container: generalTypeOptions,
+	row: generalTypeOptions,
+	column: generalTypeOptions,
+	group: generalTypeOptions,
+	pane: generalTypeOptions,
+	slide: generalTypeOptions,
+	accordion: generalTypeOptions,
+	slider: generalTypeOptions,
+	acf: acfTypeOptions,
+	divider: generalTypeOptions,
+});
 
 const initialState = {
 	relationTypes,
@@ -10,6 +42,17 @@ const initialState = {
 	customTaxonomies: [],
 	wasCustomPostTypesLoaded: false,
 	wasCustomTaxonomiesLoaded: false,
+	integrationPlugins: [],
+	integrationListLoaded: false,
+	sourceOptions,
+	generalTypeOptions,
+	imageTypeOptions,
+	ACFTypeOptions,
+	typeOptions: createTypeOptions(
+		generalTypeOptions,
+		imageTypeOptions,
+		ACFTypeOptions
+	),
 };
 
 const reducer = (state = initialState, action) => {
@@ -49,6 +92,56 @@ const reducer = (state = initialState, action) => {
 					[action.groupId]: action.acfFields,
 				},
 			};
+		case 'SET_INTEGRATION_OPTIONS': {
+			const integrationPlugins = action.integrationPlugins || [];
+
+			const sourceOptions = [...state.sourceOptions];
+			if (integrationPlugins.includes('acf')) {
+				sourceOptions.push({
+					label: __('ACF', 'maxi-blocks'),
+					value: 'acf',
+				});
+			}
+
+			const generalTypeOptions = [...state.generalTypeOptions];
+			if (integrationPlugins.includes('woocommerce')) {
+				generalTypeOptions.push(...WCTypeOptions);
+			}
+
+			let imageTypeOptions = generalTypeOptions.filter(
+				option => !['categories', 'tags'].includes(option.value)
+			);
+
+			if (integrationPlugins.includes('woocommerce')) {
+				imageTypeOptions = [
+					...imageTypeOptions,
+					...WCTypeOptions.filter(option =>
+						['products'].includes(option.value)
+					),
+				];
+			}
+
+			const acfTypeOptions = generalTypeOptions.filter(
+				option => !['settings'].includes(option.value)
+			);
+
+			const typeOptions = createTypeOptions(
+				generalTypeOptions,
+				imageTypeOptions,
+				acfTypeOptions
+			);
+
+			return {
+				...state,
+				integrationPlugins,
+				integrationListLoaded: true,
+				sourceOptions,
+				generalTypeOptions,
+				imageTypeOptions,
+				acfTypeOptions,
+				typeOptions,
+			};
+		}
 		default:
 			return state;
 	}

--- a/src/extensions/DC/store/reducer.js
+++ b/src/extensions/DC/store/reducer.js
@@ -2,7 +2,6 @@ import {
 	limitTypes,
 	orderTypes,
 	relationTypes,
-	WCTypeOptions,
 } from '@extensions/DC/constants';
 import { __ } from '@wordpress/i18n';
 import {
@@ -10,6 +9,7 @@ import {
 	generalTypeOptions,
 	imageTypeOptions,
 	ACFTypeOptions,
+	WCTypeOptions,
 } from './initConstants';
 
 const createTypeOptions = (

--- a/src/extensions/DC/store/resolvers.js
+++ b/src/extensions/DC/store/resolvers.js
@@ -1,12 +1,14 @@
 /**
  * Wordpress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
-import { getACFFieldGroups, getACFGroupFields } from '@extensions/DC/getACFData';
+import {
+	getACFFieldGroups,
+	getACFGroupFields,
+} from '@extensions/DC/getACFData';
 
 const resolvers = {
 	getACFGroups:

--- a/src/extensions/DC/store/selectors.js
+++ b/src/extensions/DC/store/selectors.js
@@ -40,6 +40,30 @@ const selectors = {
 	getACFFields: (state, groupId) => {
 		return state?.acfFields?.[groupId];
 	},
+	getIntegrationPlugins: state => {
+		return state?.integrationPlugins || [];
+	},
+	isIntegrationListLoaded: state => {
+		return !!state?.integrationListLoaded;
+	},
+	hasIntegration: (state, pluginName) => {
+		return state?.integrationPlugins?.includes(pluginName) || false;
+	},
+	getSourceOptions: state => {
+		return state?.sourceOptions || [];
+	},
+	getGeneralTypeOptions: state => {
+		return state?.generalTypeOptions || [];
+	},
+	getImageTypeOptions: state => {
+		return state?.imageTypeOptions || [];
+	},
+	getACFTypeOptions: state => {
+		return state?.acfTypeOptions || [];
+	},
+	getTypeOptions: state => {
+		return state?.typeOptions || {};
+	},
 };
 
 export default selectors;

--- a/src/extensions/DC/store/test/actions.js
+++ b/src/extensions/DC/store/test/actions.js
@@ -1,0 +1,125 @@
+/**
+ * Internal dependencies
+ */
+import actions from '@extensions/DC/store/actions';
+
+const mockPostTypes = [
+	{ slug: 'post', supports: { editor: true, excerpt: true } },
+	{ slug: 'page', supports: { editor: true, excerpt: true } },
+	{ slug: 'attachment', supports: { editor: false, excerpt: false } },
+	{ slug: 'book', supports: { editor: true, excerpt: true } },
+	{ slug: 'recipe', supports: { editor: true, excerpt: false } },
+	{ slug: 'wp_block', supports: { editor: false, excerpt: false } },
+];
+
+const mockTaxonomies = [
+	{ slug: 'category' },
+	{ slug: 'post_tag' },
+	{ slug: 'genre' },
+	{ slug: 'cuisine' },
+	{ slug: 'nav_menu' },
+];
+
+describe('DC/actions', () => {
+	describe('setACFGroups', () => {
+		it('should return SET_ACF_GROUPS action', () => {
+			const acfGroups = [
+				{ id: 1, title: 'Group 1' },
+				{ id: 2, title: 'Group 2' },
+			];
+
+			const action = actions.setACFGroups(acfGroups);
+
+			expect(action).toEqual({
+				type: 'SET_ACF_GROUPS',
+				acfGroups,
+			});
+		});
+	});
+
+	describe('setACFFields', () => {
+		it('should return SET_ACF_FIELDS action', () => {
+			const groupId = 1;
+			const acfFields = [
+				{ id: 'field1', name: 'Field 1' },
+				{ id: 'field2', name: 'Field 2' },
+			];
+
+			const action = actions.setACFFields(groupId, acfFields);
+
+			expect(action).toEqual({
+				type: 'SET_ACF_FIELDS',
+				groupId,
+				acfFields,
+			});
+		});
+	});
+
+	describe('loadCustomPostTypes', () => {
+		it('should filter post types correctly and return LOAD_CUSTOM_POST_TYPES action', () => {
+			const generator = actions.loadCustomPostTypes();
+
+			// First yield - get post types
+			const firstYield = generator.next();
+			expect(firstYield.value).toEqual({
+				type: 'GET_POST_TYPES',
+			});
+
+			// Second yield - return filtered post types
+			const secondYield = generator.next(mockPostTypes);
+
+			expect(secondYield.value).toEqual({
+				type: 'LOAD_CUSTOM_POST_TYPES',
+				customPostTypes: ['book', 'recipe'],
+				customLimitTypes: ['post', 'page', 'book', 'recipe'],
+			});
+
+			expect(secondYield.done).toBe(true);
+		});
+	});
+
+	describe('loadCustomTaxonomies', () => {
+		it('should filter taxonomies correctly and return LOAD_CUSTOM_TAXONOMIES action', () => {
+			const generator = actions.loadCustomTaxonomies();
+
+			// First yield - get taxonomies
+			const firstYield = generator.next();
+			expect(firstYield.value).toEqual({
+				type: 'GET_TAXONOMIES',
+			});
+
+			// Second yield - return filtered taxonomies
+			const secondYield = generator.next(mockTaxonomies);
+
+			expect(secondYield.value).toEqual({
+				type: 'LOAD_CUSTOM_TAXONOMIES',
+				customTaxonomies: ['genre', 'cuisine'],
+			});
+
+			expect(secondYield.done).toBe(true);
+		});
+	});
+
+	describe('loadIntegrationOptions', () => {
+		it('should return SET_INTEGRATION_OPTIONS action with integration plugins', () => {
+			const mockIntegrationPlugins = ['acf', 'woocommerce'];
+			const generator = actions.loadIntegrationOptions();
+
+			// First yield - get integration plugins
+			const firstYield = generator.next();
+			expect(firstYield.value).toEqual({
+				type: 'GET_INTEGRATION_PLUGINS',
+			});
+
+			// Second yield - return integration options
+			const secondYield = generator.next(mockIntegrationPlugins);
+
+			expect(secondYield.value).toEqual({
+				type: 'SET_INTEGRATION_OPTIONS',
+				integrationPlugins: mockIntegrationPlugins,
+			});
+
+			expect(secondYield.done).toBe(true);
+		});
+	});
+});

--- a/src/extensions/DC/store/test/controls.js
+++ b/src/extensions/DC/store/test/controls.js
@@ -1,0 +1,166 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import controls, { clearCache } from '@extensions/DC/store/controls';
+
+jest.mock('@wordpress/data', () => ({
+	resolveSelect: jest.fn(),
+}));
+
+jest.mock('@wordpress/api-fetch', () => jest.fn());
+
+global.wp = {
+	domReady: jest.fn(callback => callback()),
+};
+
+describe('DC/controls', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		clearCache();
+	});
+
+	describe('GET_POST_TYPES', () => {
+		it('should fetch post types and return them', async () => {
+			const mockPostTypes = [
+				{ slug: 'post', supports: { editor: true } },
+				{ slug: 'page', supports: { editor: true } },
+			];
+
+			const getPostTypes = jest.fn().mockResolvedValue(mockPostTypes);
+			resolveSelect.mockImplementation(() => ({
+				getPostTypes,
+			}));
+
+			const result = await controls.GET_POST_TYPES();
+
+			expect(resolveSelect).toHaveBeenCalledWith('core');
+			expect(getPostTypes).toHaveBeenCalledWith({
+				per_page: -1,
+			});
+			expect(result).toEqual(mockPostTypes);
+		});
+
+		it('should use cached result on subsequent calls', async () => {
+			const mockPostTypes = [
+				{ slug: 'post', supports: { editor: true } },
+				{ slug: 'page', supports: { editor: true } },
+			];
+
+			resolveSelect.mockImplementation(() => ({
+				getPostTypes: jest.fn().mockResolvedValue(mockPostTypes),
+			}));
+
+			await controls.GET_POST_TYPES();
+
+			// Reset mocks to verify they aren't called again
+			resolveSelect.mockClear();
+
+			// Second call should use cache
+			const result = await controls.GET_POST_TYPES();
+
+			expect(resolveSelect).not.toHaveBeenCalled();
+			expect(result).toEqual(mockPostTypes);
+		});
+	});
+
+	describe('GET_TAXONOMIES', () => {
+		it('should fetch taxonomies and return them', async () => {
+			const mockTaxonomies = [{ slug: 'category' }, { slug: 'post_tag' }];
+
+			const getTaxonomies = jest.fn().mockResolvedValue(mockTaxonomies);
+			resolveSelect.mockImplementation(() => ({
+				getTaxonomies,
+			}));
+
+			const result = await controls.GET_TAXONOMIES();
+
+			expect(resolveSelect).toHaveBeenCalledWith('core');
+			expect(getTaxonomies).toHaveBeenCalledWith({
+				per_page: -1,
+			});
+			expect(result).toEqual(mockTaxonomies);
+		});
+
+		it('should use cached result on subsequent calls', async () => {
+			const mockTaxonomies = [{ slug: 'category' }, { slug: 'post_tag' }];
+
+			resolveSelect.mockImplementation(() => ({
+				getTaxonomies: jest.fn().mockResolvedValue(mockTaxonomies),
+			}));
+
+			await controls.GET_TAXONOMIES();
+
+			resolveSelect.mockClear();
+
+			const result = await controls.GET_TAXONOMIES();
+
+			expect(resolveSelect).not.toHaveBeenCalled();
+			expect(result).toEqual(mockTaxonomies);
+		});
+	});
+
+	describe('GET_INTEGRATION_PLUGINS', () => {
+		it('should fetch integration plugins via API and return them', async () => {
+			const mockPlugins = ['acf', 'woocommerce'];
+
+			apiFetch.mockResolvedValue(mockPlugins);
+
+			const result = await controls.GET_INTEGRATION_PLUGINS();
+
+			expect(apiFetch).toHaveBeenCalledWith({
+				path: '/maxi-blocks/v1.0/get-active-integration-plugins',
+				method: 'GET',
+			});
+			expect(result).toEqual(mockPlugins);
+		});
+
+		it('should use cached result on subsequent calls', async () => {
+			const mockPlugins = ['acf', 'woocommerce'];
+
+			apiFetch.mockResolvedValue(mockPlugins);
+
+			await controls.GET_INTEGRATION_PLUGINS();
+
+			apiFetch.mockClear();
+
+			const result = await controls.GET_INTEGRATION_PLUGINS();
+
+			expect(apiFetch).not.toHaveBeenCalled();
+			expect(result).toEqual(mockPlugins);
+		});
+
+		it('should return empty array and log error when API call fails', async () => {
+			const consoleErrorSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation();
+			const errorMessage = 'API Error';
+
+			apiFetch.mockRejectedValue(new Error(errorMessage));
+
+			const result = await controls.GET_INTEGRATION_PLUGINS();
+
+			expect(apiFetch).toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Error loading integration plugins:',
+				expect.any(Error)
+			);
+			expect(result).toEqual([]);
+
+			consoleErrorSpy.mockRestore();
+		});
+
+		it('should handle null response from API', async () => {
+			apiFetch.mockResolvedValue(null);
+
+			const result = await controls.GET_INTEGRATION_PLUGINS();
+
+			expect(result).toEqual([]);
+		});
+	});
+});

--- a/src/extensions/DC/store/test/reducer.js
+++ b/src/extensions/DC/store/test/reducer.js
@@ -1,0 +1,277 @@
+/**
+ * Internal dependencies
+ */
+import reducer from '@extensions/DC/store/reducer';
+import {
+	relationTypes,
+	orderTypes,
+	limitTypes,
+} from '@extensions/DC/constants';
+import {
+	sourceOptions,
+	generalTypeOptions,
+	imageTypeOptions,
+	ACFTypeOptions,
+	WCTypeOptions,
+} from '@extensions/DC/store/initConstants';
+
+const createTypeOptions = (
+	generalTypeOptions,
+	imageTypeOptions,
+	acfTypeOptions
+) => ({
+	text: generalTypeOptions,
+	button: generalTypeOptions,
+	image: imageTypeOptions,
+	container: generalTypeOptions,
+	row: generalTypeOptions,
+	column: generalTypeOptions,
+	group: generalTypeOptions,
+	pane: generalTypeOptions,
+	slide: generalTypeOptions,
+	accordion: generalTypeOptions,
+	slider: generalTypeOptions,
+	acf: acfTypeOptions,
+	divider: generalTypeOptions,
+});
+
+describe('DC/reducer', () => {
+	const expectedInitialState = {
+		relationTypes,
+		orderTypes,
+		limitTypes,
+		acfGroups: null,
+		acfFields: null,
+		customPostTypes: [],
+		customTaxonomies: [],
+		wasCustomPostTypesLoaded: false,
+		wasCustomTaxonomiesLoaded: false,
+		integrationPlugins: [],
+		integrationListLoaded: false,
+		sourceOptions,
+		generalTypeOptions,
+		imageTypeOptions,
+		ACFTypeOptions,
+		typeOptions: createTypeOptions(
+			generalTypeOptions,
+			imageTypeOptions,
+			ACFTypeOptions
+		),
+	};
+
+	it('should return default state', () => {
+		const state = reducer(undefined, { type: 'UNKNOWN_ACTION' });
+		expect(state).toEqual(expectedInitialState);
+	});
+
+	describe('LOAD_CUSTOM_POST_TYPES', () => {
+		it('should add custom post types to state', () => {
+			const customPostTypes = ['book', 'recipe'];
+			const customLimitTypes = ['book'];
+
+			const action = {
+				type: 'LOAD_CUSTOM_POST_TYPES',
+				customPostTypes,
+				customLimitTypes,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.customPostTypes).toEqual(customPostTypes);
+			expect(newState.relationTypes).toEqual([
+				...relationTypes,
+				...customPostTypes,
+			]);
+			expect(newState.orderTypes).toEqual([
+				...orderTypes,
+				...customPostTypes,
+			]);
+			expect(newState.limitTypes).toEqual([
+				...limitTypes,
+				...customLimitTypes,
+			]);
+			expect(newState.wasCustomPostTypesLoaded).toBe(true);
+		});
+	});
+
+	describe('LOAD_CUSTOM_TAXONOMIES', () => {
+		it('should add custom taxonomies to state', () => {
+			const customTaxonomies = ['genre', 'cuisine'];
+
+			const action = {
+				type: 'LOAD_CUSTOM_TAXONOMIES',
+				customTaxonomies,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.customTaxonomies).toEqual(customTaxonomies);
+			expect(newState.relationTypes).toEqual([
+				...relationTypes,
+				...customTaxonomies,
+			]);
+			expect(newState.wasCustomTaxonomiesLoaded).toBe(true);
+		});
+	});
+
+	describe('SET_ACF_GROUPS', () => {
+		it('should set ACF groups in state', () => {
+			const acfGroups = [
+				{ id: 1, title: 'Group 1' },
+				{ id: 2, title: 'Group 2' },
+			];
+
+			const action = {
+				type: 'SET_ACF_GROUPS',
+				acfGroups,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.acfGroups).toEqual(acfGroups);
+		});
+	});
+
+	describe('SET_ACF_FIELDS', () => {
+		it('should add ACF fields for a group', () => {
+			const groupId = 1;
+			const acfFields = [
+				{ id: 'field1', name: 'Field 1' },
+				{ id: 'field2', name: 'Field 2' },
+			];
+
+			const action = {
+				type: 'SET_ACF_FIELDS',
+				groupId,
+				acfFields,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.acfFields).toEqual({
+				[groupId]: acfFields,
+			});
+		});
+
+		it('should add ACF fields for multiple groups', () => {
+			const initialState = {
+				...expectedInitialState,
+				acfFields: {
+					1: [{ id: 'field1', name: 'Field 1' }],
+				},
+			};
+
+			const groupId = 2;
+			const acfFields = [
+				{ id: 'field2', name: 'Field 2' },
+				{ id: 'field3', name: 'Field 3' },
+			];
+
+			const action = {
+				type: 'SET_ACF_FIELDS',
+				groupId,
+				acfFields,
+			};
+
+			const newState = reducer(initialState, action);
+
+			expect(newState.acfFields).toEqual({
+				1: [{ id: 'field1', name: 'Field 1' }],
+				2: acfFields,
+			});
+		});
+	});
+
+	describe('SET_INTEGRATION_OPTIONS', () => {
+		it('should set integration options when ACF is present', () => {
+			const integrationPlugins = ['acf'];
+
+			const action = {
+				type: 'SET_INTEGRATION_OPTIONS',
+				integrationPlugins,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.sourceOptions).toContainEqual({
+				label: 'ACF',
+				value: 'acf',
+			});
+			expect(newState.integrationPlugins).toEqual(integrationPlugins);
+			expect(newState.integrationListLoaded).toBe(true);
+		});
+
+		it('should set integration options when WooCommerce is present', () => {
+			const integrationPlugins = ['woocommerce'];
+
+			const action = {
+				type: 'SET_INTEGRATION_OPTIONS',
+				integrationPlugins,
+			};
+
+			const newState = reducer(undefined, action);
+
+			WCTypeOptions.forEach(option => {
+				expect(newState.generalTypeOptions).toContainEqual(option);
+			});
+
+			expect(newState.imageTypeOptions).toContainEqual({
+				label: 'Product',
+				value: 'products',
+			});
+
+			expect(newState.integrationPlugins).toEqual(integrationPlugins);
+			expect(newState.integrationListLoaded).toBe(true);
+		});
+
+		it('should set integration options when both ACF and WooCommerce are present', () => {
+			const integrationPlugins = ['acf', 'woocommerce'];
+
+			const action = {
+				type: 'SET_INTEGRATION_OPTIONS',
+				integrationPlugins,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.sourceOptions).toContainEqual({
+				label: 'ACF',
+				value: 'acf',
+			});
+
+			WCTypeOptions.forEach(option => {
+				expect(newState.generalTypeOptions).toContainEqual(option);
+			});
+
+			expect(newState.imageTypeOptions).toContainEqual({
+				label: 'Product',
+				value: 'products',
+			});
+
+			expect(newState.typeOptions.text).toEqual(
+				newState.generalTypeOptions
+			);
+			expect(newState.typeOptions.image).toEqual(
+				newState.imageTypeOptions
+			);
+
+			expect(newState.integrationPlugins).toEqual(integrationPlugins);
+			expect(newState.integrationListLoaded).toBe(true);
+		});
+
+		it('should handle case when no integration plugins are provided', () => {
+			const action = {
+				type: 'SET_INTEGRATION_OPTIONS',
+				integrationPlugins: null,
+			};
+
+			const newState = reducer(undefined, action);
+
+			expect(newState.integrationPlugins).toEqual([]);
+			expect(newState.integrationListLoaded).toBe(true);
+			// Other options should remain unchanged
+			expect(newState.sourceOptions).toEqual(sourceOptions);
+			expect(newState.generalTypeOptions).toEqual(generalTypeOptions);
+		});
+	});
+});

--- a/src/extensions/DC/test/__snapshots__/getDCOptions.js.snap
+++ b/src/extensions/DC/test/__snapshots__/getDCOptions.js.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getIdOptions fetches categories correctly 1`] = `
+[
+  "taxonomy",
+  "category",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;
+
+exports[`getIdOptions fetches posts correctly 1`] = `
+[
+  "postType",
+  "post",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;
+
+exports[`getIdOptions handles by-custom-taxonomy relation correctly 1`] = `
+[
+  "taxonomy",
+  "product_cat",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;
+
+exports[`getIdOptions handles custom post types correctly 1`] = `
+[
+  "postType",
+  "custom-type",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;
+
+exports[`getIdOptions handles custom taxonomies correctly 1`] = `
+[
+  "taxonomy",
+  "custom-tax",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;
+
+exports[`getIdOptions handles pagination with correct per_page parameter 1`] = `
+[
+  "postType",
+  "post",
+  {
+    "_fields": [
+      "id",
+      "name",
+      "title",
+    ],
+    "orderby": "id",
+    "per_page": 100,
+  },
+]
+`;

--- a/src/extensions/DC/test/fetchAndUpdateDCData.js
+++ b/src/extensions/DC/test/fetchAndUpdateDCData.js
@@ -1,0 +1,416 @@
+import { dispatch, select } from '@wordpress/data';
+import fetchAndUpdateDCData from '@extensions/DC/fetchAndUpdateDCData';
+import { getGroupAttributes } from '@extensions/styles';
+import getDCContent from '@extensions/DC/getDCContent';
+import getDCMedia from '@extensions/DC/getDCMedia';
+import getDCNewLinkSettings from '@extensions/DC/getDCNewLinkSettings';
+import getDCValues from '@extensions/DC/getDCValues';
+import getValidatedDCAttributes from '@extensions/DC/validateDCAttributes';
+import { getUpdatedImgSVG } from '@extensions/svg';
+import { inlineLinkFields } from '@extensions/DC/constants';
+
+jest.mock('@wordpress/data', () => ({
+	dispatch: jest.fn(),
+	select: jest.fn(),
+}));
+jest.mock('@extensions/styles', () => ({
+	getGroupAttributes: jest.fn(),
+}));
+jest.mock('@extensions/DC/getDCContent', () => jest.fn());
+jest.mock('@extensions/DC/getDCMedia', () => jest.fn());
+jest.mock('@extensions/DC/getDCNewLinkSettings', () => jest.fn());
+jest.mock('@extensions/DC/getDCValues', () => jest.fn());
+jest.mock('@extensions/DC/validateDCAttributes', () => jest.fn());
+jest.mock('@extensions/svg', () => ({
+	getUpdatedImgSVG: jest.fn(),
+}));
+
+describe('fetchAndUpdateDCData', () => {
+	const mockAttributes = { uniqueID: 'test-id' };
+	const mockClientId = 'test-client-id';
+	const mockOnChange = jest.fn();
+	const mockContentType = 'text';
+	const mockContextLoop = { 'cl-status': false };
+	const mockMarkNextChangeAsNotPersistent = jest.fn();
+	const mockCustomTaxonomies = ['custom_tax1', 'custom_tax2'];
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		dispatch.mockImplementation(() => ({
+			__unstableMarkNextChangeAsNotPersistent:
+				mockMarkNextChangeAsNotPersistent,
+		}));
+
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomTaxonomies: () => mockCustomTaxonomies,
+				};
+			}
+			return {};
+		});
+	});
+
+	it('should return early if dynamic content and context loop are not active', async () => {
+		getGroupAttributes.mockReturnValue({ 'dc-status': false });
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			mockContentType,
+			mockClientId
+		);
+
+		expect(mockOnChange).not.toHaveBeenCalled();
+		expect(getDCValues).not.toHaveBeenCalled();
+	});
+
+	it('should return early if required dynamic content props are missing', async () => {
+		getGroupAttributes.mockReturnValue({ 'dc-status': true });
+		getDCValues.mockReturnValue({ content: 'test', type: 'posts' }); // Missing field and id
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			mockContentType,
+			mockClientId
+		);
+
+		expect(mockOnChange).not.toHaveBeenCalled();
+		expect(getValidatedDCAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should update text content when content changes', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: 'old content',
+			type: 'posts',
+			field: 'title',
+			id: 123,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockNewContent = 'new content';
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCContent.mockResolvedValue(mockNewContent);
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockMarkNextChangeAsNotPersistent).toHaveBeenCalled();
+		expect(mockOnChange).toHaveBeenCalledWith({
+			'dc-content': mockNewContent,
+			...mockSyncAttrs,
+		});
+	});
+
+	it('should update link settings when they change', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: 'test content',
+			type: 'posts',
+			field: 'title',
+			id: 123,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockNewLinkSettings = {
+			url: 'https://example.com',
+			title: 'Example',
+			disabled: false,
+		};
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCContent.mockResolvedValue(mockDynamicContentProps.content); // Same content
+		getDCNewLinkSettings.mockResolvedValue(mockNewLinkSettings);
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockMarkNextChangeAsNotPersistent).toHaveBeenCalled();
+		expect(mockOnChange).toHaveBeenCalledWith({
+			linkSettings: mockNewLinkSettings,
+			...mockSyncAttrs,
+		});
+	});
+
+	it('should handle HTML content', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: 'old content',
+			type: 'posts',
+			field: 'content',
+			id: 123,
+			linkTarget: 'content', // Same as field - will trigger HTML content handling
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockNewContent = '<p>HTML content</p>';
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCContent.mockResolvedValue(mockNewContent);
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		// Set up content field to be in inlineLinkFields
+		inlineLinkFields.push('content');
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockOnChange).toHaveBeenCalledWith({
+			'dc-content': mockNewContent,
+			'dc-contains-html': true,
+			...mockSyncAttrs,
+		});
+
+		inlineLinkFields.pop();
+	});
+
+	it('should update image content with media data', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: null,
+			type: 'media',
+			field: 'image',
+			id: 123,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockMediaContent = {
+			id: 456,
+			url: 'https://example.com/image.jpg',
+			caption: 'Test caption',
+		};
+		const mockSVGData = { key: 'value' };
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCMedia.mockResolvedValue(mockMediaContent);
+		getDCNewLinkSettings.mockResolvedValue(null);
+		getUpdatedImgSVG.mockReturnValue({ SVGData: mockSVGData });
+
+		await fetchAndUpdateDCData(
+			{ ...mockAttributes, SVGData: {}, SVGElement: {} },
+			mockOnChange,
+			mockContextLoop,
+			'image',
+			mockClientId
+		);
+
+		expect(mockOnChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'dc-media-id': mockMediaContent.id,
+				'dc-media-url': mockMediaContent.url,
+				'dc-media-caption': 'Test caption',
+				SVGData: mockSVGData,
+				...mockSyncAttrs,
+			})
+		);
+	});
+
+	it('should handle null media content', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: null,
+			type: 'media',
+			field: 'image',
+			id: 123,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCMedia.mockResolvedValue(null);
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'image',
+			mockClientId
+		);
+
+		expect(mockOnChange).toHaveBeenCalledWith({
+			'dc-media-id': null,
+			'dc-media-url': null,
+			...mockSyncAttrs,
+		});
+	});
+
+	it('should update only synchronizedAttributes when no other changes are needed', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: 'test content',
+			type: 'posts',
+			field: 'title',
+			id: 123,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp', 'dc-type': 'posts' };
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+
+		// Mock getDCContent to return the same content (no content change)
+		getDCContent.mockResolvedValue(mockDynamicContentProps.content);
+
+		// Mock getDCNewLinkSettings to return null (no link settings change)
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockMarkNextChangeAsNotPersistent).toHaveBeenCalled();
+		expect(mockOnChange).toHaveBeenCalledWith(mockSyncAttrs);
+	});
+
+	it('should handle special types like settings and cart', async () => {
+		const mockDynamicContent = { 'dc-status': true };
+		const mockDynamicContentProps = {
+			content: 'old content',
+			type: 'settings', // Special type that doesn't require id
+			field: 'site_title',
+			id: null,
+			linkTarget: 'entity',
+			containsHTML: false,
+		};
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockNewContent = 'Site Title';
+
+		getGroupAttributes.mockReturnValue(mockDynamicContent);
+		getDCValues
+			.mockReturnValueOnce(mockDynamicContentProps)
+			.mockReturnValueOnce(mockDynamicContentProps);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCContent.mockResolvedValue(mockNewContent);
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		await fetchAndUpdateDCData(
+			mockAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockOnChange).toHaveBeenCalledWith({
+			'dc-content': mockNewContent,
+			...mockSyncAttrs,
+		});
+	});
+
+	it('should handle date formatting with specific DC attributes', async () => {
+		const mockDCAttributes = {
+			'dc-error': '',
+			'dc-hide': true,
+			'dc-status': true,
+			'dc-id': 1,
+			'dc-author': 1,
+			'dc-show': 'current',
+			'dc-field': 'title',
+			'dc-format': 'd.m.Y t',
+			'dc-custom-date': false,
+			'dc-year': 'numeric',
+			'dc-month': 'numeric',
+			'dc-day': 'numeric',
+			'dc-hour': 'numeric',
+			'dc-hour12': false,
+			'dc-minute': 'numeric',
+			'dc-second': 'numeric',
+			'dc-locale': 'en',
+			'dc-timezone': 'Europe/London',
+			'dc-timezone-name': 'none',
+			'dc-weekday': 'none',
+			'dc-era': 'none',
+			'dc-limit': 100,
+			'dc-content': 'Hello world!',
+			'dc-media-size': 512,
+			'dc-delimiter-content': '',
+			'dc-contains-html': false,
+			'dc-image-accumulator': 0,
+			'dc-keep-only-text-content': false,
+			'dc-link-target': 'entity',
+			'dc-type': 'posts',
+			uniqueID: 'text-maxi-0f303954-u',
+		};
+
+		const mockSyncAttrs = { 'dc-source': 'wp' };
+		const mockNewContent = 'Updated title';
+
+		getGroupAttributes.mockReturnValue(mockDCAttributes);
+		getDCValues.mockImplementation(
+			jest.requireActual('@extensions/DC/getDCValues').default
+		);
+		getValidatedDCAttributes.mockResolvedValue(mockSyncAttrs);
+		getDCContent.mockResolvedValue(mockNewContent);
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		await fetchAndUpdateDCData(
+			mockDCAttributes,
+			mockOnChange,
+			mockContextLoop,
+			'text',
+			mockClientId
+		);
+
+		expect(mockMarkNextChangeAsNotPersistent).toHaveBeenCalled();
+		expect(mockOnChange).toHaveBeenCalledWith({
+			'dc-contains-html': false,
+			'dc-content': mockNewContent,
+			...mockSyncAttrs,
+		});
+	});
+});

--- a/src/extensions/DC/test/getCLAttributes.js
+++ b/src/extensions/DC/test/getCLAttributes.js
@@ -1,0 +1,113 @@
+/**
+ * Internal dependencies
+ */
+import getCLAttributes from '@extensions/DC/getCLAttributes';
+import { attributeDefaults } from '@extensions/DC/constants';
+
+jest.mock('lodash', () => ({
+	isFunction: jest.fn(val => typeof val === 'function'),
+	isNil: jest.fn(val => val === null || val === undefined),
+}));
+
+jest.mock('@extensions/DC/constants', () => ({
+	attributeDefaults: {
+		status: false,
+		source: 'wp',
+		type: 'posts',
+		relation: 'by-id',
+		'order-by': 'by-date',
+		order: jest.fn(attributes => {
+			const dictionary = {
+				'by-date': 'desc',
+				alphabetical: 'asc',
+			};
+			const relation =
+				attributes?.relation ?? attributes?.['cl-relation'];
+			const orderBy = attributes?.orderBy ?? attributes?.['cl-order-by'];
+
+			if (
+				[
+					'by-category',
+					'by-author',
+					'by-tag',
+					'current-archive',
+				].includes(relation)
+			) {
+				return dictionary[orderBy];
+			}
+			return dictionary[relation];
+		}),
+		accumulator: 0,
+	},
+}));
+
+describe('getCLAttributes', () => {
+	it('should return the input value when it is not nil', () => {
+		const contextLoop = {
+			'cl-status': true,
+			'cl-source': 'custom',
+			'cl-type': 'custom-type',
+		};
+
+		const result = getCLAttributes(contextLoop);
+
+		expect(result).toEqual({
+			'cl-status': true,
+			'cl-source': 'custom',
+			'cl-type': 'custom-type',
+		});
+	});
+
+	it('should use default value when input value is nil', () => {
+		const contextLoop = {
+			'cl-status': undefined,
+			'cl-source': null,
+			'cl-type': undefined,
+		};
+
+		const result = getCLAttributes(contextLoop);
+
+		expect(result).toEqual({
+			'cl-status': false,
+			'cl-source': 'wp',
+			'cl-type': 'posts',
+		});
+	});
+
+	it('should call function default with contextLoop when default is a function', () => {
+		const contextLoop = {
+			'cl-order': undefined,
+			'cl-relation': 'by-author',
+			'cl-order-by': 'by-date',
+		};
+
+		const result = getCLAttributes(contextLoop);
+
+		expect(result['cl-order']).toBe('desc');
+		expect(attributeDefaults.order).toHaveBeenCalledWith(contextLoop);
+	});
+
+	it('should handle mixed nil and non-nil values', () => {
+		const contextLoop = {
+			'cl-status': true,
+			'cl-source': undefined,
+			'cl-type': 'custom-type',
+			'cl-relation': undefined,
+		};
+
+		const result = getCLAttributes(contextLoop);
+
+		expect(result).toEqual({
+			'cl-status': true,
+			'cl-source': 'wp',
+			'cl-type': 'custom-type',
+			'cl-relation': 'by-id',
+		});
+	});
+
+	it('should handle empty input object', () => {
+		const contextLoop = {};
+		const result = getCLAttributes(contextLoop);
+		expect(result).toEqual({});
+	});
+});

--- a/src/extensions/DC/test/getDCContent.js
+++ b/src/extensions/DC/test/getDCContent.js
@@ -1,0 +1,255 @@
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import getDCContent from '@extensions/DC/getDCContent';
+import * as utils from '@extensions/DC/utils';
+import getDCEntity from '@extensions/DC/getDCEntity';
+import { getACFFieldContent } from '@extensions/DC/getACFData';
+import getACFContentByType from '@extensions/DC/getACFContentByType';
+import {
+	getCartContent,
+	getProductsContent,
+} from '@extensions/DC/getWCContent';
+import processDCDate, { formatDateOptions } from '@extensions/DC/processDCDate';
+
+jest.mock('@wordpress/data', () => ({
+	resolveSelect: jest.fn(),
+	select: jest.fn(store => {
+		if (store === 'maxiBlocks/dynamic-content') {
+			return {
+				getLimitTypes: jest.fn(),
+				getOrderTypes: jest.fn(),
+				getRelationTypes: jest.fn(),
+				getACFGroups: jest.fn(),
+				getACFFields: jest.fn(),
+				getCustomTaxonomies: jest.fn(),
+			};
+		}
+		return jest.fn();
+	}),
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: jest.fn(text => text),
+}));
+
+jest.mock('@extensions/DC/constants', () => ({
+	...jest.requireActual('@extensions/DC/constants'),
+	attributeDefaults: {
+		status: false,
+		source: 'wp',
+		type: 'posts',
+		relation: 'by-id',
+		'order-by': 'by-date',
+		order: jest.fn(attributes => ({
+			attributes,
+			order: 'ASC',
+		})),
+	},
+}));
+
+jest.mock('@extensions/DC/utils', () => ({
+	limitString: jest.fn((str, limit) => str),
+	parseText: jest.fn(text => text),
+	getSimpleText: jest.fn(text => text),
+	getItemLinkContent: jest.fn((content, linkStatus) => content),
+	getTaxonomyContent: jest.fn(async () => 'Taxonomy content'),
+	getCurrentTemplateSlug: jest.fn(() => 'archive-slug'),
+}));
+
+jest.mock('@extensions/DC/processDCDate', () => {
+	const processDCDate = jest.fn(() => 'Formatted date');
+	return {
+		__esModule: true,
+		default: processDCDate,
+		formatDateOptions: jest.fn(() => ({})),
+	};
+});
+
+jest.mock('@extensions/DC/getDCEntity', () => jest.fn());
+jest.mock('@extensions/DC/getACFData', () => ({
+	getACFFieldContent: jest.fn(),
+}));
+jest.mock('@extensions/DC/getACFContentByType', () => jest.fn());
+jest.mock('@extensions/DC/getWCContent', () => ({
+	getCartContent: jest.fn(),
+	getProductsContent: jest.fn(),
+}));
+
+describe('handleParentField', () => {
+	const originalHandleParentField = jest.requireActual(
+		'@extensions/DC/getDCContent'
+	).handleParentField;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return "No parent" if contentValue is falsy', async () => {
+		const mockResolveSelect = {
+			getEntityRecords: jest.fn(),
+		};
+		resolveSelect.mockReturnValue(mockResolveSelect);
+
+		const result = await originalHandleParentField(0, 'category');
+
+		expect(result).toBe('No parent');
+		expect(mockResolveSelect.getEntityRecords).not.toHaveBeenCalled();
+	});
+
+	it('should return parent name if found', async () => {
+		const mockResolveSelect = {
+			getEntityRecords: jest
+				.fn()
+				.mockResolvedValue([{ name: 'Parent Category' }]),
+		};
+		resolveSelect.mockReturnValue(mockResolveSelect);
+
+		const result = await originalHandleParentField(123, 'category');
+
+		expect(result).toBe('Parent Category');
+		expect(mockResolveSelect.getEntityRecords).toHaveBeenCalledWith(
+			'taxonomy',
+			'category',
+			{ per_page: 1, include: 123 }
+		);
+	});
+
+	it('should return "No parent" if parent is not found', async () => {
+		const mockResolveSelect = {
+			getEntityRecords: jest.fn().mockResolvedValue([]),
+		};
+		resolveSelect.mockReturnValue(mockResolveSelect);
+
+		const result = await originalHandleParentField(123, 'category');
+
+		expect(result).toBe('No parent');
+	});
+});
+
+describe('getDCContent', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.resetModules();
+	});
+
+	it('should return null if dataRequest is empty', async () => {
+		const result = await getDCContent({});
+		expect(result).toBeNull();
+	});
+
+	it('should handle archive-type field', async () => {
+		const result = await getDCContent({ field: 'archive-type' });
+		expect(utils.getCurrentTemplateSlug).toHaveBeenCalled();
+		expect(result).toBe('archive slug');
+	});
+
+	it('should return ACF field content', async () => {
+		getDCEntity.mockResolvedValue({ id: 123 });
+		getACFFieldContent.mockResolvedValue('ACF content');
+		getACFContentByType.mockReturnValue('Processed ACF content');
+
+		const result = await getDCContent({
+			source: 'acf',
+			field: 'acf_field',
+			acfFieldType: 'text',
+		});
+
+		expect(getACFFieldContent).toHaveBeenCalledWith('acf_field', 123);
+		expect(getACFContentByType).toHaveBeenCalledWith(
+			'ACF content',
+			'text',
+			expect.any(Object)
+		);
+		expect(result).toBe('Processed ACF content');
+	});
+
+	it('should handle example values for empty current relation data', async () => {
+		getDCEntity.mockResolvedValue({});
+
+		const result = await getDCContent({
+			source: 'acf',
+			relation: 'current',
+			field: 'test_field',
+		});
+
+		expect(result).toBe('Test_field: example value');
+	});
+
+	it('should handle products type', async () => {
+		getDCEntity.mockResolvedValue({ title: 'Product title' });
+		getProductsContent.mockReturnValue('Product content');
+
+		const dataRequest = {
+			type: 'products',
+			field: 'title',
+		};
+
+		const result = await getDCContent(dataRequest);
+
+		expect(getProductsContent).toHaveBeenCalledWith(dataRequest, {
+			title: 'Product title',
+		});
+		expect(result).toBe('Product content');
+	});
+
+	it('should handle cart type', async () => {
+		getDCEntity.mockResolvedValue({ items: [] });
+		getCartContent.mockReturnValue('Cart content');
+
+		const dataRequest = {
+			type: 'cart',
+			field: 'items',
+		};
+
+		const result = await getDCContent(dataRequest);
+
+		expect(getCartContent).toHaveBeenCalledWith(dataRequest, { items: [] });
+		expect(result).toBe('Cart content');
+	});
+
+	it('should handle date field', async () => {
+		getDCEntity.mockResolvedValue({ date: '2023-01-01' });
+		processDCDate.mockReturnValue('Formatted date');
+
+		const dataRequest = {
+			field: 'date',
+			customDate: 'custom',
+			format: 'F j, Y',
+			locale: 'en',
+		};
+
+		const result = await getDCContent(dataRequest);
+
+		expect(formatDateOptions).toHaveBeenCalledWith(dataRequest);
+		expect(processDCDate).toHaveBeenCalledWith(
+			'2023-01-01',
+			'custom',
+			'F j, Y',
+			'en',
+			{}
+		);
+		expect(result).toBe('Formatted date');
+	});
+
+	it('should use cache for repeated requests', async () => {
+		getDCEntity.mockResolvedValue({ title: 'Cached title' });
+		select.mockReturnValue({
+			getLimitTypes: jest.fn(
+				() => jest.requireActual('@extensions/DC/constants').limitTypes
+			),
+		});
+		const dataRequest = { field: 'title', type: 'posts' };
+
+		await getDCContent(dataRequest);
+		await getDCContent(dataRequest);
+
+		// getDCEntity should be called only once due to caching
+		expect(getDCEntity).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/extensions/DC/test/getDCEntity.js
+++ b/src/extensions/DC/test/getDCEntity.js
@@ -1,0 +1,445 @@
+/**
+ * WordPress dependencies
+ */
+import { select, resolveSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import getDCEntity from '@extensions/DC/getDCEntity';
+import getDCErrors from '@extensions/DC/getDCErrors';
+import {
+	getDCOrder,
+	getRelationKeyForId,
+	getCurrentTemplateSlug,
+	getPostBySlug,
+} from '@extensions/DC/utils';
+import { getCartData } from '@extensions/DC/getWooCommerceData';
+
+jest.mock('@wordpress/data', () => ({
+	select: jest.fn(),
+	resolveSelect: jest.fn(),
+}));
+
+jest.mock('@extensions/DC/getDCErrors', () => jest.fn());
+
+jest.mock('@extensions/DC/utils', () => ({
+	getDCOrder: jest.fn(),
+	getRelationKeyForId: jest.fn(),
+	getCurrentTemplateSlug: jest.fn(),
+	getPostBySlug: jest.fn(),
+}));
+
+jest.mock('@extensions/DC/getWooCommerceData', () => ({
+	getCartData: jest.fn(),
+}));
+
+describe('getDCEntity', () => {
+	const mockPost = {
+		id: 123,
+		title: { rendered: 'Test Post' },
+		content: { rendered: '<p>Test content</p>' },
+		excerpt: { rendered: '<p>Test excerpt</p>' },
+		link: '/test-post/',
+	};
+
+	const mockUser = {
+		id: 1,
+		name: 'Test User',
+		slug: 'test-user',
+	};
+
+	const mockCategory = {
+		id: 5,
+		name: 'Test Category',
+		slug: 'test-category',
+	};
+
+	const mockTag = {
+		id: 10,
+		name: 'Test Tag',
+		slug: 'test-tag',
+	};
+
+	const mockSettingsData = {
+		title: 'Site Title',
+		description: 'Site Description',
+	};
+
+	const mockCartData = {
+		items: [],
+		total: 0,
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		getDCErrors.mockReturnValue(false);
+		getCurrentTemplateSlug.mockReturnValue('single');
+		getDCOrder.mockImplementation((relation, orderBy) => {
+			if (relation === 'by-date') return 'date';
+			if (relation === 'alphabetical') return 'title';
+			return null;
+		});
+		getRelationKeyForId.mockReturnValue(null);
+		getPostBySlug.mockResolvedValue(null);
+		getCartData.mockResolvedValue(mockCartData);
+
+		const selectStores = {
+			'maxiBlocks/dynamic-content': {
+				getCustomPostTypes: () => [
+					'products',
+					'testimonials',
+					'wp_font_family',
+				],
+				getCustomTaxonomies: () => ['category', 'product_cat'],
+				getRelationTypes: () => ['posts', 'pages', 'products'],
+				getOrderTypes: () => ['posts', 'pages', 'products'],
+			},
+			core: {
+				getPostType: () => ({
+					taxonomies: ['category', 'post_tag'],
+				}),
+				getTaxonomy: () => mockCategory,
+				getCurrentUser: () => ({ id: 1 }),
+				getCurrentPostId: () => 123,
+			},
+			'core/edit-site': {},
+			'core/editor': {
+				getCurrentPostId: () => 123,
+			},
+		};
+		select.mockImplementation(store => {
+			return selectStores[store];
+		});
+
+		const resolveSelectStores = {
+			core: {
+				getEntityRecords: jest.fn().mockResolvedValue([mockPost]),
+				getEntityRecord: jest.fn().mockResolvedValue(mockPost),
+				getEditedEntityRecord: jest
+					.fn()
+					.mockResolvedValue(mockSettingsData),
+				getUsers: jest.fn().mockResolvedValue([mockUser]),
+				getUser: jest.fn().mockResolvedValue(mockUser),
+				getPostType: jest.fn().mockResolvedValue({
+					taxonomies: ['category', 'post_tag'],
+				}),
+				getTaxonomies: jest
+					.fn()
+					.mockResolvedValue([
+						{ slug: 'category' },
+						{ slug: 'post_tag' },
+					]),
+			},
+		};
+		resolveSelect.mockImplementation(store => {
+			return resolveSelectStores[store];
+		});
+	});
+
+	it('should return content error when there is an error', async () => {
+		const errorMessage = 'This is an error message';
+		getDCErrors.mockReturnValue(errorMessage);
+
+		const dataRequest = {
+			type: 'posts',
+			error: 'next',
+			show: 'next',
+			relation: 'by-id',
+		};
+
+		const result = await getDCEntity(dataRequest);
+		expect(result).toBe(errorMessage);
+		expect(getDCErrors).toHaveBeenCalledWith(
+			'posts',
+			'next',
+			'next',
+			'by-id'
+		);
+	});
+
+	it('should get user when type is users and relation is by-id', async () => {
+		const dataRequest = {
+			type: 'users',
+			id: 1,
+			relation: 'by-id',
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(result).toEqual(mockUser);
+		expect(resolveSelect('core').getUser).toHaveBeenCalledWith(1);
+	});
+
+	it('should get user based on author id when specified', async () => {
+		const dataRequest = {
+			type: 'users',
+			id: 2,
+			author: 5,
+			relation: 'by-id',
+		};
+
+		await getDCEntity(dataRequest);
+
+		expect(resolveSelect('core').getUser).toHaveBeenCalledWith(5);
+	});
+
+	it('should get random user when relation is random', async () => {
+		const dataRequest = {
+			type: 'users',
+			relation: 'random',
+			accumulator: 0.5,
+		};
+
+		const users = [
+			{ id: 1, name: 'User 1' },
+			{ id: 2, name: 'User 2' },
+			{ id: 3, name: 'User 3' },
+		];
+
+		const mockGetUsers = jest.fn().mockResolvedValue(users);
+		resolveSelect.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getUsers: mockGetUsers,
+				};
+			}
+			return null;
+		});
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(resolveSelect('core').getUsers).toHaveBeenCalledWith({
+			who: 'authors',
+			per_page: 100,
+			hide_empty: false,
+		});
+		expect(users).toContain(result);
+	});
+
+	it('should get users by date', async () => {
+		const dataRequest = {
+			type: 'users',
+			relation: 'by-date',
+			order: 'desc',
+			accumulator: 2,
+		};
+
+		const users = [
+			{ id: 1, name: 'User 1' },
+			{ id: 2, name: 'User 2' },
+			{ id: 3, name: 'User 3' },
+		];
+
+		const mockGetUsers = jest.fn().mockResolvedValue(users);
+		resolveSelect.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getUsers: mockGetUsers,
+				};
+			}
+			return null;
+		});
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(resolveSelect('core').getUsers).toHaveBeenCalledWith({
+			who: 'authors',
+			per_page: 3,
+			hide_empty: false,
+			order: 'desc',
+			orderby: 'registered_date',
+		});
+		expect(result).toEqual(users[2]);
+	});
+
+	it('should get random entity when relation is random', async () => {
+		const dataRequest = {
+			type: 'posts',
+			relation: 'random',
+			accumulator: 0.7,
+		};
+
+		const posts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+			{ id: 3, title: { rendered: 'Post 3' } },
+		];
+
+		const mockGetEntityRecords = jest.fn().mockResolvedValue(posts);
+		resolveSelect.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getEntityRecords: mockGetEntityRecords,
+				};
+			}
+			return null;
+		});
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(resolveSelect('core').getEntityRecords).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			{
+				per_page: 100,
+				hide_empty: false,
+			}
+		);
+		expect(posts).toContain(result);
+	});
+
+	it('should get settings when type is settings', async () => {
+		const dataRequest = {
+			type: 'settings',
+			relation: 'by-id',
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(result).toEqual(mockSettingsData);
+		expect(
+			resolveSelect('core').getEditedEntityRecord
+		).toHaveBeenCalledWith('root', 'site');
+	});
+
+	it('should get cart data when type is cart', async () => {
+		const dataRequest = {
+			type: 'cart',
+			relation: 'by-id',
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(result).toEqual(mockCartData);
+		expect(getCartData).toHaveBeenCalled();
+	});
+
+	it('should get ordered entities', async () => {
+		getRelationKeyForId.mockReturnValue('author');
+		getDCOrder.mockReturnValue('date');
+
+		const dataRequest = {
+			type: 'posts',
+			relation: 'by-author',
+			id: 1,
+			order: 'desc',
+			orderBy: 'by-date',
+			accumulator: 0,
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(getDCOrder).toHaveBeenCalledWith('by-author', 'by-date');
+		expect(getRelationKeyForId).toHaveBeenCalledWith('by-author', 'posts');
+		expect(resolveSelect('core').getEntityRecords).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			{
+				per_page: 1,
+				order: 'desc',
+				orderby: 'date',
+				offset: 0,
+				author: 1,
+			}
+		);
+		expect(result).toEqual(mockPost);
+	});
+
+	it('should handle current relation in FSE for single posts', async () => {
+		select.mockImplementation(store => {
+			if (store === 'core/edit-site') {
+				return {}; // Exists
+			}
+			return select.mock.results[0].value;
+		});
+
+		getCurrentTemplateSlug.mockReturnValue('single-post-test-post');
+		getPostBySlug.mockResolvedValue(mockPost);
+
+		const dataRequest = {
+			type: 'posts',
+			relation: 'current',
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(getCurrentTemplateSlug).toHaveBeenCalled();
+		expect(getPostBySlug).toHaveBeenCalledWith('test-post');
+		expect(result).toEqual(mockPost);
+	});
+
+	it('should get taxonomy terms by ID', async () => {
+		const dataRequest = {
+			type: 'tags',
+			id: 10,
+			relation: 'by-id',
+		};
+
+		const mockGetEntityRecords = jest.fn().mockResolvedValue([mockTag]);
+		resolveSelect.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getEntityRecords: mockGetEntityRecords,
+				};
+			}
+			return null;
+		});
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(resolveSelect('core').getEntityRecords).toHaveBeenCalledWith(
+			'taxonomy',
+			'post_tag',
+			{
+				per_page: 1,
+				hide_empty: false,
+				include: 10,
+			}
+		);
+		expect(result).toEqual(mockTag);
+	});
+
+	it('should cache and reuse existing entities', async () => {
+		getRelationKeyForId.mockReturnValue('author');
+
+		await getDCEntity({
+			type: 'posts',
+			relation: 'by-author',
+			id: 1,
+		});
+
+		resolveSelect.mockClear();
+
+		await getDCEntity({
+			type: 'posts',
+			relation: 'by-author',
+			id: 1,
+		});
+
+		expect(resolveSelect('core').getEntityRecord.mock.calls.length).toBe(0);
+	});
+
+	it('should return null when entity does not exist', async () => {
+		resolveSelect.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getEntityRecords: jest.fn().mockResolvedValue([]),
+					getEntityRecord: jest.fn().mockResolvedValue(null),
+				};
+			}
+			return null;
+		});
+
+		const dataRequest = {
+			type: 'posts',
+			id: 999,
+			relation: 'by-id',
+		};
+
+		const result = await getDCEntity(dataRequest);
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/extensions/DC/test/getDCImgSVG.js
+++ b/src/extensions/DC/test/getDCImgSVG.js
@@ -1,0 +1,247 @@
+/**
+ * Internal dependencies
+ */
+import getDCImgSVG from '@extensions/DC/getDCImgSVG';
+import { injectImgSVG } from '@extensions/svg';
+
+/**
+ * External dependencies
+ */
+import DOMPurify from 'dompurify';
+
+jest.mock('@extensions/svg', () => ({
+	injectImgSVG: jest.fn(),
+}));
+
+jest.mock('dompurify', () => ({
+	sanitize: jest.fn(),
+}));
+
+describe('getDCImgSVG', () => {
+	let documentCreateRangeMock;
+	let rangeCreateContextualFragmentMock;
+	let firstElementChildMock;
+	let createRangeSpy;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		firstElementChildMock = {
+			outerHTML: '<svg>mocked svg content</svg>',
+		};
+
+		rangeCreateContextualFragmentMock = {
+			firstElementChild: firstElementChildMock,
+		};
+
+		documentCreateRangeMock = {
+			createContextualFragment: jest
+				.fn()
+				.mockReturnValue(rangeCreateContextualFragmentMock),
+		};
+
+		createRangeSpy = jest
+			.spyOn(document, 'createRange')
+			.mockReturnValue(documentCreateRangeMock);
+
+		injectImgSVG.mockReturnValue({
+			outerHTML: '<svg>processed svg content</svg>',
+		});
+
+		DOMPurify.sanitize.mockImplementation(content => content);
+	});
+
+	afterEach(() => {
+		createRangeSpy.mockRestore();
+	});
+
+	it('should return processed SVG content for valid input', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		const result = getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		expect(DOMPurify.sanitize).toHaveBeenCalledWith(SVGElement);
+		expect(document.createRange).toHaveBeenCalled();
+		expect(
+			documentCreateRangeMock.createContextualFragment
+		).toHaveBeenCalledWith(SVGElement);
+		expect(injectImgSVG).toHaveBeenCalledWith(
+			firstElementChildMock,
+			expect.objectContaining({
+				'test-key': expect.objectContaining({
+					imageID: '$media-id-to-replace',
+					imageURL: '$media-url-to-replace',
+				}),
+			}),
+			false,
+			uniqueID
+		);
+		expect(result).toBe('<svg>processed svg content</svg>');
+	});
+
+	it('should handle empty SVGData object', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		const result = getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		expect(injectImgSVG).toHaveBeenCalledWith(
+			firstElementChildMock,
+			{}, // Empty object should be passed as is
+			false,
+			uniqueID
+		);
+		expect(result).toBe('<svg>processed svg content</svg>');
+	});
+
+	it('should properly prepare SVGData by replacing media values with placeholders', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'layer-1': {
+				imageID: 123,
+				imageURL: 'https://example.com/image1.jpg',
+				color: '#ff0000',
+			},
+			'layer-2': {
+				imageID: 456,
+				imageURL: 'https://example.com/image2.jpg',
+				color: '#00ff00',
+			},
+		};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		// Verify the SVGData was properly prepared by replacing media values
+		expect(injectImgSVG).toHaveBeenCalledWith(
+			firstElementChildMock,
+			{
+				'layer-1': {
+					imageID: '$media-id-to-replace',
+					imageURL: '$media-url-to-replace',
+					color: '#ff0000',
+				},
+				'layer-2': {
+					imageID: '$media-id-to-replace',
+					imageURL: '$media-url-to-replace',
+					color: '#00ff00',
+				},
+			},
+			false,
+			uniqueID
+		);
+	});
+
+	it('should sanitize SVG content using DOMPurify', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const SVGElement =
+			'<svg><script>alert("XSS")</script><path d="M0 0h100v100H0z" /></svg>';
+
+		getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		expect(DOMPurify.sanitize).toHaveBeenCalledWith(SVGElement);
+	});
+
+	it('should correctly create DOM fragments and access firstElementChild', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		expect(document.createRange).toHaveBeenCalled();
+		expect(
+			documentCreateRangeMock.createContextualFragment
+		).toHaveBeenCalledWith(SVGElement);
+		expect(injectImgSVG.mock.calls[0][0]).toBe(firstElementChildMock);
+	});
+
+	it('should return the outerHTML of the injected SVG element', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		// Set a custom outerHTML value for the injected SVG
+		injectImgSVG.mockReturnValueOnce({
+			outerHTML: '<svg class="modified">processed svg content</svg>',
+		});
+
+		const result = getDCImgSVG(uniqueID, SVGData, SVGElement);
+
+		expect(result).toBe(
+			'<svg class="modified">processed svg content</svg>'
+		);
+	});
+
+	it('should handle different SVG content structures', () => {
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const complexSVGElement = `
+			<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+				<circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+				<rect x="10" y="10" width="80" height="80" fill="blue" opacity="0.5" />
+			</svg>
+		`;
+
+		getDCImgSVG(uniqueID, SVGData, complexSVGElement);
+
+		expect(DOMPurify.sanitize).toHaveBeenCalledWith(complexSVGElement);
+		expect(
+			documentCreateRangeMock.createContextualFragment
+		).toHaveBeenCalledWith(complexSVGElement);
+	});
+
+	it('should handle errors in the DOM manipulation process', () => {
+		// Simulate an error in document.createRange by restoring the original spy
+		// and creating a new one that throws an error
+		createRangeSpy.mockRestore();
+		createRangeSpy = jest
+			.spyOn(document, 'createRange')
+			.mockImplementation(() => {
+				throw new Error('DOM manipulation error');
+			});
+
+		const uniqueID = 'test-id';
+		const SVGData = {
+			'test-key': {
+				imageID: 123,
+				imageURL: 'https://example.com/image.jpg',
+			},
+		};
+		const SVGElement = '<svg><path d="M0 0h100v100H0z" /></svg>';
+
+		// The function should throw an error
+		expect(() => {
+			getDCImgSVG(uniqueID, SVGData, SVGElement);
+		}).toThrow('DOM manipulation error');
+	});
+});

--- a/src/extensions/DC/test/getDCLink.js
+++ b/src/extensions/DC/test/getDCLink.js
@@ -1,0 +1,244 @@
+import { resolveSelect, select } from '@wordpress/data';
+import getDCLink, { cache } from '@extensions/DC/getDCLink';
+import getDCEntity from '@extensions/DC/getDCEntity';
+import { getCartUrl, getProductData } from '@extensions/DC/getWooCommerceData';
+import { inlineLinkFields } from '@extensions/DC/constants';
+import { getCurrentTemplateSlug, getPostBySlug } from '@extensions/DC/utils';
+
+jest.mock('@wordpress/data', () => ({
+	resolveSelect: jest.fn(),
+	select: jest.fn(),
+}));
+
+jest.mock('@extensions/DC/getDCEntity');
+jest.mock('@extensions/DC/getWooCommerceData');
+jest.mock('@extensions/DC/utils');
+
+describe('getDCLink', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Clear cache before each test
+		Object.keys(cache).forEach(key => delete cache[key]);
+	});
+
+	it('should return cart URL for cart type', async () => {
+		const mockCartUrl = 'https://example.com/cart';
+		getCartUrl.mockResolvedValue(mockCartUrl);
+
+		const result = await getDCLink({ type: 'cart' }, 'client-1');
+		expect(result).toBe(mockCartUrl);
+	});
+
+	it('should handle author link target', async () => {
+		const mockUserLink = 'https://example.com/author/john';
+		resolveSelect.mockImplementation(() => ({
+			getUsers: () => Promise.resolve([{ link: mockUserLink }]),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'author', author: 123 },
+			'client-1'
+		);
+		expect(result).toBe(mockUserLink);
+	});
+
+	it('should handle current author in FSE template', async () => {
+		const mockPost = { author: 456 };
+		const mockUserLink = 'https://example.com/author/jane';
+
+		select.mockImplementation(() => ({
+			'core/edit-site': {},
+		}));
+		getCurrentTemplateSlug.mockReturnValue('single-post-test');
+		getPostBySlug.mockResolvedValue(mockPost);
+		resolveSelect.mockImplementation(() => ({
+			getUsers: () => Promise.resolve([{ link: mockUserLink }]),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'author', relation: 'current' },
+			'client-1'
+		);
+		expect(result).toBe(mockUserLink);
+	});
+
+	it('should handle author email link target', async () => {
+		const mockUser = { email: 'test@example.com' };
+		resolveSelect.mockImplementation(() => ({
+			getUser: () => Promise.resolve(mockUser),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'author_email', author: 123 },
+			'client-1'
+		);
+		expect(result).toBe('test@example.com');
+	});
+
+	it('should handle author site link target', async () => {
+		const mockUser = { url: 'https://example.com' };
+		resolveSelect.mockImplementation(() => ({
+			getUser: () => Promise.resolve(mockUser),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'author_site', author: 123 },
+			'client-1'
+		);
+		expect(result).toBe('https://example.com');
+	});
+
+	it('should handle default user link', async () => {
+		getDCEntity.mockResolvedValue({
+			link: 'https://example.com/author/john',
+			author: { link: 'https://example.com/author/john' },
+		});
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'entity', author: 123 },
+			'client-1'
+		);
+		expect(result).toBe('https://example.com/author/john');
+	});
+
+	it('should return null for missing author email', async () => {
+		const mockUser = { email: null };
+		resolveSelect.mockImplementation(() => ({
+			getUser: () => Promise.resolve(mockUser),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'author_email', author: 123 },
+			'client-1'
+		);
+		expect(result).toBeNull();
+	});
+
+	it('should return null for missing author site', async () => {
+		const mockUser = { url: null };
+		resolveSelect.mockImplementation(() => ({
+			getUser: () => Promise.resolve(mockUser),
+		}));
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'author_site', author: 123 },
+			'client-1'
+		);
+		expect(result).toBeNull();
+	});
+
+	it('should return null for missing default user link', async () => {
+		getDCEntity.mockResolvedValue({ link: null });
+
+		const result = await getDCLink(
+			{ type: 'users', linkTarget: 'entity', author: 123 },
+			'client-1'
+		);
+		expect(result).toBeNull();
+	});
+
+	it('should return "Multiple Links" for inline link fields', async () => {
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: inlineLinkFields[0] },
+			'client-1'
+		);
+		expect(result).toBe('Multiple Links');
+	});
+
+	it('should return "Multiple Links" for custom taxonomies', async () => {
+		select.mockImplementation(() => ({
+			getCustomTaxonomies: () => ['custom_tax'],
+		}));
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'custom_tax' },
+			'client-1'
+		);
+		expect(result).toBe('Multiple Links');
+	});
+
+	it('should handle product links', async () => {
+		const mockProductData = {
+			permalink: 'https://example.com/product/test',
+		};
+		getDCEntity.mockResolvedValue({ id: 789 });
+		getProductData.mockResolvedValue(mockProductData);
+
+		const result = await getDCLink(
+			{ type: 'products', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(result).toBe(mockProductData.permalink);
+	});
+
+	it('should handle add to cart product links', async () => {
+		const mockSiteUrl = 'https://example.com';
+		const mockAddToCartUrl = '/add-to-cart/789';
+		const mockProductData = {
+			add_to_cart: { url: mockAddToCartUrl },
+		};
+
+		select.mockImplementation(() => ({
+			getSite: () => ({ url: mockSiteUrl }),
+			getCustomTaxonomies: () => ['custom_tax'],
+		}));
+		getDCEntity.mockResolvedValue({ id: 789 });
+		getProductData.mockResolvedValue(mockProductData);
+
+		const result = await getDCLink(
+			{ type: 'products', linkTarget: 'add_to_cart' },
+			'client-1'
+		);
+		expect(result).toBe(`${mockSiteUrl}${mockAddToCartUrl}`);
+	});
+
+	it('should handle settings links', async () => {
+		const mockSettingsData = { url: 'https://example.com/settings' };
+		getDCEntity.mockResolvedValue(mockSettingsData);
+
+		const result = await getDCLink(
+			{ type: 'settings', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(result).toBe(mockSettingsData.url);
+	});
+
+	it('should handle default entity links', async () => {
+		const mockEntityData = { link: 'https://example.com/post/123' };
+		getDCEntity.mockResolvedValue(mockEntityData);
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(result).toBe(mockEntityData.link);
+	});
+
+	it('should return null when no data is available', async () => {
+		getDCEntity.mockResolvedValue(null);
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(result).toBeNull();
+	});
+
+	it('should cache links', async () => {
+		getDCEntity.mockResolvedValueOnce({ link: 'test' });
+		getDCEntity.mockResolvedValueOnce({ link: 'test2' });
+
+		const result = await getDCLink(
+			{ type: 'posts', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(result).toBe('test');
+
+		const cachedResult = await getDCLink(
+			{ type: 'posts', linkTarget: 'entity' },
+			'client-1'
+		);
+		expect(cachedResult).toBe('test');
+	});
+});

--- a/src/extensions/DC/test/getDCMedia.js
+++ b/src/extensions/DC/test/getDCMedia.js
@@ -1,0 +1,222 @@
+import { resolveSelect } from '@wordpress/data';
+import getDCMedia, { cache } from '@extensions/DC/getDCMedia';
+import getDCEntity from '@extensions/DC/getDCEntity';
+import { getACFFieldContent } from '@extensions/DC/getACFData';
+import { getProductsContent } from '@extensions/DC/getWCContent';
+
+jest.mock('@wordpress/data', () => ({
+	resolveSelect: jest.fn(),
+}));
+
+jest.mock('@wordpress/i18n', () => ({
+	__: jest.fn(str => str),
+}));
+
+jest.mock('@extensions/DC/getDCEntity');
+jest.mock('@extensions/DC/getACFData');
+jest.mock('@extensions/DC/getWCContent');
+
+describe('getDCMedia', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		// Clear cache before each test
+		Object.keys(cache).forEach(key => delete cache[key]);
+	});
+
+	it('should handle user avatar', async () => {
+		const mockUser = {
+			avatar_urls: {
+				24: 'https://example.com/avatar.jpg?s=24',
+				48: 'https://example.com/avatar.jpg?s=48',
+				96: 'https://example.com/avatar.jpg?s=96',
+			},
+		};
+		getDCEntity.mockResolvedValue(mockUser);
+
+		const result = await getDCMedia(
+			{ type: 'users', field: 'avatar', mediaSize: 48 },
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			url: 'https://example.com/avatar.jpg?s=48',
+		});
+	});
+
+	it('should handle author avatar for posts', async () => {
+		const mockPost = { author: 123 };
+		const mockAuthor = {
+			avatar_urls: {
+				96: 'https://example.com/author.jpg?s=96',
+			},
+		};
+
+		getDCEntity.mockResolvedValue(mockPost);
+		resolveSelect.mockImplementation(() => ({
+			getUser: () => Promise.resolve(mockAuthor),
+		}));
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'author_avatar', mediaSize: 48 },
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			url: 'https://example.com/author.jpg?s=48',
+		});
+	});
+
+	it('should handle ACF field with URL return format', async () => {
+		const mockPost = { id: 123 };
+		const mockACFField = {
+			return_format: 'url',
+			value: 'https://example.com/image.jpg',
+		};
+
+		getDCEntity.mockResolvedValue(mockPost);
+		getACFFieldContent.mockResolvedValue(mockACFField);
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'custom_image', source: 'acf' },
+			'client-1'
+		);
+
+		expect(result).toEqual({ url: 'https://example.com/image.jpg' });
+	});
+
+	it('should handle ACF field with ID return format', async () => {
+		const mockPost = { id: 123 };
+		const mockACFField = {
+			return_format: 'id',
+			value: 456,
+		};
+		const mockMedia = {
+			source_url: 'https://example.com/media.jpg',
+			caption: { rendered: 'Test Caption' },
+		};
+
+		getDCEntity.mockResolvedValue(mockPost);
+		getACFFieldContent.mockResolvedValue(mockACFField);
+		resolveSelect.mockImplementation(() => ({
+			getMedia: () => Promise.resolve(mockMedia),
+		}));
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'custom_image', source: 'acf' },
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			id: 456,
+			url: 'https://example.com/media.jpg',
+			caption: 'Test Caption',
+		});
+	});
+
+	it('should handle product media', async () => {
+		const mockProduct = { id: 123 };
+		const mockMedia = {
+			source_url: 'https://example.com/product.jpg',
+			caption: { rendered: 'Product Image' },
+		};
+
+		getDCEntity.mockResolvedValue(mockProduct);
+		getProductsContent.mockResolvedValue(456);
+		resolveSelect.mockImplementation(() => ({
+			getMedia: () => Promise.resolve(mockMedia),
+		}));
+
+		const result = await getDCMedia(
+			{ type: 'products', field: 'featured_image' },
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			id: 456,
+			url: 'https://example.com/product.jpg',
+			caption: 'Product Image',
+		});
+	});
+
+	it('should handle regular media', async () => {
+		const mockPost = { featured_image: 789 };
+		const mockMedia = {
+			source_url: 'https://example.com/post.jpg',
+			caption: { rendered: 'Post Image' },
+		};
+
+		getDCEntity.mockResolvedValue(mockPost);
+		resolveSelect.mockImplementation(() => ({
+			getMedia: () => Promise.resolve(mockMedia),
+		}));
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'featured_image' },
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			id: 789,
+			url: 'https://example.com/post.jpg',
+			caption: 'Post Image',
+		});
+	});
+
+	it('should return null when media fetch fails', async () => {
+		const mockPost = { featured_image: 789 };
+		const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+		getDCEntity.mockResolvedValue(mockPost);
+		resolveSelect.mockImplementation(() => ({
+			getMedia: () => Promise.reject(new Error('Media not found')),
+		}));
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'featured_image' },
+			'client-1'
+		);
+
+		expect(result).toBeNull();
+		expect(consoleSpy).toHaveBeenCalled();
+		consoleSpy.mockRestore();
+	});
+
+	it('should cache media data', async () => {
+		const mockPost = { featured_image: 789 };
+		const mockMedia = {
+			source_url: 'https://example.com/post.jpg',
+			caption: { rendered: 'Post Image' },
+		};
+
+		getDCEntity.mockResolvedValueOnce(mockPost);
+		resolveSelect.mockImplementation(() => ({
+			getMedia: () => Promise.resolve(mockMedia),
+		}));
+
+		// First call
+		const result1 = await getDCMedia(
+			{ type: 'posts', field: 'featured_image' },
+			'client-1'
+		);
+
+		// Second call should use cache
+		const result2 = await getDCMedia(
+			{ type: 'posts', field: 'featured_image' },
+			'client-1'
+		);
+
+		expect(result1).toEqual(result2);
+		expect(getDCEntity).toHaveBeenCalledTimes(1);
+	});
+
+	it('should return null when no data is available', async () => {
+		getDCEntity.mockResolvedValue(null);
+
+		const result = await getDCMedia(
+			{ type: 'posts', field: 'featured_image' },
+			'client-1'
+		);
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/extensions/DC/test/getDCNewLinkSettings.js
+++ b/src/extensions/DC/test/getDCNewLinkSettings.js
@@ -1,0 +1,176 @@
+import getDCNewLinkSettings from '@extensions/DC/getDCNewLinkSettings';
+import getDCLink from '@extensions/DC/getDCLink';
+
+jest.mock('@extensions/DC/getDCLink');
+
+describe('getDCNewLinkSettings', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should update disabled status when postTaxonomyLinksStatus changes', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://example.com',
+				title: 'Example',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: true,
+			linkStatus: true,
+		};
+
+		getDCLink.mockResolvedValue('https://example.com');
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			disabled: true,
+			url: 'https://example.com',
+			title: 'Example',
+		});
+	});
+
+	it('should update URL and title when link changes and linkStatus is true', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://old-url.com',
+				title: 'Old URL',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: false,
+			linkStatus: true,
+		};
+
+		getDCLink.mockResolvedValue('https://new-url.com');
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			disabled: false,
+			url: 'https://new-url.com',
+			title: 'https://new-url.com',
+		});
+	});
+
+	it('should clear URL and title when linkStatus is false and current URL matches dcLink', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://example.com',
+				title: 'Example',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: false,
+			linkStatus: false,
+		};
+
+		getDCLink.mockResolvedValue('https://example.com');
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			disabled: false,
+			url: null,
+			title: null,
+		});
+	});
+
+	it('should return null when no changes are needed', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://example.com',
+				title: 'Example',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: false,
+			linkStatus: true,
+		};
+
+		getDCLink.mockResolvedValue('https://example.com');
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it('should handle null dcLink value', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://example.com',
+				title: 'Example',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: false,
+			linkStatus: true,
+		};
+
+		getDCLink.mockResolvedValue(null);
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it('should update both disabled and URL/title when both conditions are met', async () => {
+		const attributes = {
+			linkSettings: {
+				disabled: false,
+				url: 'https://old-url.com',
+				title: 'Old URL',
+			},
+		};
+
+		const dynamicContentProps = {
+			postTaxonomyLinksStatus: true,
+			linkStatus: true,
+		};
+
+		getDCLink.mockResolvedValue('https://new-url.com');
+
+		const result = await getDCNewLinkSettings(
+			attributes,
+			dynamicContentProps,
+			'client-1'
+		);
+
+		expect(result).toEqual({
+			disabled: true,
+			url: 'https://new-url.com',
+			title: 'https://new-url.com',
+		});
+	});
+});

--- a/src/extensions/DC/test/getDCOptions.js
+++ b/src/extensions/DC/test/getDCOptions.js
@@ -63,6 +63,7 @@ describe('getIdOptions', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		clearIdOptionsCache();
+		localStorage.clear();
 
 		// Reset the timestamp to control cache testing
 		jest.spyOn(Date, 'now').mockImplementation(() => 1000);
@@ -102,9 +103,7 @@ describe('getIdOptions', () => {
 
 		const result = await getIdOptions('posts', 'by-id', null, false, false);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
-			per_page: -1,
-		});
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 		expect(result).toEqual(mockPosts);
 	});
 
@@ -164,15 +163,7 @@ describe('getIdOptions', () => {
 			false
 		);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith(
-			'taxonomy',
-			'category',
-			expect.objectContaining({
-				_fields: ['id', 'name'],
-				orderby: 'id',
-				per_page: 100,
-			})
-		);
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 		expect(result).toEqual(mockCategories);
 	});
 
@@ -205,11 +196,7 @@ describe('getIdOptions', () => {
 			false
 		);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith(
-			'postType',
-			'custom-type',
-			{ per_page: -1 }
-		);
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 		expect(result).toEqual(mockCustomPosts);
 	});
 
@@ -229,11 +216,7 @@ describe('getIdOptions', () => {
 			true
 		);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith(
-			'taxonomy',
-			'custom-tax',
-			{ per_page: -1 }
-		);
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 		expect(result).toEqual(mockCustomTaxonomy);
 	});
 
@@ -253,27 +236,16 @@ describe('getIdOptions', () => {
 			false
 		);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith(
-			'taxonomy',
-			'product_cat',
-			{ per_page: -1 }
-		);
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 		expect(result).toEqual(mockTaxonomyTerms);
 	});
 
 	it('handles errors gracefully', async () => {
 		mockGetEntityRecords.mockRejectedValue(new Error('API error'));
 
-		// Mock console.error to avoid test output pollution
-		const originalConsoleError = console.error;
-		console.error = jest.fn();
-
 		const result = await getIdOptions('posts', 'by-id', null, false, false);
 
-		expect(result).toBeNull();
-		expect(console.error).toHaveBeenCalled();
-
-		console.error = originalConsoleError;
+		expect(result).toEqual([]);
 	});
 
 	it('handles pagination with correct per_page parameter', async () => {
@@ -286,11 +258,7 @@ describe('getIdOptions', () => {
 
 		await getIdOptions('posts', 'by-date', null, false, false, 5);
 
-		expect(mockGetEntityRecords).toHaveBeenCalledWith(
-			'postType',
-			'post',
-			{ per_page: 15 } // 5 * 3 as per the function logic
-		);
+		expect(mockGetEntityRecords.mock.calls[0]).toMatchSnapshot();
 	});
 });
 

--- a/src/extensions/DC/test/getDCOptions.js
+++ b/src/extensions/DC/test/getDCOptions.js
@@ -1,0 +1,481 @@
+/**
+ * External dependencies
+ */
+import { jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { resolveSelect, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import getDCOptions, {
+	getIdOptions,
+	clearIdOptionsCache,
+} from '@extensions/DC/getDCOptions';
+
+// Mock WordPress dependencies
+jest.mock('@wordpress/data', () => ({
+	resolveSelect: jest.fn(),
+	select: jest.fn(),
+}));
+
+jest.mock('@wordpress/core-data', () => ({
+	store: 'core',
+}));
+
+// Mock utils
+jest.mock('@extensions/DC/utils', () => ({
+	getFields: jest.fn(() => [{ value: 'title' }]),
+	limitString: jest.fn(str => str),
+	getCurrentTemplateSlug: jest.fn(() => 'single'),
+}));
+
+// Mock DC constants
+jest.mock('@extensions/DC/constants', () => ({
+	idTypes: [
+		'posts',
+		'pages',
+		'users',
+		'categories',
+		'tags',
+		'media',
+		'products',
+		'product_categories',
+		'product_tags',
+	],
+	orderByRelations: ['by-category'],
+	idOptionByField: {
+		posts: 'title',
+		pages: 'title',
+		media: 'title',
+		products: 'title',
+		users: 'name',
+	},
+}));
+
+describe('getIdOptions', () => {
+	let mockGetEntityRecords;
+	let mockGetUsers;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		clearIdOptionsCache();
+
+		// Reset the timestamp to control cache testing
+		jest.spyOn(Date, 'now').mockImplementation(() => 1000);
+
+		// Set up commonly used mocks
+		mockGetEntityRecords = jest.fn();
+		mockGetUsers = jest.fn();
+
+		resolveSelect.mockReturnValue({
+			getEntityRecords: mockGetEntityRecords,
+			getUsers: mockGetUsers,
+		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('returns false for invalid type', async () => {
+		const result = await getIdOptions(
+			'invalid-type',
+			'by-id',
+			null,
+			false,
+			false
+		);
+		expect(result).toBe(false);
+	});
+
+	it('fetches posts correctly', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		const result = await getIdOptions('posts', 'by-id', null, false, false);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
+			per_page: -1,
+		});
+		expect(result).toEqual(mockPosts);
+	});
+
+	it('uses cache when available', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		// First call should fetch data
+		await getIdOptions('posts', 'by-id', null, false, false);
+
+		// Second call should use cache
+		await getIdOptions('posts', 'by-id', null, false, false);
+
+		// Should only have been called once
+		expect(mockGetEntityRecords).toHaveBeenCalledTimes(1);
+	});
+
+	it('fetches new data when cache expires', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		// First call
+		await getIdOptions('posts', 'by-id', null, false, false);
+
+		// Simulate cache expiration (5 minutes + 1 ms)
+		jest.spyOn(Date, 'now').mockImplementation(
+			() => 1000 + 5 * 60 * 1000 + 1
+		);
+
+		// Second call should fetch again
+		await getIdOptions('posts', 'by-id', null, false, false);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledTimes(2);
+	});
+
+	it('fetches categories correctly', async () => {
+		const mockCategories = [
+			{ id: 1, name: 'Category 1' },
+			{ id: 2, name: 'Category 2' },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockCategories);
+
+		const result = await getIdOptions(
+			'categories',
+			'by-id',
+			null,
+			false,
+			false
+		);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith(
+			'taxonomy',
+			'category',
+			expect.objectContaining({
+				_fields: ['id', 'name'],
+				orderby: 'id',
+				per_page: 100,
+			})
+		);
+		expect(result).toEqual(mockCategories);
+	});
+
+	it('fetches users correctly', async () => {
+		const mockUsers = [
+			{ id: 1, name: 'User 1' },
+			{ id: 2, name: 'User 2' },
+		];
+
+		mockGetUsers.mockResolvedValue(mockUsers);
+
+		const result = await getIdOptions('users', 'by-id', null, false, false);
+
+		expect(result).toEqual(mockUsers);
+	});
+
+	it('handles custom post types correctly', async () => {
+		const mockCustomPosts = [
+			{ id: 1, title: { rendered: 'Custom Post 1' } },
+			{ id: 2, title: { rendered: 'Custom Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockCustomPosts);
+
+		const result = await getIdOptions(
+			'custom-type',
+			'by-id',
+			null,
+			true,
+			false
+		);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith(
+			'postType',
+			'custom-type',
+			{ per_page: -1 }
+		);
+		expect(result).toEqual(mockCustomPosts);
+	});
+
+	it('handles custom taxonomies correctly', async () => {
+		const mockCustomTaxonomy = [
+			{ id: 1, name: 'Custom Tax 1' },
+			{ id: 2, name: 'Custom Tax 2' },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockCustomTaxonomy);
+
+		const result = await getIdOptions(
+			'custom-tax',
+			'by-id',
+			null,
+			false,
+			true
+		);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith(
+			'taxonomy',
+			'custom-tax',
+			{ per_page: -1 }
+		);
+		expect(result).toEqual(mockCustomTaxonomy);
+	});
+
+	it('handles by-custom-taxonomy relation correctly', async () => {
+		const mockTaxonomyTerms = [
+			{ id: 1, name: 'Term 1' },
+			{ id: 2, name: 'Term 2' },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockTaxonomyTerms);
+
+		const result = await getIdOptions(
+			'posts',
+			'by-custom-taxonomy-product_cat',
+			null,
+			false,
+			false
+		);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith(
+			'taxonomy',
+			'product_cat',
+			{ per_page: -1 }
+		);
+		expect(result).toEqual(mockTaxonomyTerms);
+	});
+
+	it('handles errors gracefully', async () => {
+		mockGetEntityRecords.mockRejectedValue(new Error('API error'));
+
+		// Mock console.error to avoid test output pollution
+		const originalConsoleError = console.error;
+		console.error = jest.fn();
+
+		const result = await getIdOptions('posts', 'by-id', null, false, false);
+
+		expect(result).toBeNull();
+		expect(console.error).toHaveBeenCalled();
+
+		console.error = originalConsoleError;
+	});
+
+	it('handles pagination with correct per_page parameter', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		await getIdOptions('posts', 'by-date', null, false, false, 5);
+
+		expect(mockGetEntityRecords).toHaveBeenCalledWith(
+			'postType',
+			'post',
+			{ per_page: 15 } // 5 * 3 as per the function logic
+		);
+	});
+});
+
+describe('getDCOptions', () => {
+	let mockGetEntityRecords;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		clearIdOptionsCache();
+
+		// Setup mock data for custom post types/taxonomies
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: jest
+						.fn()
+						.mockReturnValue(['custom-post-type']),
+					getCustomTaxonomies: jest
+						.fn()
+						.mockReturnValue(['custom-taxonomy']),
+				};
+			}
+			return {};
+		});
+
+		// Mock entity records for getIdOptions to use
+		mockGetEntityRecords = jest.fn();
+		resolveSelect.mockReturnValue({
+			getEntityRecords: mockGetEntityRecords,
+			getUsers: jest.fn().mockResolvedValue([
+				{ id: 1, name: 'User 1' },
+				{ id: 2, name: 'User 2' },
+			]),
+		});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('formats post options correctly', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		const params = {
+			type: 'posts',
+			id: 1,
+			field: 'title',
+			relation: 'by-id',
+			author: null,
+		};
+
+		const result = await getDCOptions(params, [], 'text');
+
+		expect(result.newPostIdOptions).toEqual([
+			{ label: '1 - Post 1', value: 1 },
+			{ label: '2 - Post 2', value: 2 },
+		]);
+	});
+
+	it('formats category options correctly', async () => {
+		const mockCategories = [
+			{ id: 1, name: 'Category 1' },
+			{ id: 2, name: 'Category 2' },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockCategories);
+
+		const params = {
+			type: 'categories',
+			id: 1,
+			field: 'name',
+			relation: 'by-id',
+			author: null,
+		};
+
+		const result = await getDCOptions(params, [], 'text');
+
+		expect(result.newPostIdOptions).toEqual([
+			{ label: 'Category 1', value: 1 },
+			{ label: 'Category 2', value: 2 },
+		]);
+	});
+
+	it('sets default ID when current ID is not in options', async () => {
+		const mockPosts = [
+			{ id: 2, title: { rendered: 'Post 2' } },
+			{ id: 3, title: { rendered: 'Post 3' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		const params = {
+			type: 'posts',
+			id: 1, // This ID doesn't exist in the mock data
+			field: 'title',
+			relation: 'by-id',
+			author: null,
+		};
+
+		const result = await getDCOptions(params, [], 'text');
+
+		// Should set the ID to the first available one
+		expect(result.newValues).toHaveProperty('dc-id', 2);
+	});
+
+	it('changes relation for orderByRelations when no options', async () => {
+		mockGetEntityRecords.mockResolvedValue([]);
+
+		const params = {
+			type: 'posts',
+			id: 1,
+			field: 'title',
+			relation: 'by-category',
+			author: null,
+		};
+
+		const result = await getDCOptions(
+			params,
+			[{ label: 'Category 1', value: 1 }],
+			'text'
+		);
+
+		expect(result.newValues).toEqual({
+			'dc-relation': 'by-date',
+			'dc-order': 'desc',
+		});
+	});
+
+	it('handles context loop mode correctly', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		const params = {
+			type: 'posts',
+			id: undefined, // ID that doesn't exist on block
+			field: 'title',
+			relation: 'by-id',
+			author: null,
+		};
+
+		const result = await getDCOptions(params, [], 'text', true, {
+			'cl-status': true,
+		});
+
+		// In CL mode with cl-status true, should set ID to undefined if doesn't exist on block
+		expect(result.newValues).toHaveProperty('cl-id', undefined);
+	});
+
+	it('returns null when post ID options are unchanged', async () => {
+		const mockPosts = [
+			{ id: 1, title: { rendered: 'Post 1' } },
+			{ id: 2, title: { rendered: 'Post 2' } },
+		];
+
+		mockGetEntityRecords.mockResolvedValue(mockPosts);
+
+		const existingPostIdOptions = [
+			{ label: '1 - Post 1', value: 1 },
+			{ label: '2 - Post 2', value: 2 },
+		];
+
+		const params = {
+			type: 'posts',
+			id: 1,
+			field: 'title',
+			relation: 'by-id',
+			author: null,
+		};
+
+		const result = await getDCOptions(
+			params,
+			existingPostIdOptions,
+			'text'
+		);
+
+		// Should return null when options haven't changed
+		expect(result).toBeNull();
+	});
+});

--- a/src/extensions/DC/test/getDCValues.js
+++ b/src/extensions/DC/test/getDCValues.js
@@ -1,0 +1,169 @@
+import getDCValues from '@extensions/DC/getDCValues';
+import { attributeDefaults } from '@extensions/DC/constants';
+
+jest.mock('@extensions/DC/constants', () => ({
+	attributeDefaults: {
+		status: false,
+		type: 'posts',
+		source: 'wp',
+		relation: 'current',
+		author: '',
+		content: props => props.testProperty || 'default content',
+	},
+}));
+
+describe('getDCValues', () => {
+	it('should process only keys present in the dynamic content object', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-type': 'pages',
+			'dc-source': 'acf',
+		};
+
+		const result = getDCValues(dynamicContent, null);
+
+		// The result should only contain keys that were in the dynamicContent object
+		expect(result).toEqual({
+			status: true,
+			type: 'pages',
+			source: 'acf',
+		});
+	});
+
+	it('should prioritize dynamic content over context loop', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-type': 'pages',
+			'dc-source': undefined, // Include the key with undefined value
+		};
+
+		const contextLoop = {
+			'cl-status': true,
+			'cl-type': 'products',
+			'cl-source': 'acf',
+		};
+
+		const result = getDCValues(dynamicContent, contextLoop);
+
+		expect(result).toEqual({
+			status: true, // from dc
+			type: 'pages', // from dc
+			source: 'acf', // from cl because dc-source is undefined
+		});
+	});
+
+	it('should use context loop values when dynamic content values are undefined', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-type': undefined, // Include the key with undefined value
+			'dc-source': undefined, // Include the key with undefined value
+		};
+
+		const contextLoop = {
+			'cl-status': true,
+			'cl-type': 'products',
+			'cl-source': 'acf',
+		};
+
+		const result = getDCValues(dynamicContent, contextLoop);
+
+		expect(result).toEqual({
+			status: true, // from dc
+			type: 'products', // from cl
+			source: 'acf', // from cl
+		});
+	});
+
+	it('should use default values when both dynamic content and context loop values are undefined', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-type': undefined, // Include the key with undefined value
+			'dc-source': undefined, // Include the key with undefined value
+			'dc-relation': undefined,
+			'dc-author': undefined,
+		};
+
+		const contextLoop = {
+			'cl-status': true,
+		};
+
+		const result = getDCValues(dynamicContent, contextLoop);
+
+		expect(result).toEqual({
+			status: true, // from dc
+			type: 'posts', // default
+			source: 'wp', // default
+			relation: 'current', // default
+			author: '', // default
+		});
+	});
+
+	it('should ignore context loop values when cl-status is false', () => {
+		const dynamicContent = {
+			'dc-status': undefined, // Include to get default status
+			'dc-type': 'pages',
+		};
+
+		const contextLoop = {
+			'cl-status': false,
+			'cl-type': 'products',
+		};
+
+		const result = getDCValues(dynamicContent, contextLoop);
+
+		expect(result).toEqual({
+			status: false, // default
+			type: 'pages', // from dc
+		});
+	});
+
+	it('should execute function-based default values with the accumulator', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-type': 'pages',
+			'dc-content': undefined, // Include to get the function-based default
+		};
+
+		const result = getDCValues(dynamicContent, null);
+
+		expect(result.content).toBe('default content');
+
+		// Test with accumulated value
+		const dynamicContent2 = {
+			'dc-status': true,
+			'dc-type': 'pages',
+			'dc-content': undefined,
+		};
+
+		// Simulate how the accumulator would look with testProperty
+		const mockAcc = { testProperty: 'custom value' };
+		const keys = Object.keys(dynamicContent2);
+
+		// Manually simulate the reduce function
+		const finalResult = keys.reduce((acc, key) => {
+			const target = key.replace('dc-', '');
+			if (target === 'content') {
+				acc[target] = attributeDefaults.content(acc);
+			} else {
+				acc[target] = dynamicContent2[key] ?? attributeDefaults[target];
+			}
+			return acc;
+		}, mockAcc);
+
+		expect(finalResult.content).toBe('custom value');
+	});
+
+	it('should convert kebab-case keys to camelCase', () => {
+		const dynamicContent = {
+			'dc-special-field': 'special value',
+			'dc-another-special-field': 'another special value',
+		};
+
+		const result = getDCValues(dynamicContent, null);
+
+		expect(result).toEqual({
+			specialField: 'special value',
+			anotherSpecialField: 'another special value',
+		});
+	});
+});

--- a/src/extensions/DC/test/getTypes.js
+++ b/src/extensions/DC/test/getTypes.js
@@ -137,8 +137,6 @@ describe('getTypes', () => {
 			'Custom types': [
 				{ label: 'Product', value: 'products' },
 				{ label: 'Testimonial', value: 'testimonials' },
-				{ label: 'Category', value: 'category' },
-				{ label: 'Product Category', value: 'product_cat' },
 			],
 		});
 	});

--- a/src/extensions/DC/test/getTypes.js
+++ b/src/extensions/DC/test/getTypes.js
@@ -1,0 +1,224 @@
+import { select } from '@wordpress/data';
+import getTypes from '@extensions/DC/getTypes';
+
+jest.mock('@wordpress/data', () => ({
+	select: jest.fn(),
+}));
+
+describe('getTypes', () => {
+	const mockDefaultOptions = [
+		{ label: 'Posts', value: 'posts' },
+		{ label: 'Pages', value: 'pages' },
+	];
+
+	const mockACFOptions = [
+		{ label: 'Text', value: 'text' },
+		{ label: 'Image', value: 'image' },
+	];
+
+	const mockCustomPostTypes = [
+		'products',
+		'testimonials',
+		'wp_font_family', // Should be filtered out
+		'wp_font_face', // Should be filtered out
+		'wp_global_styles', // Should be filtered out
+	];
+
+	const mockCustomTaxonomies = ['category', 'product_cat'];
+
+	const mockPostTypeData = {
+		products: {
+			labels: { singular_name: 'Product' },
+			slug: 'products',
+		},
+		testimonials: {
+			labels: { singular_name: 'Testimonial' },
+			slug: 'testimonials',
+		},
+		wp_font_family: {
+			labels: { singular_name: 'Font Family' },
+			slug: 'wp_font_family',
+		},
+		wp_font_face: {
+			labels: { singular_name: 'Font Face' },
+			slug: 'wp_font_face',
+		},
+		wp_global_styles: {
+			labels: { singular_name: 'Global Styles' },
+			slug: 'wp_global_styles',
+		},
+	};
+
+	const mockTaxonomyData = {
+		category: {
+			labels: { singular_name: 'Category' },
+			slug: 'category',
+		},
+		product_cat: {
+			labels: { singular_name: 'Product Category' },
+			slug: 'product_cat',
+		},
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: () => mockCustomPostTypes,
+					getCustomTaxonomies: () => mockCustomTaxonomies,
+					getTypeOptions: () => ({
+						posts: mockDefaultOptions,
+					}),
+					getACFTypeOptions: () => mockACFOptions,
+				};
+			}
+			if (store === 'core') {
+				return {
+					getPostType: type => mockPostTypeData[type],
+					getTaxonomy: type => mockTaxonomyData[type],
+				};
+			}
+			return {};
+		});
+	});
+
+	it('should return grouped types with default parameters', () => {
+		const result = getTypes('posts');
+
+		expect(result).toEqual({
+			'Standard types': mockDefaultOptions,
+			'Custom types': [
+				{ label: 'Product', value: 'products' },
+				{ label: 'Testimonial', value: 'testimonials' },
+				{ label: 'Category', value: 'category' },
+				{ label: 'Product Category', value: 'product_cat' },
+			],
+		});
+	});
+
+	it('should return a flat array when group is false', () => {
+		const result = getTypes('posts', false);
+
+		expect(Array.isArray(result)).toBe(true);
+		expect(result).toEqual([
+			...mockDefaultOptions,
+			{ label: 'Product', value: 'products' },
+			{ label: 'Testimonial', value: 'testimonials' },
+			{ label: 'Category', value: 'category' },
+			{ label: 'Product Category', value: 'product_cat' },
+		]);
+	});
+
+	it('should include archive option when currentTemplateSlug includes archive', () => {
+		const result = getTypes('posts', true, 'archive-template');
+
+		expect(result['Standard types']).toContainEqual({
+			label: 'All archives',
+			value: 'archive',
+		});
+	});
+
+	it('should append archive option to flat array when group is false', () => {
+		const result = getTypes('posts', false, 'archive-template');
+
+		expect(result).toContainEqual({
+			label: 'All archives',
+			value: 'archive',
+		});
+	});
+
+	it('should return ACF options when source is acf', () => {
+		const result = getTypes('posts', true, false, 'acf');
+
+		expect(result).toEqual({
+			'Standard types': mockACFOptions,
+			'Custom types': [
+				{ label: 'Product', value: 'products' },
+				{ label: 'Testimonial', value: 'testimonials' },
+				{ label: 'Category', value: 'category' },
+				{ label: 'Product Category', value: 'product_cat' },
+			],
+		});
+	});
+
+	it('should filter out excluded post types', () => {
+		const result = getTypes('posts', false);
+
+		const excludedTypes = [
+			'wp_font_family',
+			'wp_font_face',
+			'wp_global_styles',
+		];
+
+		// Check that none of the excluded types are in the result
+		excludedTypes.forEach(excludedType => {
+			expect(result.some(type => type.value === excludedType)).toBe(
+				false
+			);
+		});
+	});
+
+	it('should return only default options when there are no custom post types', () => {
+		// Mock empty custom post types
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: () => [],
+					getCustomTaxonomies: () => [],
+					getTypeOptions: () => ({
+						posts: mockDefaultOptions,
+					}),
+					getACFTypeOptions: () => mockACFOptions,
+				};
+			}
+			return store === 'core'
+				? {
+						getPostType: () => null,
+						getTaxonomy: () => null,
+				  }
+				: {};
+		});
+
+		const result = getTypes('posts');
+
+		// Should be a flat array since there are no custom types
+		expect(Array.isArray(result)).toBe(true);
+		expect(result).toEqual(mockDefaultOptions);
+	});
+
+	it('should combine default options and all archives when on archive template with no custom types', () => {
+		// Mock empty custom post types
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: () => [],
+					getCustomTaxonomies: () => [],
+					getTypeOptions: () => ({
+						posts: mockDefaultOptions,
+					}),
+					getACFTypeOptions: () => mockACFOptions,
+				};
+			}
+			return store === 'core'
+				? {
+						getPostType: () => null,
+						getTaxonomy: () => null,
+				  }
+				: {};
+		});
+
+		const result = getTypes('posts', true, 'archive-template');
+
+		// Should be a flat array with default options and archive option
+		expect(Array.isArray(result)).toBe(true);
+		expect(result).toEqual([
+			...mockDefaultOptions,
+			{
+				label: 'All archives',
+				value: 'archive',
+			},
+		]);
+	});
+});

--- a/src/extensions/DC/test/getWCContent.js
+++ b/src/extensions/DC/test/getWCContent.js
@@ -1,0 +1,382 @@
+import {
+	getProductsContent,
+	getCartContent,
+} from '@extensions/DC/getWCContent';
+import { getProductData } from '@extensions/DC/getWooCommerceData';
+import { getTaxonomyContent } from '@extensions/DC/utils';
+
+jest.mock('@extensions/DC/getWooCommerceData');
+jest.mock('@extensions/DC/utils', () => {
+	const actual = jest.requireActual('@extensions/DC/utils');
+	return {
+		...actual,
+		getTaxonomyContent: jest.fn(),
+	};
+});
+
+describe('getProductsContent', () => {
+	const mockProductData = {
+		name: 'Test Product',
+		slug: 'test-product',
+		review_count: '5',
+		average_rating: '4.5',
+		sku: 'TP123',
+		description: '<p>This is a long product description.</p>',
+		short_description: '<p>Short description.</p>',
+		prices: {
+			price: '1999',
+			regular_price: '2999',
+			sale_price: '1999',
+			price_range: {
+				min_amount: '1999',
+				max_amount: '2999',
+			},
+			currency_prefix: '$',
+			currency_suffix: '',
+			currency_minor_unit: 2,
+			currency_decimal_separator: '.',
+			currency_thousand_separator: ',',
+		},
+		images: [
+			{ id: 100 }, // featured image
+			{ id: 101 }, // gallery image 1
+			{ id: 102 }, // gallery image 2
+		],
+	};
+
+	const mockEntityData = {
+		id: 1,
+		product_tag: [
+			{ id: 10, name: 'Tag 1', slug: 'tag-1', link: '/tag/tag-1' },
+			{ id: 11, name: 'Tag 2', slug: 'tag-2', link: '/tag/tag-2' },
+		],
+		product_cat: [
+			{ id: 20, name: 'Category 1', slug: 'cat-1', link: '/cat/cat-1' },
+			{ id: 21, name: 'Category 2', slug: 'cat-2', link: '/cat/cat-2' },
+		],
+		featured_media: 100,
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		getProductData.mockResolvedValue(mockProductData);
+
+		getTaxonomyContent.mockImplementation((taxonomy, delimiter, isLink) =>
+			isLink
+				? 'Multiple Links'
+				: taxonomy.map(item => item.name).join(delimiter || ', ')
+		);
+	});
+
+	it('should return null if entity data is null', async () => {
+		const result = await getProductsContent({ field: 'name' }, null);
+		expect(result).toBeNull();
+	});
+
+	it('should fetch product name with limit', async () => {
+		const result = await getProductsContent(
+			{ field: 'name', limit: 4 },
+			mockEntityData
+		);
+
+		expect(getProductData).toHaveBeenCalledWith(mockEntityData.id);
+		expect(result).toBe('Test…');
+	});
+
+	it('should fetch product slug', async () => {
+		const result = await getProductsContent(
+			{ field: 'slug' },
+			mockEntityData
+		);
+
+		expect(result).toBe(mockProductData.slug);
+	});
+
+	it('should fetch review count', async () => {
+		const result = await getProductsContent(
+			{ field: 'review_count' },
+			mockEntityData
+		);
+
+		expect(result).toBe(mockProductData.review_count);
+	});
+
+	it('should fetch average rating', async () => {
+		const result = await getProductsContent(
+			{ field: 'average_rating' },
+			mockEntityData
+		);
+
+		expect(result).toBe(mockProductData.average_rating);
+	});
+
+	it('should fetch product SKU', async () => {
+		const result = await getProductsContent(
+			{ field: 'sku' },
+			mockEntityData
+		);
+
+		expect(result).toBe(mockProductData.sku);
+	});
+
+	it('should fetch product price', async () => {
+		const result = await getProductsContent(
+			{ field: 'price' },
+			mockEntityData
+		);
+
+		// The price should be formatted according to the currency settings
+		expect(result).toBe('$19.99');
+	});
+
+	it('should fetch product regular price', async () => {
+		const result = await getProductsContent(
+			{ field: 'regular_price' },
+			mockEntityData
+		);
+
+		expect(result).toBe('$29.99');
+	});
+
+	it('should fetch product sale price', async () => {
+		const result = await getProductsContent(
+			{ field: 'sale_price' },
+			mockEntityData
+		);
+
+		expect(result).toBe('$19.99');
+	});
+
+	it('should fetch price range when min and max are different', async () => {
+		const result = await getProductsContent(
+			{ field: 'price_range' },
+			mockEntityData
+		);
+
+		expect(result).toBe('$19.99 – $29.99');
+	});
+
+	it('should fetch single price when price range min and max are the same', async () => {
+		// Update mock to have same min and max
+		getProductData.mockResolvedValue({
+			...mockProductData,
+			prices: {
+				...mockProductData.prices,
+				price_range: {
+					min_amount: '1999',
+					max_amount: '1999',
+				},
+			},
+		});
+
+		const result = await getProductsContent(
+			{ field: 'price_range' },
+			mockEntityData
+		);
+
+		expect(result).toBe('$19.99');
+	});
+
+	it('should fetch product description with limiting', async () => {
+		const result = await getProductsContent(
+			{ field: 'description', limit: 15 },
+			mockEntityData
+		);
+
+		expect(result).toBe('This is a long …');
+	});
+
+	it('should fetch product short description', async () => {
+		const result = await getProductsContent(
+			{ field: 'short_description' },
+			mockEntityData
+		);
+
+		expect(result).toBe('Short description.');
+	});
+
+	it('should fetch product tags', async () => {
+		getTaxonomyContent.mockReturnValue('Tag 1, Tag 2');
+
+		const result = await getProductsContent(
+			{ field: 'tags', delimiterContent: ', ' },
+			mockEntityData
+		);
+
+		expect(getTaxonomyContent).toHaveBeenCalledWith(
+			mockEntityData.product_tag,
+			', ',
+			false,
+			'product_tag'
+		);
+		expect(result).toBe('Tag 1, Tag 2');
+	});
+
+	it('should fetch product tags with link status', async () => {
+		getTaxonomyContent.mockReturnValue('Multiple Links');
+
+		const result = await getProductsContent(
+			{ field: 'tags', linkTarget: 'tags' },
+			mockEntityData
+		);
+
+		expect(getTaxonomyContent).toHaveBeenCalledWith(
+			mockEntityData.product_tag,
+			undefined,
+			true,
+			'product_tag'
+		);
+		expect(result).toBe('Multiple Links');
+	});
+
+	it('should fetch product categories', async () => {
+		getTaxonomyContent.mockReturnValue('Category 1, Category 2');
+
+		const result = await getProductsContent(
+			{ field: 'categories', delimiterContent: ', ' },
+			mockEntityData
+		);
+
+		expect(getTaxonomyContent).toHaveBeenCalledWith(
+			mockEntityData.product_cat,
+			', ',
+			false,
+			'product_cat'
+		);
+		expect(result).toBe('Category 1, Category 2');
+	});
+
+	it('should fetch product featured media', async () => {
+		const result = await getProductsContent(
+			{ field: 'featured_media' },
+			mockEntityData
+		);
+
+		expect(result).toBe(mockEntityData.featured_media);
+	});
+
+	it('should fetch product gallery image', async () => {
+		const result = await getProductsContent(
+			{ field: 'gallery', imageAccumulator: 0 },
+			mockEntityData
+		);
+
+		// Should return the second image (index 1) since the first is featured
+		expect(result).toBe(101);
+	});
+
+	it('should fetch product gallery image with accumulator', async () => {
+		const result = await getProductsContent(
+			{ field: 'gallery', imageAccumulator: 1 },
+			mockEntityData
+		);
+
+		// Should return the third image (index 2)
+		expect(result).toBe(102);
+	});
+
+	it('should return null for unknown field', async () => {
+		const result = await getProductsContent(
+			{ field: 'unknown_field' },
+			mockEntityData
+		);
+
+		expect(result).toBeNull();
+	});
+});
+
+describe('getCartContent', () => {
+	const mockCartData = {
+		totals: {
+			total_price: '5999',
+			total_tax: '599',
+			total_shipping: '499',
+			total_shipping_tax: '49',
+			total_discount: '1000',
+			total_items: '5400',
+			total_items_tax: '540',
+			total_fees: '100',
+			total_fees_tax: '10',
+			currency_prefix: '$',
+			currency_suffix: '',
+			currency_minor_unit: 2,
+			currency_decimal_separator: '.',
+			currency_thousand_separator: ',',
+		},
+	};
+
+	it('should fetch cart total price', () => {
+		const result = getCartContent({ field: 'total_price' }, mockCartData);
+
+		expect(result).toBe('$59.99');
+	});
+
+	it('should fetch cart total tax', () => {
+		const result = getCartContent({ field: 'total_tax' }, mockCartData);
+
+		expect(result).toBe('$5.99');
+	});
+
+	it('should fetch cart total shipping', () => {
+		const result = getCartContent(
+			{ field: 'total_shipping' },
+			mockCartData
+		);
+
+		expect(result).toBe('$4.99');
+	});
+
+	it('should fetch cart total shipping tax', () => {
+		const result = getCartContent(
+			{ field: 'total_shipping_tax' },
+			mockCartData
+		);
+
+		expect(result).toBe('$0.49');
+	});
+
+	it('should fetch cart total discount', () => {
+		const result = getCartContent(
+			{ field: 'total_discount' },
+			mockCartData
+		);
+
+		expect(result).toBe('$10.00');
+	});
+
+	it('should fetch cart total items', () => {
+		const result = getCartContent({ field: 'total_items' }, mockCartData);
+
+		expect(result).toBe('$54.00');
+	});
+
+	it('should fetch cart total items tax', () => {
+		const result = getCartContent(
+			{ field: 'total_items_tax' },
+			mockCartData
+		);
+
+		expect(result).toBe('$5.40');
+	});
+
+	it('should fetch cart total fees', () => {
+		const result = getCartContent({ field: 'total_fees' }, mockCartData);
+
+		expect(result).toBe('$1.00');
+	});
+
+	it('should fetch cart total fees tax', () => {
+		const result = getCartContent(
+			{ field: 'total_fees_tax' },
+			mockCartData
+		);
+
+		expect(result).toBe('$0.10');
+	});
+
+	it('should return null for unknown field', () => {
+		const result = getCartContent({ field: 'unknown_field' }, mockCartData);
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/extensions/DC/test/processDCDate.js
+++ b/src/extensions/DC/test/processDCDate.js
@@ -1,0 +1,274 @@
+import processDCDate, { formatDateOptions } from '@extensions/DC/processDCDate';
+import moment from 'moment';
+
+// Mock moment to ensure consistent tests regardless of timezone
+jest.mock('moment', () => {
+	const mockMoment = jest.fn().mockImplementation(date => {
+		const momentInstance = jest.requireActual('moment')(date);
+		momentInstance.format = jest.fn().mockImplementation(format => {
+			// Return predictable values for certain formats to keep tests consistent
+			if (format === 'ddd') return 'Sat';
+			if (format === 'dddd') return 'Saturday';
+			if (format === 'MMM') return 'Jan';
+			if (format === 'MMMM') return 'January';
+			if (format === 'D') return '1';
+			if (format === 'MM') return '01';
+			if (format === 'YY') return '22';
+			if (format === 'YYYY') return '2022';
+			if (format === 'HH:mm') return '12:30';
+
+			// For custom formats, return a deterministic representation
+			return jest
+				.requireActual('moment')(new Date('2022-01-01T12:30:00Z'))
+				.format(format);
+		});
+		return momentInstance;
+	});
+	return mockMoment;
+});
+
+describe('formatDateOptions', () => {
+	it('should convert "none" values to undefined', () => {
+		const input = {
+			day: 'none',
+			month: 'none',
+			year: 'none',
+			weekday: 'none',
+			era: 'none',
+			hour: 'none',
+			minute: 'none',
+			second: 'none',
+			timezone: 'none',
+			timezoneName: 'none',
+			hour12: 'false',
+		};
+
+		const result = formatDateOptions(input);
+
+		expect(result.day).toBeUndefined();
+		expect(result.month).toBeUndefined();
+		expect(result.year).toBeUndefined();
+		expect(result.weekday).toBeUndefined();
+		expect(result.era).toBeUndefined();
+		expect(result.hour).toBeUndefined();
+		expect(result.minute).toBeUndefined();
+		expect(result.second).toBeUndefined();
+		expect(result.timeZoneName).toBeUndefined();
+	});
+
+	it('should convert hour12 strings to boolean values', () => {
+		expect(formatDateOptions({ hour12: 'true' }).hour12).toBe(true);
+		expect(formatDateOptions({ hour12: 'false' }).hour12).toBe(false);
+		expect(formatDateOptions({ hour12: 'numeric' }).hour12).toBe('numeric');
+	});
+
+	it('should set timeZone to UTC when "none" is provided', () => {
+		expect(formatDateOptions({ timezone: 'none' }).timeZone).toBe('UTC');
+	});
+
+	it('should preserve timeZone when a value is provided', () => {
+		expect(
+			formatDateOptions({ timezone: 'America/New_York' }).timeZone
+		).toBe('America/New_York');
+	});
+
+	it('should handle mixed values correctly', () => {
+		const input = {
+			day: 'numeric',
+			month: 'long',
+			year: 'none',
+			weekday: 'short',
+			hour12: 'true',
+			timezone: 'Europe/London',
+		};
+
+		const result = formatDateOptions(input);
+
+		expect(result.day).toBe('numeric');
+		expect(result.month).toBe('long');
+		expect(result.year).toBeUndefined();
+		expect(result.weekday).toBe('short');
+		expect(result.hour12).toBe(true);
+		expect(result.timeZone).toBe('Europe/London');
+	});
+
+	it('should handle all "none" values', () => {
+		const input = {
+			day: 'none',
+			era: 'none',
+			hour: 'none',
+			hour12: 'none',
+			minute: 'none',
+			month: 'none',
+			second: 'none',
+			timezone: 'none',
+			timezoneName: 'none',
+			weekday: 'none',
+			year: 'none',
+		};
+
+		const result = formatDateOptions(input);
+
+		// Test timezone special case
+		expect(result.timeZone).toBe('UTC');
+
+		// Test hour12 special case - it remains as 'none'
+		expect(result.hour12).toBe('none');
+
+		// Test timezoneName becomes undefined
+		expect(result.timeZoneName).toBeUndefined();
+
+		// Test remaining properties become undefined
+		expect(result.day).toBeUndefined();
+		expect(result.era).toBeUndefined();
+		expect(result.hour).toBeUndefined();
+		expect(result.minute).toBeUndefined();
+		expect(result.month).toBeUndefined();
+		expect(result.second).toBeUndefined();
+		expect(result.weekday).toBeUndefined();
+		expect(result.year).toBeUndefined();
+	});
+});
+
+describe('processDCDate', () => {
+	// Setting up a fixed date for all tests
+	const testDate = '2022-01-01T12:30:00Z';
+	let getTimezoneOffsetSpy;
+
+	beforeAll(() => {
+		getTimezoneOffsetSpy = jest
+			.spyOn(Date.prototype, 'getTimezoneOffset')
+			.mockImplementation(() => 0);
+	});
+
+	afterAll(() => {
+		getTimezoneOffsetSpy.mockRestore();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should format standard date with basic tokens', () => {
+		const result = processDCDate(testDate, false, 'Y-m-d', 'en-US', {});
+
+		expect(moment).toHaveBeenCalledWith(new Date(testDate));
+		expect(result).toBe('2022-01-1');
+	});
+
+	it('should substitute special tokens DS and MS correctly', () => {
+		const result = processDCDate(
+			testDate,
+			false,
+			'DS, MS d, Y',
+			'en-US',
+			{}
+		);
+
+		// DS should become ddd, MS should become MMM
+		expect(result).toBe('Sat, Jan 1, 2022');
+	});
+
+	it('should handle full date format tokens', () => {
+		const result = processDCDate(testDate, false, 'D, M d, Y', 'en-US', {});
+
+		// D -> dddd, M -> MMMM
+		expect(result).toBe('Saturday, January 1, 2022');
+	});
+
+	it('should handle time token', () => {
+		const result = processDCDate(testDate, false, 'd/m/Y t', 'en-US', {});
+
+		// t -> HH:mm
+		expect(result).toBe('1/01/2022 12:30');
+	});
+
+	it('should use toLocaleString when isCustomDate is true', () => {
+		const mockDate = {
+			toLocaleString: jest.fn().mockReturnValue('Custom Formatted Date'),
+		};
+
+		const originalDate = global.Date;
+		global.Date = jest.fn(() => mockDate);
+		global.Date.UTC = originalDate.UTC;
+
+		const options = {
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric',
+		};
+
+		const result = processDCDate(
+			testDate,
+			true,
+			'irrelevant-format',
+			'en-US',
+			options
+		);
+
+		expect(result).toBe('Custom Formatted Date');
+		expect(mockDate.toLocaleString).toHaveBeenCalledWith('en-US', options);
+
+		global.Date = originalDate;
+	});
+
+	it('should handle different locales with custom date', () => {
+		const mockLocaleStringFn = jest.fn(locale => {
+			if (locale === 'fr-FR') return '1 janvier 2022';
+			if (locale === 'de-DE') return '1. Januar 2022';
+			return 'January 1, 2022';
+		});
+
+		const mockDate = {
+			toLocaleString: mockLocaleStringFn,
+		};
+
+		const originalDate = global.Date;
+		global.Date = jest.fn(() => mockDate);
+		global.Date.UTC = originalDate.UTC;
+
+		const options = { day: 'numeric', month: 'long', year: 'numeric' };
+
+		expect(processDCDate(testDate, true, '', 'en-US', options)).toBe(
+			'January 1, 2022'
+		);
+		expect(processDCDate(testDate, true, '', 'fr-FR', options)).toBe(
+			'1 janvier 2022'
+		);
+		expect(processDCDate(testDate, true, '', 'de-DE', options)).toBe(
+			'1. Januar 2022'
+		);
+
+		// Restore original Date constructor
+		global.Date = originalDate;
+	});
+
+	it('should handle complex format patterns', () => {
+		const result = processDCDate(
+			testDate,
+			false,
+			'DS, MS d, Y t',
+			'en-US',
+			{}
+		);
+
+		expect(result).toBe('Sat, Jan 1, 2022 12:30');
+	});
+
+	it('should handle format with special characters', () => {
+		const result = processDCDate(
+			testDate,
+			false,
+			'Y-m-d (DS)',
+			'en-US',
+			{}
+		);
+
+		expect(result).toBe('2022-01-1 (Sat)');
+	});
+
+	it('should handle year format variations', () => {
+		expect(processDCDate(testDate, false, 'y', 'en-US', {})).toBe('22');
+		expect(processDCDate(testDate, false, 'Y', 'en-US', {})).toBe('2022');
+	});
+});

--- a/src/extensions/DC/test/useMaxiDCLink.js
+++ b/src/extensions/DC/test/useMaxiDCLink.js
@@ -1,0 +1,300 @@
+/**
+ * External dependencies
+ */
+import { jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useMaxiDCLink from '@extensions/DC/useMaxiDCLink';
+import { getGroupAttributes } from '@extensions/styles';
+import getDCNewLinkSettings from '@extensions/DC/getDCNewLinkSettings';
+import getDCValues from '@extensions/DC/getDCValues';
+
+jest.mock('@wordpress/data', () => ({
+	dispatch: jest.fn(),
+}));
+
+// Mock useEffect to execute callback immediately
+jest.mock('@wordpress/element', () => ({
+	useEffect: jest.fn(cb => cb()),
+}));
+
+jest.mock('@extensions/styles', () => ({
+	getGroupAttributes: jest.fn(),
+}));
+
+jest.mock('@extensions/DC/getDCNewLinkSettings', () => jest.fn());
+jest.mock('@extensions/DC/getDCValues', () => jest.fn());
+
+describe('useMaxiDCLink', () => {
+	const mockSetAttributes = jest.fn();
+	const mockClientId = 'test-client-id';
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		const mockDispatchObject = {
+			__unstableMarkNextChangeAsNotPersistent: jest.fn(),
+		};
+		dispatch.mockReturnValue(mockDispatchObject);
+
+		getGroupAttributes.mockReturnValue({
+			'dc-type': 'posts',
+			'dc-id': 1,
+		});
+
+		getDCValues.mockReturnValue({
+			type: 'posts',
+			id: 1,
+			field: 'title',
+		});
+
+		getDCNewLinkSettings.mockResolvedValue({
+			url: 'https://example.com/post/1',
+			opensInNewTab: false,
+		});
+	});
+
+	it('should update link settings when all conditions are met', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).toHaveBeenCalledWith(
+			attributes,
+			'dynamicContent'
+		);
+		expect(getDCValues).toHaveBeenCalledWith(
+			{ 'dc-type': 'posts', 'dc-id': 1 },
+			contextLoopContext.contextLoop
+		);
+		expect(getDCNewLinkSettings).toHaveBeenCalledWith(
+			attributes,
+			{ type: 'posts', id: 1, field: 'title' },
+			mockClientId
+		);
+		expect(dispatch).toHaveBeenCalledWith('core/block-editor');
+		expect(mockSetAttributes).toHaveBeenCalledWith({
+			linkSettings: {
+				url: 'https://example.com/post/1',
+				opensInNewTab: false,
+			},
+		});
+	});
+
+	it('should not update link settings when block is not in DC_LINK_BLOCKS', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		useMaxiDCLink(
+			'paragraph', // Not in DC_LINK_BLOCKS
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).not.toHaveBeenCalled();
+		expect(getDCValues).not.toHaveBeenCalled();
+		expect(getDCNewLinkSettings).not.toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(mockSetAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should not update link settings when dc-link-status is false', async () => {
+		const attributes = {
+			'dc-link-status': false,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).not.toHaveBeenCalled();
+		expect(getDCValues).not.toHaveBeenCalled();
+		expect(getDCNewLinkSettings).not.toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(mockSetAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should not update link settings when contextLoop is not provided', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {};
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).not.toHaveBeenCalled();
+		expect(getDCValues).not.toHaveBeenCalled();
+		expect(getDCNewLinkSettings).not.toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(mockSetAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should not update attributes when getDCNewLinkSettings returns falsy value', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		getDCNewLinkSettings.mockResolvedValue(null);
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).toHaveBeenCalled();
+		expect(getDCValues).toHaveBeenCalled();
+		expect(getDCNewLinkSettings).toHaveBeenCalled();
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(mockSetAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should handle errors from getDCNewLinkSettings', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		const originalConsoleError = console.error;
+		console.error = jest.fn();
+
+		const mockError = new Error('Test error');
+		getDCNewLinkSettings.mockRejectedValue(mockError);
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(getGroupAttributes).toHaveBeenCalled();
+		expect(getDCValues).toHaveBeenCalled();
+		expect(getDCNewLinkSettings).toHaveBeenCalled();
+		expect(console.error).toHaveBeenCalledWith(mockError);
+		expect(dispatch).not.toHaveBeenCalled();
+		expect(mockSetAttributes).not.toHaveBeenCalled();
+
+		console.error = originalConsoleError;
+	});
+
+	it('should update link settings with the response from getDCNewLinkSettings', async () => {
+		const attributes = {
+			'dc-link-status': true,
+			linkSettings: {},
+		};
+
+		const contextLoopContext = {
+			contextLoop: {
+				type: 'posts',
+				id: 1,
+			},
+		};
+
+		const customLinkSettings = {
+			url: 'https://example.com/custom-link',
+			opensInNewTab: true,
+			title: 'Custom Link',
+		};
+
+		getDCNewLinkSettings.mockResolvedValue(customLinkSettings);
+
+		useMaxiDCLink(
+			'maxi-blocks/column-maxi',
+			attributes,
+			mockClientId,
+			contextLoopContext,
+			mockSetAttributes
+		);
+
+		await Promise.resolve();
+
+		expect(mockSetAttributes).toHaveBeenCalledWith({
+			linkSettings: customLinkSettings,
+		});
+	});
+});

--- a/src/extensions/DC/test/utils.js
+++ b/src/extensions/DC/test/utils.js
@@ -21,19 +21,52 @@ jest.mock('@wordpress/i18n', () => ({
 	__: jest.fn(text => text),
 }));
 
-jest.mock('@extensions/DC/constants', () => ({
-	linkTypesOptions: {
-		posts: [
-			{ label: 'Post link', value: 'post' },
-			{ label: 'Author link', value: 'author' },
+jest.mock('@extensions/DC/constants', () => {
+	const mockFieldOptions = {
+		text: {
+			posts: [{ label: 'Title', value: 'title' }],
+			categories: [{ label: 'Name', value: 'name' }],
+		},
+		image: {
+			posts: [{ label: 'Featured image', value: 'featured_media' }],
+			categories: [{ label: 'Category image', value: 'category_image' }],
+		},
+	};
+
+	const mockRelationOptions = {
+		text: {
+			posts: [
+				{ label: 'Get latest', value: 'latest' },
+				{ label: 'Get oldest', value: 'oldest' },
+			],
+			categories: [{ label: 'Get top level', value: 'top-level' }],
+		},
+	};
+
+	return {
+		...jest.requireActual('@extensions/DC/constants'),
+		fieldOptions: mockFieldOptions,
+		relationOptions: mockRelationOptions,
+		postTypeRelationOptions: [
+			{ label: 'Get latest', value: 'latest' },
+			{ label: 'Get oldest', value: 'oldest' },
 		],
-		pages: [{ label: 'Page link', value: 'page' }],
-	},
-	linkFieldsOptions: {
-		title: [{ label: 'Title link', value: 'title_link' }],
-		content: [{ label: 'Content link', value: 'content_link' }],
-	},
-}));
+		taxonomyRelationOptions: [
+			{ label: 'Get hierarchical', value: 'hierarchical' },
+		],
+		linkTypesOptions: {
+			posts: [
+				{ label: 'Post link', value: 'post' },
+				{ label: 'Author link', value: 'author' },
+			],
+			pages: [{ label: 'Page link', value: 'page' }],
+		},
+		linkFieldsOptions: {
+			title: [{ label: 'Title link', value: 'title_link' }],
+			content: [{ label: 'Content link', value: 'content_link' }],
+		},
+	};
+});
 
 /**
  * Internal dependencies
@@ -630,43 +663,6 @@ describe('getFields', () => {
 
 		expect(result).toEqual([{ label: 'Title', value: 'title' }]);
 	});
-});
-
-// Mock additional dependencies for getRelationOptions tests
-jest.doMock('@extensions/DC/constants', () => {
-	const mockFieldOptions = {
-		text: {
-			posts: [{ label: 'Title', value: 'title' }],
-			categories: [{ label: 'Name', value: 'name' }],
-		},
-		image: {
-			posts: [{ label: 'Featured image', value: 'featured_media' }],
-			categories: [{ label: 'Category image', value: 'category_image' }],
-		},
-	};
-
-	const mockRelationOptions = {
-		text: {
-			posts: [
-				{ label: 'Get latest', value: 'latest' },
-				{ label: 'Get oldest', value: 'oldest' },
-			],
-			categories: [{ label: 'Get top level', value: 'top-level' }],
-		},
-	};
-
-	return {
-		...jest.requireActual('@extensions/DC/constants'),
-		fieldOptions: mockFieldOptions,
-		relationOptions: mockRelationOptions,
-		postTypeRelationOptions: [
-			{ label: 'Get latest', value: 'latest' },
-			{ label: 'Get oldest', value: 'oldest' },
-		],
-		taxonomyRelationOptions: [
-			{ label: 'Get hierarchical', value: 'hierarchical' },
-		],
-	};
 });
 
 describe('getRelationOptions', () => {

--- a/src/extensions/DC/test/utils.js
+++ b/src/extensions/DC/test/utils.js
@@ -262,6 +262,18 @@ describe('DC utility string manipulation functions', () => {
 					label: 'Selected entity',
 					value: 'entity',
 				},
+				{
+					label: 'Post link',
+					value: 'post',
+				},
+				{
+					label: 'Author link',
+					value: 'author',
+				},
+				{
+					label: 'Title link',
+					value: 'title_link',
+				},
 			]);
 		});
 
@@ -272,6 +284,18 @@ describe('DC utility string manipulation functions', () => {
 				{
 					label: 'Selected entity',
 					value: 'entity',
+				},
+				{
+					label: 'Post link',
+					value: 'post',
+				},
+				{
+					label: 'Author link',
+					value: 'author',
+				},
+				{
+					label: 'Title link',
+					value: 'title_link',
 				},
 			]);
 		});
@@ -285,11 +309,31 @@ describe('DC utility string manipulation functions', () => {
 					label: 'Selected entity',
 					value: 'entity',
 				},
+				{
+					label: 'Post link',
+					value: 'post',
+				},
+				{
+					label: 'Author link',
+					value: 'author',
+				},
+				{
+					label: 'Content link',
+					value: 'content_link',
+				},
 			]);
 			expect(pagesResult).toEqual([
 				{
 					label: 'Selected entity',
 					value: 'entity',
+				},
+				{
+					label: 'Page link',
+					value: 'page',
+				},
+				{
+					label: 'Content link',
+					value: 'content_link',
 				},
 			]);
 		});
@@ -503,25 +547,6 @@ describe('getCurrentTemplateSlug', () => {
 
 		expect(result).toBe('single-post');
 	});
-});
-
-// Mock the non-exported functions used by getFields
-jest.mock('@extensions/DC/constants', () => {
-	const mockFieldOptions = {
-		text: {
-			posts: [{ label: 'Title', value: 'title' }],
-			categories: [{ label: 'Name', value: 'name' }],
-		},
-		image: {
-			posts: [{ label: 'Featured image', value: 'featured_media' }],
-			categories: [{ label: 'Category image', value: 'category_image' }],
-		},
-	};
-
-	return {
-		...jest.requireActual('@extensions/DC/constants'),
-		fieldOptions: mockFieldOptions,
-	};
 });
 
 describe('getFields', () => {

--- a/src/extensions/DC/test/utils.js
+++ b/src/extensions/DC/test/utils.js
@@ -670,8 +670,8 @@ describe('getFields', () => {
 		mockGetCustomTaxonomies.mockReturnValue([]);
 
 		// No FSE mode
-		const originalMock = select.mockImplementation;
-		select.mockImplementation = jest.fn(store => {
+		const originalMock = select.getMockImplementation();
+		select.mockImplementation(store => {
 			if (store === 'maxiBlocks/dynamic-content') {
 				return {
 					getCustomPostTypes: mockGetCustomPostTypes,
@@ -684,7 +684,7 @@ describe('getFields', () => {
 		const result = getFields('text', 'posts');
 
 		// Restore original mock
-		select.mockImplementation = originalMock;
+		select.mockImplementation(originalMock);
 
 		expect(result).toEqual([{ label: 'Title', value: 'title' }]);
 	});

--- a/src/extensions/DC/test/utils.js
+++ b/src/extensions/DC/test/utils.js
@@ -1,0 +1,1092 @@
+jest.mock('@wordpress/data', () => {
+	const mockGetCustomTaxonomies = jest.fn();
+	const mockEntityRecords = jest.fn();
+
+	return {
+		select: jest.fn(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomTaxonomies: mockGetCustomTaxonomies,
+				};
+			}
+			return {};
+		}),
+		resolveSelect: jest.fn(() => ({
+			getEntityRecords: mockEntityRecords,
+		})),
+	};
+});
+
+jest.mock('@wordpress/i18n', () => ({
+	__: jest.fn(text => text),
+}));
+
+jest.mock('@extensions/DC/constants', () => ({
+	linkTypesOptions: {
+		posts: [
+			{ label: 'Post link', value: 'post' },
+			{ label: 'Author link', value: 'author' },
+		],
+		pages: [{ label: 'Page link', value: 'page' }],
+	},
+	linkFieldsOptions: {
+		title: [{ label: 'Title link', value: 'title_link' }],
+		content: [{ label: 'Content link', value: 'content_link' }],
+	},
+}));
+
+/**
+ * Internal dependencies
+ */
+import {
+	parseText,
+	cutTags,
+	getSimpleText,
+	limitString,
+	getLinkTargets,
+	getTaxonomyContent,
+	getCurrentTemplateSlug,
+	getFields,
+	getRelationOptions,
+	validationsValues,
+	getPostBySlug,
+} from '@extensions/DC/utils';
+
+import { resolveSelect, select } from '@wordpress/data';
+
+// Get references to the mocked functions
+const mockGetCustomTaxonomies = select(
+	'maxiBlocks/dynamic-content'
+).getCustomTaxonomies;
+const mockEntityRecords = resolveSelect().getEntityRecords;
+
+describe('DC utility string manipulation functions', () => {
+	describe('parseText', () => {
+		it('should sanitize HTML and return text content', () => {
+			const html = '<p>Hello <strong>world</strong>!</p>';
+
+			const result = parseText(html);
+
+			expect(result).toBe('Hello world!');
+		});
+
+		it('should handle empty input', () => {
+			expect(parseText('')).toBe('');
+			expect(parseText(null)).toBe('');
+			expect(parseText(undefined)).toBe('');
+		});
+	});
+
+	describe('cutTags', () => {
+		it('should remove HTML tags and replace with spaces', () => {
+			const html = '<p>Hello</p><div>world!</div>';
+
+			const result = cutTags(html);
+
+			expect(result).toBe(' Hello  world! ');
+		});
+
+		it('should handle inline tags', () => {
+			const html =
+				'This is <strong>bold</strong> and <em>italic</em> text';
+
+			const result = cutTags(html);
+
+			expect(result).toBe('This is  bold  and  italic  text');
+		});
+
+		it('should handle empty input', () => {
+			expect(cutTags('')).toBe('');
+			expect(cutTags(null)).toBe('');
+			expect(cutTags(undefined)).toBe('');
+		});
+
+		it('should not modify string without tags', () => {
+			const text = 'Plain text without tags';
+
+			const result = cutTags(text);
+
+			expect(result).toBe('Plain text without tags');
+		});
+	});
+
+	describe('getSimpleText', () => {
+		it('should remove style tags and their content', () => {
+			const html =
+				'<p>Hello</p><style>.class { color: red; }</style><p>world!</p>';
+
+			const result = getSimpleText(html);
+
+			expect(result).toBe(' Hello  world! ');
+		});
+
+		it('should remove SVG tags and their content', () => {
+			const html =
+				'<p>Start</p><svg width="100"><circle cx="50" cy="50" r="40"/></svg><p>End</p>';
+
+			const result = getSimpleText(html);
+
+			expect(result).toBe(' Start  End ');
+		});
+
+		it('should remove other HTML tags', () => {
+			const html =
+				'<h1>Title</h1><p>Description with <a href="#">link</a></p>';
+
+			const result = getSimpleText(html);
+
+			expect(result).toBe(' Title  Description with  link  ');
+		});
+
+		it('should handle empty input', () => {
+			expect(getSimpleText('')).toBe('');
+			expect(getSimpleText(null)).toBe('');
+			expect(getSimpleText(undefined)).toBe('');
+		});
+	});
+
+	describe('limitString', () => {
+		it('should truncate strings longer than the limit', () => {
+			const text = 'This is a long text that needs to be truncated';
+			const limit = 10;
+
+			const result = limitString(text, limit);
+
+			expect(result).toBe('This is a …');
+			expect(result.length).toBe(limit + 1); // +1 for the ellipsis
+		});
+
+		it('should add ellipsis to truncated strings', () => {
+			const text = 'Hello world!';
+			const limit = 5;
+
+			const result = limitString(text, limit);
+
+			expect(result).toBe('Hello…');
+		});
+
+		it('should not modify strings shorter than the limit', () => {
+			const text = 'Short';
+			const limit = 10;
+
+			const result = limitString(text, limit);
+
+			expect(result).toBe('Short');
+		});
+
+		it('should remove HTML tags before limiting', () => {
+			const html = '<p>Text with <strong>tags</strong> to be limited</p>';
+			const limit = 15;
+
+			const result = limitString(html, limit);
+
+			expect(result).toBe('Text with  tags…');
+		});
+
+		it('should trim the text before limiting', () => {
+			const text = '  Text with spaces  ';
+			const limit = 10;
+
+			const result = limitString(text, limit);
+
+			expect(result).toBe('Text with …');
+		});
+
+		it('should return the original string for zero or negative limits', () => {
+			const text = 'Test text';
+
+			expect(limitString(text, 0)).toBe('Test text');
+			expect(limitString(text, -5)).toBe('Test text');
+		});
+
+		it('should handle empty input', () => {
+			expect(limitString('', 10)).toBe('');
+			expect(limitString(null, 10)).toBe('');
+			expect(limitString(undefined, 10)).toBe('');
+		});
+	});
+
+	describe('getLinkTargets', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			mockGetCustomTaxonomies.mockReturnValue([]);
+		});
+
+		it('should always include the default entity target', () => {
+			const result = getLinkTargets('posts', 'title');
+
+			expect(result).toContainEqual({
+				label: 'Selected entity',
+				value: 'entity',
+			});
+		});
+
+		it('should include link targets based on type', () => {
+			const result = getLinkTargets('posts', 'title');
+
+			expect(result).toEqual([
+				{
+					label: 'Selected entity',
+					value: 'entity',
+				},
+			]);
+		});
+
+		it('should include link targets based on field', () => {
+			const result = getLinkTargets('posts', 'title');
+
+			expect(result).toEqual([
+				{
+					label: 'Selected entity',
+					value: 'entity',
+				},
+			]);
+		});
+
+		it('should include different link targets for different types', () => {
+			const postsResult = getLinkTargets('posts', 'content');
+			const pagesResult = getLinkTargets('pages', 'content');
+
+			expect(postsResult).toEqual([
+				{
+					label: 'Selected entity',
+					value: 'entity',
+				},
+			]);
+			expect(pagesResult).toEqual([
+				{
+					label: 'Selected entity',
+					value: 'entity',
+				},
+			]);
+		});
+
+		it('should add custom taxonomy links when field is a custom taxonomy', () => {
+			mockGetCustomTaxonomies.mockReturnValue([
+				'category',
+				'tag',
+				'custom_tax',
+			]);
+
+			const result = getLinkTargets('posts', 'custom_tax');
+
+			expect(result).toContainEqual({
+				label: 'Custom_tax links',
+				value: 'custom_tax',
+			});
+		});
+
+		it('should not add custom taxonomy links when field is not a custom taxonomy', () => {
+			mockGetCustomTaxonomies.mockReturnValue(['category', 'tag']);
+
+			const result = getLinkTargets('posts', 'title');
+
+			expect(result).not.toContainEqual(
+				expect.objectContaining({
+					value: 'title',
+				})
+			);
+		});
+	});
+});
+
+describe('getTaxonomyContent', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return null when taxonomyIds is empty', async () => {
+		const result = await getTaxonomyContent([], ', ', false, 'category');
+
+		expect(result).toBeNull();
+		expect(mockEntityRecords).not.toHaveBeenCalled();
+	});
+
+	it('should return null when taxonomyIds is null', async () => {
+		const result = await getTaxonomyContent(null, ', ', false, 'category');
+
+		expect(result).toBeNull();
+		expect(mockEntityRecords).not.toHaveBeenCalled();
+	});
+
+	it('should return null when no taxonomy records are found', async () => {
+		mockEntityRecords.mockResolvedValue(null);
+
+		const result = await getTaxonomyContent(
+			[1, 2],
+			', ',
+			false,
+			'category'
+		);
+
+		expect(result).toBeNull();
+		expect(mockEntityRecords).toHaveBeenCalledWith('taxonomy', 'category', {
+			include: [1, 2],
+		});
+	});
+
+	it('should return null when taxonomy records array is empty', async () => {
+		mockEntityRecords.mockResolvedValue([]);
+
+		const result = await getTaxonomyContent(
+			[1, 2],
+			', ',
+			false,
+			'category'
+		);
+
+		expect(result).toBeNull();
+		expect(mockEntityRecords).toHaveBeenCalledWith('taxonomy', 'category', {
+			include: [1, 2],
+		});
+	});
+
+	it('should return plain text with delimiter when linkStatus is false', async () => {
+		mockEntityRecords.mockResolvedValue([
+			{ name: 'Category 1' },
+			{ name: 'Category 2' },
+		]);
+
+		const result = await getTaxonomyContent(
+			[1, 2],
+			', ',
+			false,
+			'category'
+		);
+
+		expect(result).toBe('Category 1,  Category 2');
+		expect(mockEntityRecords).toHaveBeenCalledWith('taxonomy', 'category', {
+			include: [1, 2],
+		});
+	});
+
+	it('should return HTML with links when linkStatus is true', async () => {
+		mockEntityRecords.mockResolvedValue([
+			{ name: 'Category 1' },
+			{ name: 'Category 2' },
+		]);
+
+		const result = await getTaxonomyContent([1, 2], ', ', true, 'category');
+
+		expect(result).toBe(
+			'<span><a class="maxi-text-block--link"><span>Category 1</span></a>,  <a class="maxi-text-block--link"><span>Category 2</span></a></span>'
+		);
+		expect(mockEntityRecords).toHaveBeenCalledWith('taxonomy', 'category', {
+			include: [1, 2],
+		});
+	});
+
+	it('should use provided delimiter in the output', async () => {
+		mockEntityRecords.mockResolvedValue([
+			{ name: 'Tag 1' },
+			{ name: 'Tag 2' },
+		]);
+
+		const result = await getTaxonomyContent(
+			[1, 2],
+			' | ',
+			false,
+			'post_tag'
+		);
+
+		expect(result).toBe('Tag 1 |  Tag 2');
+		expect(mockEntityRecords).toHaveBeenCalledWith('taxonomy', 'post_tag', {
+			include: [1, 2],
+		});
+	});
+});
+
+describe('getCurrentTemplateSlug', () => {
+	const mockEditSite = {
+		getEditedPostContext: jest.fn(),
+		getEditedPostId: jest.fn(),
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		select.mockImplementation(store => {
+			if (store === 'core/edit-site') {
+				return mockEditSite;
+			}
+			return null;
+		});
+	});
+
+	it('should return null when editSite is not available', () => {
+		select.mockReturnValueOnce(null);
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBeNull();
+	});
+
+	it('should return null when templateSlug and postId are both not available', () => {
+		mockEditSite.getEditedPostContext.mockReturnValue({});
+		mockEditSite.getEditedPostId.mockReturnValue(null);
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBeNull();
+	});
+
+	it('should use templateSlug from getEditedPostContext when available', () => {
+		mockEditSite.getEditedPostContext.mockReturnValue({
+			templateSlug: 'home',
+		});
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBe('home');
+		expect(mockEditSite.getEditedPostContext).toHaveBeenCalled();
+	});
+
+	it('should use getEditedPostId as fallback (WordPress 6.5 compatibility)', () => {
+		mockEditSite.getEditedPostContext.mockReturnValue({});
+		mockEditSite.getEditedPostId.mockReturnValue('page');
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBe('page');
+		expect(mockEditSite.getEditedPostContext).toHaveBeenCalled();
+		expect(mockEditSite.getEditedPostId).toHaveBeenCalled();
+	});
+
+	it('should extract the part after // when template slug contains it', () => {
+		mockEditSite.getEditedPostContext.mockReturnValue({
+			templateSlug: 'wp-custom-template//archive-products',
+		});
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBe('archive-products');
+	});
+
+	it('should return the original slug when no // is present', () => {
+		mockEditSite.getEditedPostContext.mockReturnValue({
+			templateSlug: 'single-post',
+		});
+
+		const result = getCurrentTemplateSlug();
+
+		expect(result).toBe('single-post');
+	});
+});
+
+// Mock the non-exported functions used by getFields
+jest.mock('@extensions/DC/constants', () => {
+	const mockFieldOptions = {
+		text: {
+			posts: [{ label: 'Title', value: 'title' }],
+			categories: [{ label: 'Name', value: 'name' }],
+		},
+		image: {
+			posts: [{ label: 'Featured image', value: 'featured_media' }],
+			categories: [{ label: 'Category image', value: 'category_image' }],
+		},
+	};
+
+	return {
+		...jest.requireActual('@extensions/DC/constants'),
+		fieldOptions: mockFieldOptions,
+	};
+});
+
+describe('getFields', () => {
+	const mockGetPostType = jest.fn();
+	const mockGetTaxonomy = jest.fn();
+	const mockGetCustomPostTypes = jest.fn();
+	const mockGetCustomTaxonomies = jest.fn();
+	const mockEditSite = {};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Reset default implementation of select
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: mockGetCustomPostTypes,
+					getCustomTaxonomies: mockGetCustomTaxonomies,
+				};
+			}
+			if (store === 'core') {
+				return {
+					getPostType: mockGetPostType,
+					getTaxonomy: mockGetTaxonomy,
+				};
+			}
+			if (store === 'core/edit-site') {
+				return mockEditSite;
+			}
+			return null;
+		});
+
+		// Default custom types response
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+	});
+
+	it('should return fields for custom post types', () => {
+		mockGetCustomPostTypes.mockReturnValue(['book']);
+		mockGetPostType.mockReturnValue({
+			supports: {
+				title: true,
+				editor: true,
+				thumbnail: true,
+			},
+			taxonomies: [],
+		});
+
+		const result = getFields('text', 'book');
+
+		expect(mockGetCustomPostTypes).toHaveBeenCalled();
+		expect(mockGetPostType).toHaveBeenCalledWith('book');
+		// At minimum, should contain these fields
+		expect(result).toContainEqual({
+			label: 'Static text',
+			value: 'static_text',
+		});
+		expect(result).toContainEqual({ label: 'Title', value: 'title' });
+		expect(result).toContainEqual({ label: 'Date', value: 'date' });
+	});
+
+	it('should return fields for custom taxonomies', () => {
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue(['custom_tax']);
+		mockGetTaxonomy.mockReturnValue({
+			hierarchical: true,
+		});
+		// Mock for getCurrentTemplateSlug
+		mockEditSite.getEditedPostContext = jest
+			.fn()
+			.mockReturnValue({ templateSlug: 'default' });
+
+		const result = getFields('text', 'custom_tax');
+
+		expect(mockGetCustomTaxonomies).toHaveBeenCalled();
+		expect(mockGetTaxonomy).toHaveBeenCalledWith('custom_tax');
+		// Should contain base taxonomy fields
+		expect(result).toContainEqual({ label: 'Name', value: 'name' });
+		expect(result).toContainEqual({
+			label: 'Description',
+			value: 'description',
+		});
+		expect(result).toContainEqual({ label: 'Parent', value: 'parent' });
+	});
+
+	it('should add archive type name when in FSE mode for supported types', () => {
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+		// Setup FSE mode
+		mockEditSite.getEditedPostContext = jest
+			.fn()
+			.mockReturnValue({ templateSlug: 'category' });
+
+		const result = getFields('text', 'categories');
+
+		expect(result).toContainEqual({
+			label: "Archive type's name",
+			value: 'archive-type',
+		});
+	});
+
+	it('should not add archive type name for image content type', () => {
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+		// Setup FSE mode
+		mockEditSite.getEditedPostContext = jest
+			.fn()
+			.mockReturnValue({ templateSlug: 'category' });
+
+		const result = getFields('image', 'categories');
+
+		// Should return fields from fieldOptions without archive type
+		expect(result).toBeDefined();
+		expect(result).toEqual([
+			{ label: 'Category image', value: 'category_image' },
+		]);
+	});
+
+	it('should fall back to fieldOptions when not a custom type', () => {
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+
+		// No FSE mode
+		const originalMock = select.mockImplementation;
+		select.mockImplementation = jest.fn(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: mockGetCustomPostTypes,
+					getCustomTaxonomies: mockGetCustomTaxonomies,
+				};
+			}
+			return store === 'core/edit-site' ? undefined : null;
+		});
+
+		const result = getFields('text', 'posts');
+
+		// Restore original mock
+		select.mockImplementation = originalMock;
+
+		expect(result).toEqual([{ label: 'Title', value: 'title' }]);
+	});
+});
+
+// Mock additional dependencies for getRelationOptions tests
+jest.doMock('@extensions/DC/constants', () => {
+	const mockFieldOptions = {
+		text: {
+			posts: [{ label: 'Title', value: 'title' }],
+			categories: [{ label: 'Name', value: 'name' }],
+		},
+		image: {
+			posts: [{ label: 'Featured image', value: 'featured_media' }],
+			categories: [{ label: 'Category image', value: 'category_image' }],
+		},
+	};
+
+	const mockRelationOptions = {
+		text: {
+			posts: [
+				{ label: 'Get latest', value: 'latest' },
+				{ label: 'Get oldest', value: 'oldest' },
+			],
+			categories: [{ label: 'Get top level', value: 'top-level' }],
+		},
+	};
+
+	return {
+		...jest.requireActual('@extensions/DC/constants'),
+		fieldOptions: mockFieldOptions,
+		relationOptions: mockRelationOptions,
+		postTypeRelationOptions: [
+			{ label: 'Get latest', value: 'latest' },
+			{ label: 'Get oldest', value: 'oldest' },
+		],
+		taxonomyRelationOptions: [
+			{ label: 'Get hierarchical', value: 'hierarchical' },
+		],
+	};
+});
+
+describe('getRelationOptions', () => {
+	const mockGetPostType = jest.fn();
+	const mockGetCustomPostTypes = jest.fn();
+	const mockGetCustomTaxonomies = jest.fn();
+	const mockGetCurrentPostType = jest.fn();
+	const mockEditSite = {};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Reset select mock implementation
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: mockGetCustomPostTypes,
+					getCustomTaxonomies: mockGetCustomTaxonomies,
+				};
+			}
+			if (store === 'core') {
+				return {
+					getPostType: mockGetPostType,
+				};
+			}
+			if (store === 'core/editor') {
+				return {
+					getCurrentPostType: mockGetCurrentPostType,
+				};
+			}
+			if (store === 'core/edit-site') {
+				return mockEditSite;
+			}
+			return null;
+		});
+
+		// Default responses
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+		mockGetCurrentPostType.mockReturnValue('post');
+	});
+
+	it('should return options for custom post types', () => {
+		// Setup custom post type
+		mockGetCustomPostTypes.mockReturnValue(['book']);
+		mockGetPostType.mockReturnValue({
+			supports: { title: true, author: true },
+			taxonomies: ['category', 'post_tag'],
+		});
+
+		const result = getRelationOptions('book', 'text');
+
+		expect(mockGetCustomPostTypes).toHaveBeenCalled();
+		expect(mockGetPostType).toHaveBeenCalledWith('book');
+		// Just check that we get an array with some options
+		expect(Array.isArray(result)).toBe(true);
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it('should return options for custom taxonomies', () => {
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue(['custom_taxonomy']);
+
+		const result = getRelationOptions('custom_taxonomy', 'text');
+
+		expect(mockGetCustomTaxonomies).toHaveBeenCalled();
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should return options for regular content types', () => {
+		const result = getRelationOptions('posts', 'text');
+
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should add custom taxonomy options for non-archive types', () => {
+		mockGetCustomTaxonomies.mockReturnValue(['genre', 'mood']);
+
+		const result = getRelationOptions('posts', 'text');
+
+		// Since we can't guarantee exactly what will be in the results due to mocking,
+		// just check that we get something back
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should handle current post type matching', () => {
+		// Current post type matches the requested type
+		mockGetCurrentPostType.mockReturnValue('posts');
+
+		const result = getRelationOptions('posts', 'text');
+
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should handle archive templates', () => {
+		// Setup archive template
+		mockEditSite.getEditedPostContext = jest.fn().mockReturnValue({
+			templateSlug: 'archive',
+		});
+
+		const result = getRelationOptions('posts', 'text', 'archive');
+
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should handle showing current content', () => {
+		// Setup template that should show current content
+		const result = getRelationOptions('posts', 'text', 'single');
+
+		expect(Array.isArray(result)).toBe(true);
+	});
+
+	it('should handle not showing current content', () => {
+		// Mock implementation to return options
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getCustomPostTypes: () => [],
+					getCustomTaxonomies: () => [],
+				};
+			}
+			if (store === 'core/editor') {
+				return {
+					getCurrentPostType: () => 'page',
+				};
+			}
+			return null;
+		});
+
+		// Use a template type that shouldn't show current for 'posts'
+		const result = getRelationOptions(
+			'posts',
+			'text',
+			'non-matching-template'
+		);
+
+		expect(Array.isArray(result)).toBe(true);
+	});
+});
+
+describe('validationsValues', () => {
+	const mockGetWasCustomPostTypesLoaded = jest.fn();
+	const mockGetWasCustomTaxonomiesLoaded = jest.fn();
+	const mockIsIntegrationListLoaded = jest.fn();
+	const mockGetCurrentPostType = jest.fn();
+	const mockGetTypeOptions = jest.fn();
+	const mockGetACFTypeOptions = jest.fn();
+	const mockGetCustomPostTypes = jest.fn();
+	const mockGetCustomTaxonomies = jest.fn();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return {
+					getWasCustomPostTypesLoaded:
+						mockGetWasCustomPostTypesLoaded,
+					getWasCustomTaxonomiesLoaded:
+						mockGetWasCustomTaxonomiesLoaded,
+					isIntegrationListLoaded: mockIsIntegrationListLoaded,
+					getCustomPostTypes: mockGetCustomPostTypes,
+					getCustomTaxonomies: mockGetCustomTaxonomies,
+					getTypeOptions: mockGetTypeOptions,
+					getACFTypeOptions: mockGetACFTypeOptions,
+				};
+			}
+			if (store === 'core/editor') {
+				return {
+					getCurrentPostType: mockGetCurrentPostType,
+				};
+			}
+			if (store === 'core/edit-site') {
+				return {
+					getEditedPostContext: () => ({ templateSlug: 'single' }),
+				};
+			}
+			return {};
+		});
+
+		// Set default values
+		mockGetWasCustomPostTypesLoaded.mockReturnValue(true);
+		mockGetWasCustomTaxonomiesLoaded.mockReturnValue(true);
+		mockIsIntegrationListLoaded.mockReturnValue(true);
+		mockGetCurrentPostType.mockReturnValue('post');
+		mockGetCustomPostTypes.mockReturnValue([]);
+		mockGetCustomTaxonomies.mockReturnValue([]);
+
+		// Mock typeOptions for different content types
+		mockGetTypeOptions.mockReturnValue({
+			text: [
+				{ label: 'Posts', value: 'posts' },
+				{ label: 'Pages', value: 'pages' },
+			],
+			image: [{ label: 'Media', value: 'media' }],
+		});
+
+		// Mock ACF type options
+		mockGetACFTypeOptions.mockReturnValue([
+			{ label: 'ACF Text', value: 'acf_text' },
+			{ label: 'ACF Image', value: 'acf_image' },
+		]);
+	});
+
+	it('should return empty object if custom post types not loaded', () => {
+		mockGetWasCustomPostTypesLoaded.mockReturnValue(false);
+
+		const result = validationsValues('posts', 'title', 'latest', 'text');
+
+		expect(result).toEqual({});
+	});
+
+	it('should return empty object if custom taxonomies not loaded', () => {
+		mockGetWasCustomTaxonomiesLoaded.mockReturnValue(false);
+
+		const result = validationsValues('posts', 'title', 'latest', 'text');
+
+		expect(result).toEqual({});
+	});
+
+	it('should validate field for WordPress source', () => {
+		// We can't fully mock the real functions in the test file,
+		// but we can check that the function completes without errors
+		// and returns an object with expected structure
+		const result = validationsValues(
+			'posts',
+			'invalid_field',
+			'latest',
+			'text'
+		);
+
+		// The validation should detect the invalid field
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+	});
+
+	it('should validate relation', () => {
+		const result = validationsValues(
+			'posts',
+			'title',
+			'invalid_relation',
+			'text'
+		);
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+	});
+
+	it('should validate content type', () => {
+		const result = validationsValues(
+			'invalid_type',
+			'title',
+			'latest',
+			'text'
+		);
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+	});
+
+	it('should validate link target', () => {
+		const result = validationsValues(
+			'posts',
+			'title',
+			'latest',
+			'text',
+			'wp',
+			'invalid_link_target'
+		);
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+	});
+
+	it('should handle context loop fields with cl prefix', () => {
+		// With context loop enabled (isCL = true)
+		const result = validationsValues(
+			'posts',
+			'title',
+			'latest',
+			'text',
+			'wp',
+			'entity',
+			true
+		);
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+
+		// Check that any returned attributes use the cl- prefix
+		const hasClPrefix = Object.keys(result).every(
+			key => !key || key.startsWith('cl-')
+		);
+		expect(hasClPrefix).toBe(true);
+	});
+
+	it('should handle ACF source fields', () => {
+		// With ACF source
+		const result = validationsValues(
+			'posts',
+			'acf_field',
+			'latest',
+			'text',
+			'acf',
+			'entity',
+			false,
+			'test_group'
+		);
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('object');
+	});
+});
+
+describe('getPostBySlug', () => {
+	const mockGetEntityRecords = jest.fn();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Mock select for core
+		select.mockImplementation(store => {
+			if (store === 'core') {
+				return {
+					getEntityRecords: mockGetEntityRecords,
+				};
+			}
+			return {};
+		});
+	});
+
+	it('should return a post when exact slug match exists', async () => {
+		// Mock post with exact slug - make sure it returns posts with length > 0 on first call
+		// to satisfy the retry logic's early return condition
+		const mockPost = { id: 123, title: 'Test Post', slug: 'test-post' };
+		mockGetEntityRecords.mockResolvedValue([mockPost]);
+
+		const result = await getPostBySlug('test-post');
+
+		// We can't assert exact number of calls due to retry logic,
+		// but we can check it was called with the right parameters
+		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
+			slug: 'test-post',
+			per_page: 1,
+		});
+		expect(result).toEqual(mockPost);
+	});
+
+	it('should try without numeric suffix when exact match not found', async () => {
+		// First set of calls (with original slug) return empty array
+		// Second set (with slug without suffix) returns a post
+		const mockPost = {
+			id: 456,
+			title: 'Another Post',
+			slug: 'another-post',
+		};
+		mockGetEntityRecords.mockImplementation((...args) => {
+			const options = args[2];
+			if (options.slug === 'another-post-2') {
+				return Promise.resolve([]);
+			}
+			if (options.slug === 'another-post') {
+				return Promise.resolve([mockPost]);
+			}
+			return Promise.resolve([]);
+		});
+
+		const result = await getPostBySlug('another-post-2');
+
+		// Check that both slugs were tried (exact parameters checking)
+		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
+			slug: 'another-post-2',
+			per_page: 1,
+		});
+		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
+			slug: 'another-post',
+			per_page: 1,
+		});
+		expect(result).toEqual(mockPost);
+	});
+
+	it('should return null when no post is found', async () => {
+		// Always return empty array to simulate no posts found
+		mockGetEntityRecords.mockResolvedValue([]);
+
+		const result = await getPostBySlug('non-existent-post-1');
+
+		// Can't check exact call count due to retries
+		expect(result).toBeNull();
+	});
+
+	it('should return null for slug without numeric suffix when not found', async () => {
+		// Always return empty array to simulate no posts found
+		mockGetEntityRecords.mockResolvedValue([]);
+
+		const result = await getPostBySlug('plain-slug');
+
+		// Should still attempt to find by exact slug
+		expect(mockGetEntityRecords).toHaveBeenCalledWith('postType', 'post', {
+			slug: 'plain-slug',
+			per_page: 1,
+		});
+		expect(result).toBeNull();
+	});
+
+	it('should retry operations when initial attempts fail', async () => {
+		// First calls reject, later calls succeed
+		const mockPost = { id: 789, title: 'Retry Post', slug: 'retry-post' };
+
+		let callCount = 0;
+		mockGetEntityRecords.mockImplementation(() => {
+			callCount += 1;
+			if (callCount <= 2) {
+				return Promise.reject(new Error('Network error'));
+			}
+			return Promise.resolve([mockPost]);
+		});
+
+		const result = await getPostBySlug('retry-post');
+
+		expect(result).toEqual(mockPost);
+	});
+});

--- a/src/extensions/DC/test/validateDCAttributes.js
+++ b/src/extensions/DC/test/validateDCAttributes.js
@@ -77,7 +77,7 @@ describe('getValidatedDCAttributes', () => {
 		);
 
 		expect(getDCOptions).toHaveBeenCalledWith(
-			attributes,
+			{ ...attributes, previousRelation: attributes.relation },
 			attributes.id,
 			contentType,
 			isCL,

--- a/src/extensions/DC/test/validateDCAttributes.js
+++ b/src/extensions/DC/test/validateDCAttributes.js
@@ -1,0 +1,270 @@
+/**
+ * External dependencies
+ */
+import { jest } from '@jest/globals';
+
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import getValidatedDCAttributes from '@extensions/DC/validateDCAttributes';
+import getDCOptions from '@extensions/DC/getDCOptions';
+import { validateRelations, validationsValues } from '@extensions/DC/utils';
+import { getValidatedACFAttributes } from '@components/dynamic-content/acf-settings-control/utils';
+
+jest.mock('@wordpress/data', () => ({
+	select: jest.fn(),
+}));
+
+jest.mock('@extensions/DC/getDCOptions', () => jest.fn());
+jest.mock('@extensions/DC/utils', () => ({
+	validateRelations: jest.fn(),
+	validationsValues: jest.fn(),
+}));
+jest.mock('@components/dynamic-content/acf-settings-control/utils', () => ({
+	getValidatedACFAttributes: jest.fn(),
+}));
+
+describe('getValidatedDCAttributes', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		getDCOptions.mockResolvedValue({ newValues: null });
+		validateRelations.mockReturnValue(null);
+		validationsValues.mockReturnValue(null);
+		getValidatedACFAttributes.mockResolvedValue({
+			validatedAttributes: null,
+		});
+
+		const mockDCStore = {
+			getWasCustomPostTypesLoaded: jest.fn().mockReturnValue(true),
+			getWasCustomTaxonomiesLoaded: jest.fn().mockReturnValue(true),
+			isIntegrationListLoaded: jest.fn().mockReturnValue(true),
+		};
+
+		select.mockImplementation(store => {
+			if (store === 'maxiBlocks/dynamic-content') {
+				return mockDCStore;
+			}
+			return {};
+		});
+	});
+
+	it('should call all validation functions with correct parameters', async () => {
+		const attributes = {
+			type: 'posts',
+			field: 'title',
+			relation: 'by-id',
+			id: 1,
+			source: 'wp',
+			linkTarget: 'post',
+			acfGroup: '',
+		};
+
+		const contentType = 'text';
+		const contextLoop = { 'cl-status': true, 'cl-pagination-per-page': 5 };
+		const isCL = false;
+
+		await getValidatedDCAttributes(
+			attributes,
+			contentType,
+			contextLoop,
+			isCL
+		);
+
+		expect(getDCOptions).toHaveBeenCalledWith(
+			attributes,
+			attributes.id,
+			contentType,
+			isCL,
+			{
+				'cl-status': contextLoop['cl-status'],
+				'cl-pagination-per-page': contextLoop['cl-pagination-per-page'],
+			}
+		);
+
+		expect(validationsValues).toHaveBeenCalledWith(
+			attributes.type,
+			attributes.field,
+			attributes.relation,
+			contentType,
+			attributes.source,
+			attributes.linkTarget,
+			isCL,
+			attributes.acfGroup
+		);
+
+		expect(validateRelations).toHaveBeenCalledWith(
+			attributes.type,
+			attributes.relation,
+			isCL
+		);
+
+		// Check ACF validation wasn't called for 'wp' source
+		expect(getValidatedACFAttributes).not.toHaveBeenCalled();
+	});
+
+	it('should call ACF validation function when source is acf', async () => {
+		const attributes = {
+			type: 'posts',
+			field: 'acf_field',
+			relation: 'by-id',
+			id: 1,
+			source: 'acf',
+			linkTarget: 'post',
+			acfGroup: 'test_group',
+		};
+
+		const contentType = 'text';
+		const contextLoop = null;
+		const isCL = false;
+
+		await getValidatedDCAttributes(
+			attributes,
+			contentType,
+			contextLoop,
+			isCL
+		);
+
+		expect(getValidatedACFAttributes).toHaveBeenCalledWith(
+			attributes.acfGroup,
+			attributes.field,
+			contentType,
+			'dc-'
+		);
+	});
+
+	it('should use cl prefix for ACF validation when isCL is true', async () => {
+		const attributes = {
+			type: 'posts',
+			field: 'acf_field',
+			relation: 'by-id',
+			id: 1,
+			source: 'acf',
+			linkTarget: 'post',
+			acfGroup: 'test_group',
+		};
+
+		const contentType = 'text';
+		const contextLoop = { 'cl-status': true };
+		const isCL = true;
+
+		await getValidatedDCAttributes(
+			attributes,
+			contentType,
+			contextLoop,
+			isCL
+		);
+
+		// Check ACF validation was called with cl- prefix
+		expect(getValidatedACFAttributes).toHaveBeenCalledWith(
+			attributes.acfGroup,
+			attributes.field,
+			contentType,
+			'cl-'
+		);
+	});
+
+	it('should combine all validation results', async () => {
+		const dcOptionsValues = { 'dc-id': 2 };
+		const validatedAttributesValues = { 'dc-field': 'excerpt' };
+		const validatedRelationsValues = { 'dc-type': 'posts' };
+		const validatedACFValues = { 'dc-acf-field': 'custom_field' };
+
+		getDCOptions.mockResolvedValue({ newValues: dcOptionsValues });
+		validationsValues.mockReturnValue(validatedAttributesValues);
+		validateRelations.mockReturnValue(validatedRelationsValues);
+		getValidatedACFAttributes.mockResolvedValue({
+			validatedAttributes: validatedACFValues,
+		});
+
+		const attributes = {
+			type: 'pages',
+			field: 'invalid_field',
+			relation: 'current',
+			id: 999, // Invalid ID
+			source: 'acf',
+			linkTarget: 'invalid_target',
+			acfGroup: 'test_group',
+		};
+
+		const result = await getValidatedDCAttributes(attributes, 'text', null);
+
+		// Check that all validation results are combined
+		expect(result).toEqual({
+			...dcOptionsValues,
+			...validatedAttributesValues,
+			...validatedRelationsValues,
+			...validatedACFValues,
+		});
+	});
+
+	it('should return null if no validations return values', async () => {
+		getDCOptions.mockResolvedValue({ newValues: null });
+		validationsValues.mockReturnValue(null);
+		validateRelations.mockReturnValue(null);
+		getValidatedACFAttributes.mockResolvedValue({
+			validatedAttributes: null,
+		});
+
+		const attributes = {
+			type: 'posts',
+			field: 'title',
+			relation: 'by-id',
+			id: 1,
+			source: 'wp',
+			linkTarget: 'post',
+		};
+
+		const result = await getValidatedDCAttributes(attributes, 'text', null);
+
+		expect(result).toBeNull();
+	});
+
+	it('should handle undefined dcOptions', async () => {
+		getDCOptions.mockResolvedValue(undefined);
+		validationsValues.mockReturnValue({ 'dc-field': 'title' });
+
+		const attributes = {
+			type: 'posts',
+			field: 'content',
+			relation: 'by-id',
+			id: 1,
+			source: 'wp',
+			linkTarget: 'post',
+		};
+
+		const result = await getValidatedDCAttributes(attributes, 'text', null);
+
+		expect(result).toEqual({ 'dc-field': 'title' });
+	});
+
+	it('should handle errors from validation functions', async () => {
+		// Mock console.error to prevent test output pollution
+		const consoleErrorSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		const testError = new Error('Test error');
+		getDCOptions.mockRejectedValue(testError);
+
+		const attributes = {
+			type: 'posts',
+			field: 'title',
+			relation: 'by-id',
+			id: 1,
+			source: 'wp',
+			linkTarget: 'post',
+		};
+
+		await expect(
+			getValidatedDCAttributes(attributes, 'text', null)
+		).rejects.toThrow('Test error');
+
+		consoleErrorSpy.mockRestore();
+	});
+});

--- a/src/extensions/DC/utils.js
+++ b/src/extensions/DC/utils.js
@@ -11,7 +11,6 @@ import {
 	fieldOptions,
 	relationOptions,
 	orderByRelations,
-	getHaveLoadedIntegrationsOptions,
 	currentEntityTypes,
 	nameDictionary,
 	relationDictionary,
@@ -523,7 +522,7 @@ export const validationsValues = (
 		...(typeResult &&
 			!typeResult.includes(variableValue) &&
 			// Only validate type of DC once all integrations have loaded
-			getHaveLoadedIntegrationsOptions() && {
+			select('maxiBlocks/dynamic-content').isIntegrationListLoaded() && {
 				[`${prefix}type`]: typeResult[0],
 			}),
 		...(linkTargetResult &&

--- a/src/extensions/relations/store/test/actions.js
+++ b/src/extensions/relations/store/test/actions.js
@@ -1,0 +1,76 @@
+/**
+ * Internal dependencies
+ */
+import actions from '@extensions/relations/store/actions';
+
+describe('relations/actions', () => {
+	describe('addRelation', () => {
+		it('should return ADD_RELATION action', () => {
+			const triggerBlock = {
+				clientId: 'trigger-client-id',
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				clientId: 'target-client-id',
+				uniqueID: 'target-unique-id',
+			};
+
+			const result = actions.addRelation(triggerBlock, targetBlock);
+
+			expect(result).toEqual({
+				type: 'ADD_RELATION',
+				triggerBlock,
+				targetBlock,
+			});
+		});
+	});
+
+	describe('removeRelation', () => {
+		it('should return REMOVE_RELATION action', () => {
+			const triggerBlock = {
+				clientId: 'trigger-client-id',
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				clientId: 'target-client-id',
+				uniqueID: 'target-unique-id',
+			};
+
+			const result = actions.removeRelation(triggerBlock, targetBlock);
+
+			expect(result).toEqual({
+				type: 'REMOVE_RELATION',
+				triggerBlock,
+				targetBlock,
+			});
+		});
+	});
+
+	describe('removeBlockRelation', () => {
+		it('should return REMOVE_BLOCK_RELATION action', () => {
+			const uniqueID = 'block-unique-id';
+
+			const result = actions.removeBlockRelation(uniqueID);
+
+			expect(result).toEqual({
+				type: 'REMOVE_BLOCK_RELATION',
+				uniqueID,
+			});
+		});
+	});
+
+	describe('updateRelation', () => {
+		it('should return UPDATE_RELATION action', () => {
+			const prevUniqueID = 'old-unique-id';
+			const uniqueID = 'new-unique-id';
+
+			const result = actions.updateRelation(prevUniqueID, uniqueID);
+
+			expect(result).toEqual({
+				type: 'UPDATE_RELATION',
+				prevUniqueID,
+				uniqueID,
+			});
+		});
+	});
+});

--- a/src/extensions/relations/store/test/reducer.js
+++ b/src/extensions/relations/store/test/reducer.js
@@ -1,0 +1,323 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from '@extensions/relations/store/reducer';
+
+jest.mock('@wordpress/data', () => {
+	const mockDispatch = {
+		__unstableMarkNextChangeAsNotPersistent: jest.fn(),
+		updateBlockAttributes: jest.fn(),
+	};
+
+	return {
+		dispatch: jest.fn(() => mockDispatch),
+		select: jest.fn(() => ({
+			getBlockAttributes: jest.fn(),
+		})),
+	};
+});
+
+describe('relations/reducer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return default state', () => {
+		const state = reducer(undefined, { type: 'UNKNOWN_ACTION' });
+		expect(state).toEqual({ relations: {} });
+	});
+
+	describe('ADD_RELATION', () => {
+		it('should add a new relation', () => {
+			const initialState = { relations: {} };
+			const triggerBlock = {
+				clientId: 'trigger-client-id',
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				clientId: 'target-client-id',
+				uniqueID: 'target-unique-id',
+			};
+
+			const action = {
+				type: 'ADD_RELATION',
+				triggerBlock,
+				targetBlock,
+			};
+
+			const newState = reducer(initialState, action);
+
+			expect(newState).toEqual({
+				relations: {
+					'trigger-unique-id': {
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			});
+		});
+
+		it('should add a relation to existing relations', () => {
+			const initialState = {
+				relations: {
+					'trigger-unique-id': {
+						'existing-target-id': 'existing-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			};
+
+			const triggerBlock = {
+				clientId: 'trigger-client-id',
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				clientId: 'target-client-id',
+				uniqueID: 'target-unique-id',
+			};
+
+			const action = {
+				type: 'ADD_RELATION',
+				triggerBlock,
+				targetBlock,
+			};
+
+			const newState = reducer(initialState, action);
+
+			expect(newState).toEqual({
+				relations: {
+					'trigger-unique-id': {
+						'existing-target-id': 'existing-client-id',
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			});
+		});
+	});
+
+	describe('REMOVE_RELATION', () => {
+		it('should remove a specific relation', () => {
+			const initialState = {
+				relations: {
+					'trigger-unique-id': {
+						'target-unique-id': 'target-client-id',
+						'other-target-id': 'other-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			};
+
+			const triggerBlock = {
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				uniqueID: 'target-unique-id',
+			};
+
+			const action = {
+				type: 'REMOVE_RELATION',
+				triggerBlock,
+				targetBlock,
+			};
+
+			const newState = reducer(initialState, action);
+
+			expect(newState).toEqual({
+				relations: {
+					'trigger-unique-id': {
+						'other-target-id': 'other-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			});
+		});
+
+		it('should remove the entire trigger block when only clientId remains', () => {
+			const initialState = {
+				relations: {
+					'trigger-unique-id': {
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			};
+
+			const triggerBlock = {
+				uniqueID: 'trigger-unique-id',
+			};
+			const targetBlock = {
+				uniqueID: 'target-unique-id',
+			};
+
+			const action = {
+				type: 'REMOVE_RELATION',
+				triggerBlock,
+				targetBlock,
+			};
+
+			const newState = reducer(initialState, action);
+
+			expect(newState).toEqual({
+				relations: {},
+			});
+		});
+	});
+
+	describe('REMOVE_BLOCK_RELATION', () => {
+		it('should remove all relations for a block uniqueID', () => {
+			const initialState = {
+				relations: {
+					'unique-id-to-remove': {
+						'other-id': 'other-client-id',
+						clientId: 'client-id-to-remove',
+					},
+					'other-trigger': {
+						'unique-id-to-remove': 'client-id-to-remove',
+						clientId: 'other-trigger-client',
+					},
+				},
+			};
+
+			const action = {
+				type: 'REMOVE_BLOCK_RELATION',
+				uniqueID: 'unique-id-to-remove',
+			};
+
+			// Mock select to return block attributes with relations
+			select.mockImplementation(() => ({
+				getBlockAttributes: jest.fn().mockReturnValue({
+					relations: [
+						{ uniqueID: 'unique-id-to-remove' },
+						{ uniqueID: 'other-id' },
+					],
+				}),
+			}));
+
+			const newState = reducer(initialState, action);
+
+			// Verify the dispatch was called to update block attributes
+			expect(dispatch).toHaveBeenCalledWith('core/block-editor');
+			expect(dispatch().updateBlockAttributes).toHaveBeenCalledWith(
+				'other-trigger-client',
+				{
+					relations: [{ uniqueID: 'other-id' }],
+				}
+			);
+
+			// Verify state was updated correctly
+			expect(newState).toEqual({
+				relations: {},
+			});
+		});
+
+		it('should handle case where no relations exist', () => {
+			const initialState = {
+				relations: {},
+			};
+
+			const action = {
+				type: 'REMOVE_BLOCK_RELATION',
+				uniqueID: 'non-existent-id',
+			};
+
+			const newState = reducer(initialState, action);
+			expect(newState).toEqual({ relations: {} });
+		});
+	});
+
+	describe('UPDATE_RELATION', () => {
+		it('should update relations when block uniqueID changes', () => {
+			const initialState = {
+				relations: {
+					'old-unique-id': {
+						'target-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+					'other-trigger': {
+						'old-unique-id': 'trigger-client-id',
+						clientId: 'other-client-id',
+					},
+				},
+			};
+
+			const action = {
+				type: 'UPDATE_RELATION',
+				prevUniqueID: 'old-unique-id',
+				uniqueID: 'new-unique-id',
+			};
+
+			// Mock select to return block attributes with relations
+			select.mockImplementation(() => ({
+				getBlockAttributes: jest.fn().mockReturnValue({
+					relations: [
+						{ uniqueID: 'old-unique-id' },
+						{ uniqueID: 'some-other-id' },
+					],
+				}),
+			}));
+
+			const newState = reducer(initialState, action);
+
+			// Verify the dispatch was called to update block attributes
+			expect(dispatch).toHaveBeenCalledWith('core/block-editor');
+			expect(dispatch().updateBlockAttributes).toHaveBeenCalledWith(
+				'other-client-id',
+				{
+					relations: [
+						{ uniqueID: 'new-unique-id' },
+						{ uniqueID: 'some-other-id' },
+					],
+				}
+			);
+
+			// Verify state was updated correctly
+			expect(newState).toEqual({
+				relations: {
+					'new-unique-id': {
+						'target-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+					'other-trigger': {
+						'new-unique-id': 'trigger-client-id',
+						clientId: 'other-client-id',
+					},
+				},
+			});
+		});
+
+		it('should handle case where the old uniqueID does not exist', () => {
+			const initialState = {
+				relations: {
+					'existing-id': {
+						'target-id': 'target-client-id',
+						clientId: 'existing-client-id',
+					},
+				},
+			};
+
+			const action = {
+				type: 'UPDATE_RELATION',
+				prevUniqueID: 'non-existent-id',
+				uniqueID: 'new-unique-id',
+			};
+
+			const newState = reducer(initialState, action);
+
+			// State should remain unchanged except for potential relations updates
+			expect(newState).toEqual({
+				relations: {
+					'existing-id': {
+						'target-id': 'target-client-id',
+						clientId: 'existing-client-id',
+					},
+				},
+			});
+		});
+	});
+});

--- a/src/extensions/relations/store/test/selectors.js
+++ b/src/extensions/relations/store/test/selectors.js
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+import selectors from '@extensions/relations/store/selectors';
+
+describe('relations/selectors', () => {
+	describe('receiveRelations', () => {
+		it('should return relations from state', () => {
+			const state = {
+				relations: {
+					'trigger-unique-id': {
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-client-id',
+					},
+				},
+			};
+
+			const result = selectors.receiveRelations(state);
+
+			expect(result).toEqual({
+				'trigger-unique-id': {
+					'target-unique-id': 'target-client-id',
+					clientId: 'trigger-client-id',
+				},
+			});
+		});
+
+		it('should return false if state is not provided', () => {
+			const result = selectors.receiveRelations(null);
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('receiveBlockUnderRelationClientIDs', () => {
+		it('should return blocks that have relations with the provided uniqueID', () => {
+			const state = {
+				relations: {
+					'trigger-1': {
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-1-client-id',
+					},
+					'trigger-2': {
+						'target-unique-id': 'target-client-id',
+						clientId: 'trigger-2-client-id',
+					},
+					'trigger-3': {
+						'other-target': 'other-client-id',
+						clientId: 'trigger-3-client-id',
+					},
+				},
+			};
+
+			const result = selectors.receiveBlockUnderRelationClientIDs(
+				state,
+				'target-unique-id'
+			);
+
+			expect(result).toEqual([
+				{
+					uniqueID: 'trigger-1',
+					clientId: 'trigger-1-client-id',
+				},
+				{
+					uniqueID: 'trigger-2',
+					clientId: 'trigger-2-client-id',
+				},
+			]);
+		});
+
+		it('should return empty array if no blocks have relations with the provided uniqueID', () => {
+			const state = {
+				relations: {
+					'trigger-1': {
+						'target-1': 'target-1-client-id',
+						clientId: 'trigger-1-client-id',
+					},
+				},
+			};
+
+			const result = selectors.receiveBlockUnderRelationClientIDs(
+				state,
+				'non-existent-id'
+			);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should return false if state is not provided', () => {
+			const result = selectors.receiveBlockUnderRelationClientIDs(
+				null,
+				'target-id'
+			);
+			expect(result).toBe(false);
+		});
+
+		it('should return false if relations does not exist in state', () => {
+			const state = {};
+			const result = selectors.receiveBlockUnderRelationClientIDs(
+				state,
+				'target-id'
+			);
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
# Description

Added tests for relations redux store, and dynamic content and dynamic content store.
Refactored integration options loading, moved it from constants file to the DC store. Also added a small fix for woocommerce price rendering (prices <$1 were rendering incorrectly).

# How Has This Been Tested?
Checked that `src/extensions/relations/store` is above 80% and for DC `src/extensions/DC/` and its store `src/extensions/DC/store` added only tests that made sense, so it's below 80% but most functions should be tested.

Also since I've refactored the integration options loading, checked that ACF and woocommerce work in DC when enabled on site.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Code Testing_**

-   [ ] Check the results of `npm run test:coverage`
-   [ ] Check that ACF and WooCommerce are displayed in DC on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dynamic content integration options now update automatically based on active plugins, supporting ACF and WooCommerce.
  - Improved timezone consistency for unit tests by enforcing UTC globally.
  - Enhanced dynamic content store with new selectors and actions for integration plugins and option lists.

- **Bug Fixes**
  - Price formatting for WooCommerce content is now consistent across different price string lengths.

- **Documentation**
  - Added comprehensive JSDoc comments and extensive new test suites for dynamic content utilities, reducers, actions, and selectors.

- **Refactor**
  - Replaced static constants with dynamic selectors for retrieving source and type options.
  - Simplified and modularized initialization of option arrays for data sources and types.

- **Tests**
  - Introduced thorough unit tests for dynamic content logic, WooCommerce content, date processing, relations management, and store utilities.

- **Chores**
  - Updated Jest configuration with improved global setup, environment consistency, and targeted coverage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->