### PR TITLE
Issue 6049: Template parts or Reuseble blocks rendering bug

### DIFF
--- a/src/extensions/DC/withMaxiContextLoop.js
+++ b/src/extensions/DC/withMaxiContextLoop.js
@@ -20,7 +20,10 @@ import LoopContext from './loopContext';
 import getDCOptions from './getDCOptions';
 import getCLAttributes from './getCLAttributes';
 import { getAttributesWithoutPrefix } from './utils';
-import { isInSiteEditorPreviewIframe } from '@extensions/fse';
+import {
+	isInSiteEditorPreviewIframe,
+	getIsSiteEditor,
+} from '@extensions/fse';
 
 /**
  * External dependencies
@@ -41,6 +44,12 @@ export const ALLOWED_ACCUMULATOR_GRANDPARENT_GRANDCHILD_MAP = {
 	'maxi-blocks/column-maxi': 'maxi-blocks/column-maxi',
 	'maxi-blocks/group-maxi': 'maxi-blocks/column-maxi',
 };
+
+export const CONTAINER_BLOCKS = [
+	'maxi-blocks/container-maxi',
+	'maxi-blocks/accordion-maxi',
+	'maxi-blocks/group-maxi',
+];
 
 const withMaxiContextLoop = createHigherOrderComponent(
 	WrappedComponent =>
@@ -69,16 +78,13 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				[attributes]
 			);
 
-			// Skip Provider for container blocks without Context Loop enabled
-			const containerBlocks = [
-				'maxi-blocks/container-maxi',
-				'maxi-blocks/accordion-maxi',
-				'maxi-blocks/group-maxi',
-			];
+			// Skip Provider for container blocks without Context Loop enabled (FSE only)
+			// Check cheap conditions first, then only check FSE if needed
 			if (
-				!contextLoopAttributes['cl-status'] &&
 				attributes.isFirstOnHierarchy &&
-				containerBlocks.includes(name)
+				!contextLoopAttributes['cl-status'] &&
+				CONTAINER_BLOCKS.includes(name) &&
+				getIsSiteEditor()
 			) {
 				return <WrappedComponent {...ownProps} />;
 			}

--- a/src/extensions/DC/withMaxiContextLoop.js
+++ b/src/extensions/DC/withMaxiContextLoop.js
@@ -69,6 +69,20 @@ const withMaxiContextLoop = createHigherOrderComponent(
 				[attributes]
 			);
 
+			// Skip Provider for container blocks without Context Loop enabled
+			const containerBlocks = [
+				'maxi-blocks/container-maxi',
+				'maxi-blocks/accordion-maxi',
+				'maxi-blocks/group-maxi',
+			];
+			if (
+				!contextLoopAttributes['cl-status'] &&
+				attributes.isFirstOnHierarchy &&
+				containerBlocks.includes(name)
+			) {
+				return <WrappedComponent {...ownProps} />;
+			}
+
 			const getIsAccumulator = attributes =>
 				orderRelations.includes(attributes?.['cl-relation']) ||
 				attributes?.['cl-relation']?.includes('custom-taxonomy') ||


### PR DESCRIPTION
# Description

Fixes re-render for Containers and other blocks in FSE.

Fixes #6049 

# Tests

Please test not only the blocks / parts / reusables setting in FSE, but also CL in parts, etc. 

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced render overhead for specific container block types in the Site Editor by bypassing an intermediate context provider when those blocks are top-level and context looping is disabled, preserving existing behavior for other blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->