### PR TITLE
Fix wrong breakpoint styles on reusable block edit view

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -1350,11 +1350,18 @@ class MaxiBlockComponent extends Component {
 
 	addMaxiClassesToIframe(iframeDocument, editorWrapper, currentBreakpoint) {
 		iframeDocument.body.classList.add('maxi-blocks--active');
+		iframeDocument.documentElement.style.scrollbarWidth = 'none';
+		const tabletPreview = editorWrapper.querySelector('.is-tablet-preview');
+		const mobilePreview = editorWrapper.querySelector('.is-mobile-preview');
+
+		if (!tabletPreview && !mobilePreview) {
+			return;
+		}
+
 		editorWrapper.setAttribute(
 			'maxi-blocks-responsive',
 			currentBreakpoint === 's' ? 's' : 'xs'
 		);
-		iframeDocument.documentElement.style.scrollbarWidth = 'none';
 	}
 
 	copyFontsToIframe(iframeDocument, iframe) {
@@ -1643,8 +1650,14 @@ class MaxiBlockComponent extends Component {
 	// Add this new method to handle responsive class updates
 	updateResponsiveClasses(iframe, currentBreakpoint) {
 		const target = iframe?.contentDocument?.body || document.body;
-		const editorWrapper = target.querySelector('.editor-styles-wrapper');
+		const tabletPreview = target.querySelector('.is-tablet-preview');
+		const mobilePreview = target.querySelector('.is-mobile-preview');
 
+		if (!tabletPreview && !mobilePreview) {
+			return;
+		}
+
+		const editorWrapper = target.querySelector('.editor-styles-wrapper');
 		if (editorWrapper) {
 			editorWrapper.setAttribute(
 				'maxi-blocks-responsive',

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -1354,10 +1354,7 @@ class MaxiBlockComponent extends Component {
 			return;
 		}
 
-		editorWrapper.setAttribute(
-			'maxi-blocks-responsive',
-			currentBreakpoint === 's' ? 's' : 'xs'
-		);
+		editorWrapper.setAttribute('maxi-blocks-responsive', currentBreakpoint);
 	}
 
 	copyFontsToIframe(iframeDocument, iframe) {
@@ -1643,20 +1640,16 @@ class MaxiBlockComponent extends Component {
 		}
 	}
 
-	// Add this new method to handle responsive class updates
 	updateResponsiveClasses(iframe, currentBreakpoint) {
 		const target = iframe?.contentDocument?.body || document.body;
-		const { isPreview } = this.getPreviewElements(target);
 
-		if (!isPreview) {
-			return;
-		}
-
-		const editorWrapper = target.querySelector('.editor-styles-wrapper');
+		const editorWrapper = target.classList.contains('editor-styles-wrapper')
+			? target
+			: target.querySelector('.editor-styles-wrapper');
 		if (editorWrapper) {
 			editorWrapper.setAttribute(
 				'maxi-blocks-responsive',
-				currentBreakpoint === 's' ? 's' : 'xs'
+				currentBreakpoint
 			);
 		}
 	}

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -671,7 +671,9 @@ class MaxiBlockComponent extends Component {
 		}
 	}
 
-	handleResponsivePreview(editorWrapper, tabletPreview, mobilePreview) {
+	handleResponsivePreview(editorWrapper) {
+		const { tabletPreview, mobilePreview } =
+			this.getPreviewElements(editorWrapper);
 		const previewTarget = tabletPreview ?? mobilePreview;
 		const postEditor = document?.body?.querySelector(
 			'.edit-post-visual-editor'
@@ -690,15 +692,11 @@ class MaxiBlockComponent extends Component {
 	handleIframeStyles(iframe, currentBreakpoint) {
 		const iframeDocument = iframe.contentDocument;
 		const editorWrapper = iframeDocument.body;
-		const tabletPreview = editorWrapper.querySelector('.is-tablet-preview');
-		const mobilePreview = editorWrapper.querySelector('.is-mobile-preview');
+		const { tabletPreview, mobilePreview } =
+			this.getPreviewElements(editorWrapper);
 
 		if (tabletPreview || mobilePreview) {
-			this.handleResponsivePreview(
-				editorWrapper,
-				tabletPreview,
-				mobilePreview
-			);
+			this.handleResponsivePreview(editorWrapper);
 		}
 
 		if (editorWrapper) {
@@ -1351,8 +1349,8 @@ class MaxiBlockComponent extends Component {
 	addMaxiClassesToIframe(iframeDocument, editorWrapper, currentBreakpoint) {
 		iframeDocument.body.classList.add('maxi-blocks--active');
 		iframeDocument.documentElement.style.scrollbarWidth = 'none';
-		const tabletPreview = editorWrapper.querySelector('.is-tablet-preview');
-		const mobilePreview = editorWrapper.querySelector('.is-mobile-preview');
+		const { tabletPreview, mobilePreview } =
+			this.getPreviewElements(editorWrapper);
 
 		if (!tabletPreview && !mobilePreview) {
 			return;
@@ -1650,8 +1648,8 @@ class MaxiBlockComponent extends Component {
 	// Add this new method to handle responsive class updates
 	updateResponsiveClasses(iframe, currentBreakpoint) {
 		const target = iframe?.contentDocument?.body || document.body;
-		const tabletPreview = target.querySelector('.is-tablet-preview');
-		const mobilePreview = target.querySelector('.is-mobile-preview');
+		const { tabletPreview, mobilePreview } =
+			this.getPreviewElements(target);
 
 		if (!tabletPreview && !mobilePreview) {
 			return;
@@ -1712,6 +1710,13 @@ class MaxiBlockComponent extends Component {
 
 			this.lastCacheCleanup = now;
 		}
+	}
+
+	// Returns responsive preview elements if present
+	getPreviewElements(parentElement) {
+		const tabletPreview = parentElement.querySelector('.is-tablet-preview');
+		const mobilePreview = parentElement.querySelector('.is-mobile-preview');
+		return { tabletPreview, mobilePreview };
 	}
 
 	// Add new method for FSE iframe styles

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -692,10 +692,9 @@ class MaxiBlockComponent extends Component {
 	handleIframeStyles(iframe, currentBreakpoint) {
 		const iframeDocument = iframe.contentDocument;
 		const editorWrapper = iframeDocument.body;
-		const { tabletPreview, mobilePreview } =
-			this.getPreviewElements(editorWrapper);
+		const { isPreview } = this.getPreviewElements(editorWrapper);
 
-		if (tabletPreview || mobilePreview) {
+		if (isPreview) {
 			this.handleResponsivePreview(editorWrapper);
 		}
 
@@ -1349,10 +1348,9 @@ class MaxiBlockComponent extends Component {
 	addMaxiClassesToIframe(iframeDocument, editorWrapper, currentBreakpoint) {
 		iframeDocument.body.classList.add('maxi-blocks--active');
 		iframeDocument.documentElement.style.scrollbarWidth = 'none';
-		const { tabletPreview, mobilePreview } =
-			this.getPreviewElements(editorWrapper);
+		const { isPreview } = this.getPreviewElements(editorWrapper);
 
-		if (!tabletPreview && !mobilePreview) {
+		if (!isPreview) {
 			return;
 		}
 
@@ -1648,10 +1646,9 @@ class MaxiBlockComponent extends Component {
 	// Add this new method to handle responsive class updates
 	updateResponsiveClasses(iframe, currentBreakpoint) {
 		const target = iframe?.contentDocument?.body || document.body;
-		const { tabletPreview, mobilePreview } =
-			this.getPreviewElements(target);
+		const { isPreview } = this.getPreviewElements(target);
 
-		if (!tabletPreview && !mobilePreview) {
+		if (!isPreview) {
 			return;
 		}
 
@@ -1716,7 +1713,11 @@ class MaxiBlockComponent extends Component {
 	getPreviewElements(parentElement) {
 		const tabletPreview = parentElement.querySelector('.is-tablet-preview');
 		const mobilePreview = parentElement.querySelector('.is-mobile-preview');
-		return { tabletPreview, mobilePreview };
+		return {
+			tabletPreview,
+			mobilePreview,
+			isPreview: !!tabletPreview || !!mobilePreview,
+		};
 	}
 
 	// Add new method for FSE iframe styles


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5982 

# How Has This Been Tested?
Pasted the pattern and clicked on "edit original" button (WordPress 6.8.1)
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved responsive behavior for tablet and mobile previews, ensuring the interface updates appropriately based on the selected device preview.
  * Enhanced handling of responsive classes for better visual consistency during breakpoint changes.

* **Bug Fixes**
  * Prevented unnecessary updates to responsive attributes when not in tablet or mobile preview, resulting in a more stable editing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->