### PR TITLE
Ensure Unsplash tab sets media frame state

### DIFF
--- a/core/admin/class-maxi-unsplash.php
+++ b/core/admin/class-maxi-unsplash.php
@@ -1,0 +1,526 @@
+<?php
+/**
+ * MaxiBlocks Unsplash Integration
+ */
+
+if (!defined('ABSPATH')) {
+    exit();
+}
+
+if (!class_exists('MaxiBlocks_Unsplash')):
+    class MaxiBlocks_Unsplash
+    {
+        /**
+         * Unsplash API access key provided by MaxiBlocks.
+         */
+        const ACCESS_KEY = 'jx4CnjSPw5mEuFJrCryY_WNQxPjefnGjQbsyXmdY';
+
+        /**
+         * Unsplash API secret key (not currently used, stored for completeness).
+         */
+        const SECRET_KEY = '4KEnhyCGdS07d96PB1LSOYvnhKm0o6l1E-He-NUwdaA';
+
+        /**
+         * Nonce action for AJAX requests.
+         */
+        const NONCE_ACTION = 'maxi_unsplash_nonce';
+
+        /**
+         * API base URL.
+         */
+        const API_BASE = 'https://api.unsplash.com';
+
+        /**
+         * Track whether media assets have been enqueued.
+         *
+         * @var bool
+         */
+        private static $assets_enqueued = false;
+
+        /**
+         * Track whether templates were printed.
+         *
+         * @var bool
+         */
+        private static $templates_printed = false;
+
+        /**
+         * Register class hooks.
+         */
+        public static function register()
+        {
+            $instance = new self();
+            $instance->init_hooks();
+        }
+
+        /**
+         * Attach WordPress hooks.
+         */
+        public function init_hooks()
+        {
+            add_action('admin_enqueue_scripts', [$this, 'maybe_enqueue_admin_assets']);
+            add_action('enqueue_block_editor_assets', [$this, 'enqueue_block_editor_assets']);
+            add_action('print_media_templates', [$this, 'print_media_templates']);
+            add_action('wp_ajax_maxi_unsplash_search', [$this, 'handle_search']);
+            add_action('wp_ajax_maxi_unsplash_import', [$this, 'handle_import']);
+        }
+
+        /**
+         * Determine if the integration should load on an admin page.
+         */
+        private function should_enqueue_on_admin($hook)
+        {
+            $supported_hooks = [
+                'upload.php',
+                'media-new.php',
+                'post.php',
+                'post-new.php',
+                'site-editor.php',
+                'widgets.php',
+                'customize.php',
+            ];
+
+            return in_array($hook, $supported_hooks, true);
+        }
+
+        /**
+         * Conditionally enqueue media assets for classic admin screens.
+         */
+        public function maybe_enqueue_admin_assets($hook)
+        {
+            if (!$this->should_enqueue_on_admin($hook)) {
+                return;
+            }
+
+            $this->enqueue_assets();
+        }
+
+        /**
+         * Ensure assets are available within the block editor.
+         */
+        public function enqueue_block_editor_assets()
+        {
+            $this->enqueue_assets();
+        }
+
+        /**
+         * Shared asset loader.
+         */
+        private function enqueue_assets()
+        {
+            if (self::$assets_enqueued) {
+                return;
+            }
+
+            self::$assets_enqueued = true;
+
+            if (function_exists('wp_enqueue_media')) {
+                wp_enqueue_media();
+            }
+
+            wp_enqueue_style(
+                'maxi-unsplash-admin',
+                plugin_dir_url(__FILE__) . 'maxi-unsplash.css',
+                [],
+                MAXI_PLUGIN_VERSION
+            );
+
+            wp_enqueue_script(
+                'maxi-unsplash-admin',
+                plugin_dir_url(__FILE__) . 'maxi-unsplash.js',
+                ['jquery', 'media-views', 'wp-backbone', 'wp-i18n'],
+                MAXI_PLUGIN_VERSION,
+                true
+            );
+
+            $strings = [
+                'tabTitle' => __('Unsplash', 'maxi-blocks'),
+                'searchLabel' => __('Search Unsplash', 'maxi-blocks'),
+                'searchPlaceholder' => __('Search Unsplash…', 'maxi-blocks'),
+                'searchButton' => __('Search', 'maxi-blocks'),
+                'emptyQuery' => __('Enter a search term to find Unsplash images.', 'maxi-blocks'),
+                'importing' => __('Importing image…', 'maxi-blocks'),
+                'importSuccess' => __('Image imported to the Media Library.', 'maxi-blocks'),
+                'importError' => __('Unable to import the selected image.', 'maxi-blocks'),
+                'importLabel' => __('Import', 'maxi-blocks'),
+                'loadMore' => __('Load more', 'maxi-blocks'),
+                'noResults' => __('No images found. Try a different search term.', 'maxi-blocks'),
+                'errorGeneral' => __('Unexpected error. Please try again.', 'maxi-blocks'),
+                'viewOnUnsplash' => __('View on Unsplash', 'maxi-blocks'),
+            ];
+
+            wp_localize_script(
+                'maxi-unsplash-admin',
+                'MaxiUnsplash',
+                [
+                    'ajaxUrl' => admin_url('admin-ajax.php'),
+                    'nonce' => wp_create_nonce(self::NONCE_ACTION),
+                    'perPage' => 18,
+                    'strings' => $strings,
+                ]
+            );
+        }
+
+        /**
+         * Output Backbone templates used within the media modal.
+         */
+        public function print_media_templates()
+        {
+            if (!self::$assets_enqueued || self::$templates_printed) {
+                return;
+            }
+
+            self::$templates_printed = true;
+
+            ?>
+            <script type="text/html" id="tmpl-maxi-unsplash-browser">
+                <div class="maxi-unsplash-browser" role="presentation">
+                    <form class="maxi-unsplash-search-form" autocomplete="off">
+                        <label class="screen-reader-text" for="maxi-unsplash-query">{{ data.strings.searchLabel }}</label>
+                        <input
+                            type="search"
+                            id="maxi-unsplash-query"
+                            class="maxi-unsplash-search-field"
+                            placeholder="{{ data.strings.searchPlaceholder }}"
+                            aria-label="{{ data.strings.searchLabel }}"
+                        />
+                        <button type="submit" class="button button-primary maxi-unsplash-search-button">
+                            {{ data.strings.searchButton }}
+                        </button>
+                    </form>
+                    <div class="maxi-unsplash-feedback" aria-live="polite"></div>
+                    <div class="maxi-unsplash-results" aria-live="polite"></div>
+                    <div class="maxi-unsplash-pagination">
+                        <button type="button" class="button maxi-unsplash-load-more" hidden>
+                            {{ data.strings.loadMore }}
+                        </button>
+                    </div>
+                </div>
+            </script>
+            <script type="text/html" id="tmpl-maxi-unsplash-card">
+                <div class="maxi-unsplash-card" data-photo-id="{{ data.id }}">
+                    <div class="maxi-unsplash-card-image">
+                        <img src="{{ data.thumb }}" alt="{{ data.alt }}" loading="lazy" />
+                    </div>
+                    <div class="maxi-unsplash-card-body">
+                        <strong>{{ data.title }}</strong>
+                        <# if ( data.credit ) { #>
+                        <div class="maxi-unsplash-card-meta">{{ data.credit }}</div>
+                        <# } #>
+                        <div class="maxi-unsplash-card-actions">
+                            <button type="button" class="button button-secondary maxi-unsplash-import" data-photo-id="{{ data.id }}">
+                                {{ data.strings.importLabel }}
+                            </button>
+                            <# if ( data.link ) { #>
+                            <a class="maxi-unsplash-card-link" href="{{ data.link }}" target="_blank" rel="noopener noreferrer">
+                                {{ data.strings.viewOnUnsplash }}
+                            </a>
+                            <# } #>
+                        </div>
+                    </div>
+                </div>
+            </script>
+            <?php
+        }
+
+        /**
+         * Retrieve the Unsplash access key with filtering support.
+         */
+        private function get_access_key()
+        {
+            $key = apply_filters('maxi_unsplash_access_key', self::ACCESS_KEY);
+
+            return trim((string) $key);
+        }
+
+        /**
+         * Handle Unsplash search requests.
+         */
+        public function handle_search()
+        {
+            check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+            if (!current_user_can('upload_files')) {
+                wp_send_json_error([
+                    'message' => __('You do not have permission to search Unsplash images.', 'maxi-blocks'),
+                ], 403);
+            }
+
+            $access_key = $this->get_access_key();
+
+            if ('' === $access_key) {
+                wp_send_json_error([
+                    'message' => __('Unsplash access key is missing.', 'maxi-blocks'),
+                ], 400);
+            }
+
+            $query = isset($_POST['query']) ? sanitize_text_field(wp_unslash($_POST['query'])) : '';
+            $page = isset($_POST['page']) ? absint($_POST['page']) : 1;
+            $page = max(1, $page);
+            $per_page = isset($_POST['per_page']) ? absint($_POST['per_page']) : 18;
+            $per_page = max(1, min(30, $per_page));
+
+            $args = [
+                'page' => $page,
+                'per_page' => $per_page,
+            ];
+
+            if ('' === $query) {
+                $endpoint = self::API_BASE . '/photos';
+                $args['order_by'] = 'popular';
+            } else {
+                $endpoint = self::API_BASE . '/search/photos';
+                $args['query'] = $query;
+            }
+
+            $request_url = add_query_arg($args, $endpoint);
+
+            $response = wp_remote_get(
+                $request_url,
+                [
+                    'headers' => [
+                        'Authorization' => 'Client-ID ' . $access_key,
+                        'Accept-Version' => 'v1',
+                    ],
+                    'timeout' => 20,
+                ]
+            );
+
+            if (is_wp_error($response)) {
+                wp_send_json_error([
+                    'message' => $response->get_error_message(),
+                ], 500);
+            }
+
+            $status = wp_remote_retrieve_response_code($response);
+            $body = wp_remote_retrieve_body($response);
+            $data = json_decode($body, true);
+
+            if ($status >= 400 || null === $data) {
+                wp_send_json_error([
+                    'message' => __('Unsplash returned an unexpected response.', 'maxi-blocks'),
+                ], 500);
+            }
+
+            $items = [];
+            $raw_results = [];
+            $total = 0;
+            $total_pages = 0;
+
+            if ('' === $query) {
+                $raw_results = is_array($data) ? $data : [];
+                $total = absint(wp_remote_retrieve_header($response, 'x-total'));
+                $results_count = count($raw_results);
+                if ($total > 0 && $per_page > 0) {
+                    $total_pages = (int) ceil($total / $per_page);
+                } elseif ($results_count === $per_page) {
+                    $total_pages = $page + 1;
+                } else {
+                    $total_pages = $page;
+                }
+            } else {
+                $raw_results = !empty($data['results']) && is_array($data['results']) ? $data['results'] : [];
+                $total = isset($data['total']) ? absint($data['total']) : 0;
+                $total_pages = isset($data['total_pages']) ? absint($data['total_pages']) : 0;
+            }
+
+            foreach ($raw_results as $item) {
+                $items[] = $this->format_photo_result($item);
+            }
+
+            wp_send_json_success([
+                'results' => $items,
+                'total' => $total,
+                'totalPages' => $total_pages,
+                'page' => $page,
+            ]);
+        }
+
+        /**
+         * Normalize Unsplash photo data for the client.
+         */
+        private function format_photo_result($item)
+        {
+            $id = isset($item['id']) ? sanitize_text_field($item['id']) : '';
+            $description = isset($item['description']) ? wp_strip_all_tags($item['description']) : '';
+            $alt = isset($item['alt_description']) ? wp_strip_all_tags($item['alt_description']) : '';
+            $title = $description ? $description : $alt;
+            $title = $title ? $title : __('Unsplash Image', 'maxi-blocks');
+
+            $user_name = isset($item['user']['name']) ? sanitize_text_field($item['user']['name']) : '';
+            $user_username = isset($item['user']['username']) ? sanitize_text_field($item['user']['username']) : '';
+            $credit = '';
+
+            if ($user_name) {
+                $credit = $user_name;
+            } elseif ($user_username) {
+                $credit = '@' . $user_username;
+            }
+
+            $profile_link = isset($item['user']['links']['html']) ? esc_url_raw($item['user']['links']['html']) : '';
+            $photo_link = isset($item['links']['html']) ? esc_url_raw($item['links']['html']) : '';
+
+            return [
+                'id' => $id,
+                'title' => $title,
+                'alt' => $alt,
+                'description' => $description,
+                'thumb' => isset($item['urls']['small']) ? esc_url_raw($item['urls']['small']) : '',
+                'regular' => isset($item['urls']['regular']) ? esc_url_raw($item['urls']['regular']) : '',
+                'full' => isset($item['urls']['full']) ? esc_url_raw($item['urls']['full']) : '',
+                'credit' => $credit,
+                'profile' => $profile_link,
+                'link' => $photo_link,
+                'username' => $user_username,
+            ];
+        }
+
+        /**
+         * Handle image import requests.
+         */
+        public function handle_import()
+        {
+            check_ajax_referer(self::NONCE_ACTION, 'nonce');
+
+            if (!current_user_can('upload_files')) {
+                wp_send_json_error([
+                    'message' => __('You do not have permission to import images.', 'maxi-blocks'),
+                ], 403);
+            }
+
+            $access_key = $this->get_access_key();
+
+            if ('' === $access_key) {
+                wp_send_json_error([
+                    'message' => __('Unsplash access key is missing.', 'maxi-blocks'),
+                ], 400);
+            }
+
+            $photo_id = isset($_POST['photoId']) ? sanitize_text_field(wp_unslash($_POST['photoId'])) : '';
+
+            if ('' === $photo_id) {
+                wp_send_json_error([
+                    'message' => __('Invalid image selection.', 'maxi-blocks'),
+                ], 400);
+            }
+
+            $photo_endpoint = sprintf(self::API_BASE . '/photos/%s', rawurlencode($photo_id));
+            $photo_response = wp_remote_get(
+                $photo_endpoint,
+                [
+                    'headers' => [
+                        'Authorization' => 'Client-ID ' . $access_key,
+                        'Accept-Version' => 'v1',
+                    ],
+                    'timeout' => 20,
+                ]
+            );
+
+            if (is_wp_error($photo_response)) {
+                wp_send_json_error([
+                    'message' => $photo_response->get_error_message(),
+                ], 500);
+            }
+
+            $status = wp_remote_retrieve_response_code($photo_response);
+            $body = wp_remote_retrieve_body($photo_response);
+            $photo_data = json_decode($body, true);
+
+            if ($status >= 400 || empty($photo_data['urls'])) {
+                wp_send_json_error([
+                    'message' => __('Unable to retrieve photo details from Unsplash.', 'maxi-blocks'),
+                ], 500);
+            }
+
+            $download_location = isset($photo_data['links']['download_location'])
+                ? esc_url_raw($photo_data['links']['download_location'])
+                : '';
+
+            if ($download_location) {
+                $download_url = add_query_arg('client_id', $access_key, $download_location);
+                wp_remote_get($download_url, ['timeout' => 10]);
+            }
+
+            $image_url = isset($photo_data['urls']['full']) ? $photo_data['urls']['full'] : '';
+            if (empty($image_url) && !empty($photo_data['urls']['regular'])) {
+                $image_url = $photo_data['urls']['regular'];
+            }
+
+            if (empty($image_url)) {
+                wp_send_json_error([
+                    'message' => __('Unsplash did not return a valid image URL.', 'maxi-blocks'),
+                ], 500);
+            }
+
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+            require_once ABSPATH . 'wp-admin/includes/media.php';
+            require_once ABSPATH . 'wp-admin/includes/image.php';
+
+            $tmp = download_url($image_url, 20);
+
+            if (is_wp_error($tmp)) {
+                wp_send_json_error([
+                    'message' => $tmp->get_error_message(),
+                ], 500);
+            }
+
+            $extension = pathinfo(parse_url($image_url, PHP_URL_PATH), PATHINFO_EXTENSION);
+            $extension = $extension ? $extension : 'jpg';
+            $file_name = sanitize_file_name($photo_id . '-unsplash.' . $extension);
+
+            $file_array = [
+                'name' => $file_name,
+                'tmp_name' => $tmp,
+            ];
+
+            $attachment_id = media_handle_sideload($file_array, 0);
+
+            if (is_wp_error($attachment_id)) {
+                @unlink($tmp);
+                wp_send_json_error([
+                    'message' => $attachment_id->get_error_message(),
+                ], 500);
+            }
+
+            $title = !empty($photo_data['description'])
+                ? $photo_data['description']
+                : (!empty($photo_data['alt_description'])
+                    ? $photo_data['alt_description']
+                    : __('Unsplash Image', 'maxi-blocks'));
+
+            wp_update_post([
+                'ID' => $attachment_id,
+                'post_title' => wp_strip_all_tags($title),
+                'post_excerpt' => wp_strip_all_tags($title),
+                'post_content' => '',
+            ]);
+
+            if (!empty($photo_data['alt_description'])) {
+                update_post_meta(
+                    $attachment_id,
+                    '_wp_attachment_image_alt',
+                    wp_strip_all_tags($photo_data['alt_description'])
+                );
+            }
+
+            $credit = [
+                'name' => isset($photo_data['user']['name']) ? sanitize_text_field($photo_data['user']['name']) : '',
+                'username' => isset($photo_data['user']['username']) ? sanitize_text_field($photo_data['user']['username']) : '',
+                'profile' => isset($photo_data['user']['links']['html']) ? esc_url_raw($photo_data['user']['links']['html']) : '',
+                'unsplashUrl' => isset($photo_data['links']['html']) ? esc_url_raw($photo_data['links']['html']) : '',
+            ];
+
+            update_post_meta($attachment_id, '_maxi_unsplash_credit', $credit);
+
+            if (!empty($credit['unsplashUrl'])) {
+                update_post_meta($attachment_id, '_maxi_unsplash_source', $credit['unsplashUrl']);
+            }
+
+            wp_send_json_success([
+                'attachmentId' => $attachment_id,
+                'url' => wp_get_attachment_url($attachment_id),
+                'title' => get_the_title($attachment_id),
+            ]);
+        }
+    }
+endif;

--- a/core/admin/maxi-unsplash.css
+++ b/core/admin/maxi-unsplash.css
@@ -1,0 +1,125 @@
+.maxi-unsplash-browser-wrapper {
+    padding: 16px;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-search-form {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-search-field {
+    flex: 1 1 auto;
+    min-width: 120px;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-search-button {
+    flex: 0 0 auto;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-feedback {
+    min-height: 24px;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-feedback .spinner {
+    margin: 0;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-results {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.maxi-unsplash-card {
+    background: #fff;
+    border: 1px solid #dcdcdc;
+    border-radius: 4px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.maxi-unsplash-card-image {
+    position: relative;
+    padding-bottom: 66%;
+    overflow: hidden;
+    background: #f6f7f7;
+}
+
+.maxi-unsplash-card-image img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.maxi-unsplash-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    flex: 1;
+}
+
+.maxi-unsplash-card-body strong {
+    font-size: 14px;
+    line-height: 1.3;
+}
+
+.maxi-unsplash-card-meta {
+    font-size: 12px;
+    color: #555d66;
+}
+
+.maxi-unsplash-card-actions {
+    margin-top: auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.maxi-unsplash-card-actions .button {
+    margin: 0;
+}
+
+.maxi-unsplash-card-link {
+    font-size: 12px;
+    color: #2271b1;
+    text-decoration: none;
+}
+
+.maxi-unsplash-card-link:hover,
+.maxi-unsplash-card-link:focus {
+    color: #135e96;
+    text-decoration: underline;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-pagination {
+    margin-top: 24px;
+    text-align: center;
+}
+
+.maxi-unsplash-browser-wrapper .maxi-unsplash-load-more[hidden] {
+    display: none;
+}
+
+@media (max-width: 782px) {
+    .maxi-unsplash-browser-wrapper .maxi-unsplash-search-form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .maxi-unsplash-browser-wrapper .maxi-unsplash-search-button {
+        width: 100%;
+    }
+}

--- a/core/admin/maxi-unsplash.js
+++ b/core/admin/maxi-unsplash.js
@@ -1,0 +1,410 @@
+(function ($) {
+    const settings = window.MaxiUnsplash || {};
+    const perPage = parseInt(settings.perPage, 10) || 18;
+    const strings = $.extend(
+        {
+            tabTitle: 'Unsplash',
+            searchLabel: 'Search Unsplash',
+            searchPlaceholder: 'Search Unsplash…',
+            searchButton: 'Search',
+            emptyQuery: 'Enter a search term to find Unsplash images.',
+            importing: 'Importing image…',
+            importSuccess: 'Image imported to the Media Library.',
+            importError: 'Unable to import the selected image.',
+            importLabel: 'Import',
+            loadMore: 'Load more',
+            noResults: 'No images found. Try a different search term.',
+            errorGeneral: 'Unexpected error. Please try again.',
+            viewOnUnsplash: 'View on Unsplash',
+        },
+        settings.strings || {},
+    );
+
+    if (!window.wp || !wp.media || !wp.Backbone) {
+        return;
+    }
+
+    const media = wp.media;
+    const Frame = media.view.MediaFrame.Select;
+    const browserTemplate = wp.template('maxi-unsplash-browser');
+    const cardTemplate = wp.template('maxi-unsplash-card');
+
+    const originalCreateStates = Frame.prototype.createStates;
+    Frame.prototype.createStates = function () {
+        originalCreateStates.apply(this, arguments);
+
+        if (!this.states.get('maxi-unsplash')) {
+            this.states.add(
+                new media.controller.State({
+                    id: 'maxi-unsplash',
+                    menu: 'default',
+                    title: strings.tabTitle,
+                    content: 'maxi-unsplash',
+                    toolbar: 'maxi-unsplash',
+                    router: 'browse',
+                    priority: 120,
+                }),
+            );
+        }
+    };
+
+    const originalBrowseRouter = Frame.prototype.browseRouter;
+    Frame.prototype.browseRouter = function (routerView) {
+        originalBrowseRouter.apply(this, arguments);
+
+        if (!routerView.get('maxi-unsplash')) {
+            const frame = this;
+
+            routerView.set({
+                'maxi-unsplash': {
+                    text: strings.tabTitle,
+                    priority: 80,
+                    click() {
+                        frame.setState('maxi-unsplash');
+                    },
+                },
+            });
+        }
+    };
+
+    const PostFrame = media.view.MediaFrame.Post;
+
+    if (PostFrame) {
+        const originalPostBrowseRouter = PostFrame.prototype.browseRouter;
+        PostFrame.prototype.browseRouter = function (routerView) {
+            originalPostBrowseRouter.apply(this, arguments);
+
+            if (!routerView.get('maxi-unsplash')) {
+                const frame = this;
+
+                routerView.set({
+                    'maxi-unsplash': {
+                        text: strings.tabTitle,
+                        priority: 80,
+                        click() {
+                            frame.setState('maxi-unsplash');
+                        },
+                    },
+                });
+            }
+        };
+    }
+
+    const originalBindHandlers = Frame.prototype.bindHandlers;
+    Frame.prototype.bindHandlers = function () {
+        originalBindHandlers.apply(this, arguments);
+
+        this.on('content:render:maxi-unsplash', this.renderMaxiUnsplash, this);
+        this.on('toolbar:create:maxi-unsplash', this.createMaxiUnsplashToolbar, this);
+    };
+
+    Frame.prototype.renderMaxiUnsplash = function (contentRegion) {
+        if (!this.maxiUnsplashView) {
+            this.maxiUnsplashView = new MaxiUnsplashBrowser({
+                controller: this,
+                strings,
+                perPage,
+                settings,
+            });
+        }
+
+        contentRegion.view = this.maxiUnsplashView;
+    };
+
+    Frame.prototype.createMaxiUnsplashToolbar = function (toolbarRegion) {
+        toolbarRegion.view = new media.view.Toolbar({
+            controller: this,
+        });
+    };
+
+    const MaxiUnsplashBrowser = wp.Backbone.View.extend({
+        className: 'maxi-unsplash-browser-wrapper',
+
+        template: browserTemplate,
+
+        events: {
+            'submit .maxi-unsplash-search-form': 'onSearchSubmit',
+            'click .maxi-unsplash-load-more': 'onLoadMore',
+            'click .maxi-unsplash-import': 'onImportClick',
+        },
+
+        initialize(options) {
+            this.controller = options.controller;
+            this.strings = options.strings;
+            this.perPage = options.perPage;
+            this.settings = options.settings;
+            this.query = '';
+            this.page = 1;
+            this.totalPages = 0;
+            this.isLoading = false;
+            this.hasLoadedInitial = false;
+        },
+
+        render() {
+            this.$el.html(this.template({ strings: this.strings }));
+            this.$form = this.$('.maxi-unsplash-search-form');
+            this.$input = this.$('#maxi-unsplash-query');
+            this.$feedback = this.$('.maxi-unsplash-feedback');
+            this.$results = this.$('.maxi-unsplash-results');
+            this.$loadMore = this.$('.maxi-unsplash-load-more');
+
+            if (!this.hasLoadedInitial) {
+                this.hasLoadedInitial = true;
+                this.fetchResults();
+            }
+
+            return this;
+        },
+
+        onSearchSubmit(event) {
+            event.preventDefault();
+            const value = this.$input.val() ? this.$input.val().trim() : '';
+
+            this.query = value;
+            this.page = 1;
+            this.totalPages = 0;
+            this.$results.empty();
+
+            this.fetchResults();
+        },
+
+        onLoadMore(event) {
+            event.preventDefault();
+
+            if (this.isLoading) {
+                return;
+            }
+
+            if (this.page >= this.totalPages && this.totalPages !== 0) {
+                return;
+            }
+
+            this.page += 1;
+            if (this.$loadMore && this.$loadMore.length) {
+                this.$loadMore.prop('disabled', true);
+            }
+            this.fetchResults(true);
+        },
+
+        onImportClick(event) {
+            event.preventDefault();
+
+            const button = $(event.currentTarget);
+            const photoId = button.data('photo-id');
+
+            if (!photoId || button.hasClass('is-importing')) {
+                return;
+            }
+
+            button.addClass('is-importing');
+            button.prop('disabled', true);
+            button.text(this.strings.importing);
+
+            $.ajax({
+                url: this.settings.ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'maxi_unsplash_import',
+                    nonce: this.settings.nonce,
+                    photoId,
+                },
+            })
+                .done((response) => {
+                    if (response && response.success && response.data) {
+                        button.addClass('is-imported');
+                        button.removeClass('button-secondary').addClass('button-primary');
+                        button.text(this.strings.importSuccess);
+                        this.setFeedback(this.strings.importSuccess);
+                        this.focusAttachment(response.data.attachmentId);
+                    } else {
+                        this.handleImportError(button, response && response.data ? response.data.message : '');
+                    }
+                })
+                .fail((jqXHR) => {
+                    const message =
+                        jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data
+                            ? jqXHR.responseJSON.data.message
+                            : '';
+                    this.handleImportError(button, message);
+                })
+                .always(() => {
+                    setTimeout(() => {
+                        button.removeClass('is-importing');
+                        if (!button.hasClass('is-imported')) {
+                            button.prop('disabled', false);
+                            button.text(this.strings.importLabel);
+                        }
+                    }, 2000);
+                });
+        },
+
+        handleImportError(button, message) {
+            button.prop('disabled', false);
+            button.removeClass('is-importing');
+            button.text(this.strings.importError);
+            this.setFeedback(message || this.strings.importError);
+        },
+
+        fetchResults(append) {
+            if (this.isLoading) {
+                return;
+            }
+
+            this.isLoading = true;
+
+            if (!append) {
+                this.toggleSpinner(true);
+                this.setFeedback('');
+            }
+
+            $.ajax({
+                url: this.settings.ajaxUrl,
+                method: 'POST',
+                dataType: 'json',
+                data: {
+                    action: 'maxi_unsplash_search',
+                    nonce: this.settings.nonce,
+                    query: this.query,
+                    page: this.page,
+                    per_page: this.perPage,
+                },
+            })
+                .done((response) => {
+                    if (!response || !response.success || !response.data) {
+                        this.handleSearchError(response && response.data ? response.data.message : '');
+                        return;
+                    }
+
+                    const items = response.data.results || [];
+                    this.totalPages = response.data.totalPages || 0;
+
+                    this.renderResults(items, append);
+
+                    if (items.length === 0 && !append) {
+                        this.setFeedback(this.strings.noResults);
+                    }
+
+                    if (this.$loadMore.length) {
+                        if (this.totalPages && this.page < this.totalPages) {
+                            this.$loadMore.prop('hidden', false);
+                        } else if (!this.totalPages && items.length >= this.perPage) {
+                            this.$loadMore.prop('hidden', false);
+                        } else {
+                            this.$loadMore.prop('hidden', true);
+                        }
+                    }
+                })
+                .fail((jqXHR) => {
+                    const message =
+                        jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data
+                            ? jqXHR.responseJSON.data.message
+                            : '';
+                    this.handleSearchError(message);
+                })
+                .always(() => {
+                    this.isLoading = false;
+                    this.toggleSpinner(false);
+                    if (this.$loadMore && this.$loadMore.length) {
+                        this.$loadMore.prop('disabled', false);
+                    }
+                });
+        },
+
+        renderResults(items, append) {
+            if (!this.$results || !this.$results.length) {
+                return;
+            }
+
+            if (!items.length) {
+                if (!append) {
+                    this.$results.empty();
+                }
+                return;
+            }
+
+            const fragments = document.createDocumentFragment();
+
+            items.forEach((item) => {
+                const data = {
+                    id: item.id,
+                    title: item.title || '',
+                    alt: item.alt || '',
+                    thumb: item.thumb || item.regular || item.full || '',
+                    credit: item.credit || '',
+                    link: item.link || '',
+                    strings: this.strings,
+                };
+
+                const html = cardTemplate(data);
+                const wrapper = document.createElement('div');
+                wrapper.innerHTML = html;
+                const card = wrapper.firstElementChild;
+                if (card) {
+                    fragments.appendChild(card);
+                }
+            });
+
+            const container = this.$results[0];
+
+            if (!container) {
+                return;
+            }
+
+            if (append) {
+                container.appendChild(fragments);
+            } else {
+                this.$results.empty();
+                container.appendChild(fragments);
+            }
+        },
+
+        handleSearchError(message) {
+            this.setFeedback(message || this.strings.errorGeneral);
+            if (this.$loadMore.length) {
+                this.$loadMore.prop('hidden', true);
+            }
+        },
+
+        setFeedback(message) {
+            if (!this.$feedback) {
+                return;
+            }
+
+            this.$feedback.text(message || '');
+        },
+
+        toggleSpinner(isLoading) {
+            if (!this.$feedback) {
+                return;
+            }
+
+            if (isLoading) {
+                const spinner = $('<span />', {
+                    class: 'spinner is-active',
+                    'aria-hidden': 'true',
+                });
+                this.$feedback.empty().append(spinner);
+            } else if (this.$feedback.find('.spinner').length) {
+                this.$feedback.empty();
+            }
+        },
+
+        focusAttachment(attachmentId) {
+            if (!attachmentId || !wp.media || !wp.media.attachment) {
+                return;
+            }
+
+            const attachment = wp.media.attachment(attachmentId);
+            const frame = this.controller;
+            const libraryState = frame.states.get('library');
+
+            if (libraryState && libraryState.get('selection')) {
+                libraryState.get('selection').reset([attachment]);
+            }
+
+            frame.setState('library');
+            attachment.fetch();
+        },
+    });
+})(jQuery);

--- a/plugin.php
+++ b/plugin.php
@@ -349,6 +349,14 @@ if (class_exists('MaxiBlocks_Dashboard')) {
 }
 
 //======================================================================
+// MaxiBlocks Unsplash Integration
+//======================================================================
+require_once MAXI_PLUGIN_DIR_PATH . 'core/admin/class-maxi-unsplash.php';
+if (class_exists('MaxiBlocks_Unsplash')) {
+    MaxiBlocks_Unsplash::register();
+}
+
+//======================================================================
 // MaxiBlocks Dynamic Content
 //======================================================================
 require_once MAXI_PLUGIN_DIR_PATH . 'core/class-maxi-dynamic-content.php';


### PR DESCRIPTION
## Summary
- ensure the Unsplash media tab registers a click handler so selecting it switches the frame to the custom state
- mirror the router registration for MediaFrame.Post instances used by the editor so the Unsplash tab works consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185aa6ef488321aab98c2d4d63d334)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Unsplash image browser into the WordPress media modal for direct access to free stock photos
  * Search for images with intuitive search functionality and load-more pagination
  * One-click import adds images to the media library with automatic attribution and metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->