### PR TITLE
SVG copy and paste

### DIFF
--- a/src/blocks/list-item-maxi/data.js
+++ b/src/blocks/list-item-maxi/data.js
@@ -13,10 +13,7 @@ import {
 	getAlignmentTextStyles,
 	getTypographyStyles,
 } from '@extensions/styles/helpers';
-import {
-	getCanvasSettings,
-	getAdvancedSettings,
-} from '@extensions/relations';
+import { getCanvasSettings, getAdvancedSettings } from '@extensions/relations';
 import transitionDefault from '@extensions/styles/transitions/transitionDefault';
 
 /**

--- a/src/blocks/svg-icon-maxi/data.js
+++ b/src/blocks/svg-icon-maxi/data.js
@@ -16,10 +16,7 @@ import {
 	getBorderStyles,
 	getSVGStyles,
 } from '@extensions/styles/helpers';
-import {
-	getCanvasSettings,
-	getAdvancedSettings,
-} from '@extensions/relations';
+import { getCanvasSettings, getAdvancedSettings } from '@extensions/relations';
 import transitionDefault from '@extensions/styles/transitions/transitionDefault';
 
 /**
@@ -51,7 +48,7 @@ const copyPasteMapping = {
 			group: {
 				'Icon hover status': 'svg-status-hover',
 				'Fill colour': { props: 'svg-fill', isPalette: true },
-				'Line colour': { label: 'svg-line', isPalette: true },
+				'Line colour': { props: 'svg-line', isPalette: true },
 				'Fill hover colour': {
 					props: 'svg-fill',
 					isPalette: true,

--- a/src/blocks/text-maxi/data.js
+++ b/src/blocks/text-maxi/data.js
@@ -13,10 +13,7 @@ import {
 	getAlignmentTextStyles,
 	getTypographyStyles,
 } from '@extensions/styles/helpers';
-import {
-	getCanvasSettings,
-	getAdvancedSettings,
-} from '@extensions/relations';
+import { getCanvasSettings, getAdvancedSettings } from '@extensions/relations';
 import transitionDefault from '@extensions/styles/transitions/transitionDefault';
 
 /**


### PR DESCRIPTION
Fixes SVG copy and paste styles - the stroke colour was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Icon block: “Line colour” control now correctly recognized and applied in settings, improving consistency when editing or copying/pasting icon styles.
- Style
  - Standardized import formatting across multiple blocks for improved readability (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->