### PR TITLE
Issue 4922 - fix the validation interfering with user typing by debouncing it

### DIFF
--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -206,7 +206,13 @@ const AdvancedNumberControl = props => {
 					onChangeValue(val);
 				}
 			},
-			[onChangeValue, optionType]
+			// onChangeValue is intentionally omitted from dependencies to prevent
+			// useDebounce from cancelling the function execution
+			// due to onChangeValue changing on every render.
+			// TODO: Fix the components that use ANC to provide a stable onChangeValue reference
+			// (i.e. wrap in useCallback or declare it outside of the component)
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			[optionType]
 		),
 		300
 	);


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #4922 

# How Has This Been Tested?
Checked that I can type 33 in map marker size input. Checked that validation still works, tried typing really fast, really slow, the validation should happen only 300ms after you stopped typing, so you can type 1000000 and it will validate only after you stop. The styles shouldn't be changing before validation.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Test the component in normal state in sidebar
-   [ ] Should work in all number inputs with min/max value, so check not only map marker
-   [ ] Let me know if validation applying with delay after you typed feels weird

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved input handling for number controls to provide more consistent and responsive updates when changing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->