### PR TITLE
Fix responsive switching in template parts

### DIFF
--- a/src/components/responsive-tabs-control/index.js
+++ b/src/components/responsive-tabs-control/index.js
@@ -9,6 +9,7 @@ import { cloneElement } from '@wordpress/element';
  */
 import SettingTabsControl from '@components/setting-tabs-control';
 import { setScreenSize } from '@extensions/styles';
+import { getIsTemplatePart } from '@extensions/fse';
 
 /**
  * External dependencies
@@ -64,6 +65,14 @@ const ResponsiveTabsControl = props => {
 		return baseBreakpoint === customBreakpoint.toLowerCase();
 	};
 
+	const changeResponsive = breakpoint => {
+		if (disableCallback) return;
+
+		if (baseBreakpoint === breakpoint.toLowerCase() && !getIsTemplatePart())
+			setScreenSize('general');
+		else setScreenSize(breakpoint.toLowerCase());
+	};
+
 	return (
 		<SettingTabsControl
 			className={classes}
@@ -80,12 +89,7 @@ const ResponsiveTabsControl = props => {
 						}),
 					// content: children,
 					showNotification: showNotification(breakpoint),
-					callback: () =>
-						!disableCallback
-							? baseBreakpoint === breakpoint.toLowerCase()
-								? setScreenSize('general')
-								: setScreenSize(breakpoint.toLowerCase())
-							: null,
+					callback: () => changeResponsive(breakpoint),
 					breakpoint: breakpoint.toLowerCase(),
 				};
 			})}


### PR DESCRIPTION
# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes #5887 

# How Has This Been Tested?
Checked that changing responsive to general doesn't change it to wrong breakpoint.
<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_Front/Back Testing_**

-   [ ] Test for template parts
-   [ ] Check that works for regular editor
-   [ ] Check that the settings work on frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal logic for handling breakpoint changes in the responsive tabs control, resulting in more consistent behavior when switching between breakpoints. No changes to the visible interface or functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->