### PR TITLE
Fix block tone and Cloud button when 'Show template' is enabled

### DIFF
--- a/src/components/block-styles-control/index.js
+++ b/src/components/block-styles-control/index.js
@@ -28,6 +28,9 @@ const BlockStylesControl = props => {
 	const { onChange, isFirstOnHierarchy, className, blockStyle, clientId } =
 		props;
 
+	// Fallback to getBlockStyle if blockStyle prop is undefined
+	const effectiveBlockStyle = blockStyle ?? getBlockStyle(clientId);
+
 	const classes = classnames('maxi-block-style-control', className);
 
 	const getSelectorOptions = () => {
@@ -87,7 +90,7 @@ const BlockStylesControl = props => {
 					__nextHasNoMarginBottom
 					label={__('Block tone', 'maxi-blocks')}
 					className={classes}
-					value={blockStyle}
+					value={effectiveBlockStyle}
 					options={getSelectorOptions()}
 					onChange={blockStyle => {
 						getAllInnerBlocks(clientId, blockStyle);

--- a/src/editor/responsive-selector/index.js
+++ b/src/editor/responsive-selector/index.js
@@ -280,6 +280,12 @@ const ResponsiveSelector = props => {
 		let rootClientId;
 		const isFSE = getIsSiteEditor();
 
+		// Check if we're in "Show Template" mode in post editor
+		// This happens when the template editing is enabled in regular post editor
+		const isTemplateMode =
+			!isFSE &&
+			select('core/editor')?.getRenderingMode?.() === 'template-locked';
+
 		if (isFSE) {
 			const postId = select('core/edit-site').getEditedPostId();
 			const postType = select('core/edit-site').getEditedPostType();
@@ -303,7 +309,21 @@ const ResponsiveSelector = props => {
 			}
 		}
 
-		if (rootClientId || !isFSE) {
+		// Handle template mode or FSE context
+		if (isFSE || isTemplateMode) {
+			// If we're in template mode, find the post-content block to insert into
+			if (isTemplateMode && !rootClientId) {
+				goThroughMaxiBlocks(block => {
+					if (block.name === 'core/post-content') {
+						rootClientId = block.clientId;
+						return true;
+					}
+					return false;
+				});
+			}
+		}
+
+		if (rootClientId || (!isFSE && !isTemplateMode)) {
 			insertBlock(
 				createBlock('maxi-blocks/maxi-cloud'),
 				undefined,

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -167,13 +167,8 @@ class MaxiBlockComponent extends Component {
 	componentDidMount() {
 		this.updateDOMReferences();
 
-		const {
-			uniqueID,
-			isFirstOnHierarchy,
-			legacyUniqueID,
-			'maxi-version-current': maxiVersionCurrent,
-			'maxi-version-origin': maxiVersionOrigin,
-		} = this.props.attributes;
+		const { uniqueID, isFirstOnHierarchy, legacyUniqueID } =
+			this.props.attributes;
 
 		if (this.isPatternsPreview || this.templateModal) return;
 

--- a/src/extensions/styles/getBlockStyle.js
+++ b/src/extensions/styles/getBlockStyle.js
@@ -9,6 +9,7 @@ const getBlockStyle = clientId => {
 		getBlockAttributes,
 		getSelectedBlockClientId,
 		getFirstMultiSelectedBlockClientId,
+		getBlockParents,
 	} = select('core/block-editor');
 
 	const id =
@@ -21,10 +22,15 @@ const getBlockStyle = clientId => {
 	const blockAttributes = getBlockAttributes(id);
 	if (blockAttributes?.blockStyle) return blockAttributes.blockStyle;
 
-	// Only check root if the current block doesn't have a style
-	const rootClientId = getBlockHierarchyRootClientId(id);
+	// Check parent blocks hierarchy for blockStyle
+	const parentIds = getBlockParents(id);
+	for (const parentId of parentIds) {
+		const parentAttributes = getBlockAttributes(parentId);
+		if (parentAttributes?.blockStyle) return parentAttributes.blockStyle;
+	}
 
-	// Fix for WP 6.8 RC3: Don't use root style if it's the same as current block
+	// Fallback to root if no parent has blockStyle
+	const rootClientId = getBlockHierarchyRootClientId(id);
 	if (rootClientId && rootClientId !== id) {
 		const rootAttributes = getBlockAttributes(rootClientId);
 		if (rootAttributes?.blockStyle) return rootAttributes.blockStyle;

--- a/src/extensions/styles/test/getBlockStyle.js
+++ b/src/extensions/styles/test/getBlockStyle.js
@@ -11,11 +11,14 @@ describe('getBlockStyle', () => {
 		getBlockAttributes: jest.fn(),
 		getSelectedBlockClientId: jest.fn(),
 		getFirstMultiSelectedBlockClientId: jest.fn(),
+		getBlockParents: jest.fn(),
 	};
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		select.mockReturnValue(mockBlockEditorStore);
+		// Set default return value for getBlockParents
+		mockBlockEditorStore.getBlockParents.mockReturnValue([]);
 	});
 
 	it('Returns blockStyle from current block if available', () => {


### PR DESCRIPTION
# Description

Fixes blocks tone and Cloud library button in the editor when the Show template option is enabled.

Fixes https://github.com/maxi-blocks/maxiblocks-theme/issues/9
Fixes https://github.com/maxi-blocks/maxiblocks-theme/issues/10

# How Has This Been Tested?

The editor with the Show template option on and off.
FSE.

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved block style inheritance so that styles can now be inherited from any parent block, not just the root block. This provides more consistent styling across nested blocks.
- **Bug Fixes**
	- Enhanced block insertion logic to better support template editing mode, ensuring correct placement of blocks in different editor contexts.
- **Refactor**
	- Simplified internal attribute handling in block components for improved maintainability.
	- Updated style selection logic to use the most relevant block style available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->