### PR TITLE
Replace MarginControl and PaddingControl with SpacingControl

### DIFF
--- a/src/blocks/button-maxi/data.js
+++ b/src/blocks/button-maxi/data.js
@@ -21,8 +21,7 @@ import BorderControl from '@components/border-control';
 import BoxShadowControl from '@components/box-shadow-control';
 import IconControl from '@components/icon-control';
 import InfoBox from '@components/info-box';
-import MarginControl from '@components/margin-control';
-import PaddingControl from '@components/padding-control';
+import SpacingControl from '@components/spacing-control';
 import TypographyControl from '@components/typography-control';
 
 import {
@@ -364,8 +363,7 @@ const interactionBuilderSettings = {
 			prefix: 'button-',
 			component: props => (
 				<>
-					<MarginControl {...props} />
-					<PaddingControl {...props} />
+					<SpacingControl {...props} />
 				</>
 			),
 			helper: props => getMarginPaddingStyles(props),

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -76,6 +76,8 @@ export { default as SelectControl } from './select-control';
 export { default as SettingTabsControl } from './setting-tabs-control';
 export { default as ShapeDivider } from './shape-divider';
 export { default as Spinner } from './spinner';
+export { default as SpacingControl } from './spacing-control';
+export { default as SpacingField } from './spacing-field';
 export { default as SvgColor } from './svg-color';
 export { default as SVGFillControl } from './svg-fill-control';
 export { default as SvgStrokeWidthControl } from './svg-stroke-width-control';

--- a/src/components/inspector-tabs/inspector-margin-padding.js
+++ b/src/components/inspector-tabs/inspector-margin-padding.js
@@ -6,12 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import MarginControl from '@components/margin-control';
-import PaddingControl from '@components/padding-control';
-import {
-	getGroupAttributes,
-	getLastBreakpointAttribute,
-} from '@extensions/styles';
+import SpacingControl from '@components/spacing-control';
+import { getGroupAttributes, getLastBreakpointAttribute } from '@extensions/styles';
 
 /**
  * Component
@@ -34,30 +30,18 @@ const marginPadding = ({
 		label: customLabel ?? __('Margin / Padding', 'maxi-blocks'),
 		content: (
 			<>
-				{!disableMargin && (
-					<MarginControl
-						{...getGroupAttributes(
-							attributes,
-							'margin',
-							false,
-							prefix
-						)}
-						prefix={prefix}
-						onChange={obj => maxiSetAttributes(obj)}
-						breakpoint={deviceType}
-						fullWidth={fullWidth}
-					/>
-				)}
-				<PaddingControl
+				<SpacingControl
 					{...getGroupAttributes(
 						attributes,
-						'padding',
+						['margin', 'padding'],
 						false,
 						prefix
 					)}
+					attributes={attributes}
 					prefix={prefix}
-					onChange={obj => maxiSetAttributes(obj)}
 					breakpoint={deviceType}
+					onChange={obj => maxiSetAttributes(obj)}
+					disableMargin={disableMargin}
 				/>
 			</>
 		),

--- a/src/components/inspector-tabs/inspector-margin-padding.js
+++ b/src/components/inspector-tabs/inspector-margin-padding.js
@@ -7,7 +7,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import SpacingControl from '@components/spacing-control';
-import { getGroupAttributes, getLastBreakpointAttribute } from '@extensions/styles';
 
 /**
  * Component
@@ -20,23 +19,11 @@ const marginPadding = ({
 }) => {
 	const { attributes, deviceType, maxiSetAttributes } = props;
 
-	const fullWidth = getLastBreakpointAttribute({
-		target: `${prefix}full-width`,
-		breakpoint: deviceType,
-		attributes,
-	});
-
 	return {
 		label: customLabel ?? __('Margin / Padding', 'maxi-blocks'),
 		content: (
 			<>
 				<SpacingControl
-					{...getGroupAttributes(
-						attributes,
-						['margin', 'padding'],
-						false,
-						prefix
-					)}
 					attributes={attributes}
 					prefix={prefix}
 					breakpoint={deviceType}

--- a/src/components/spacing-control/index.js
+++ b/src/components/spacing-control/index.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import BaseControl from '@components/base-control';
+import SpacingField from '@components/spacing-field';
+import { getLastBreakpointAttribute } from '@extensions/styles';
+
+const spacingSides = ['top', 'right', 'bottom', 'left'];
+
+const buildSpacingGroup = (attributes, type, breakpoint, prefix = '') =>
+        spacingSides.reduce((acc, side) => {
+                const baseKey = `${prefix}${type}-${side}`;
+                const value = getLastBreakpointAttribute({
+                        target: baseKey,
+                        breakpoint,
+                        attributes,
+                });
+
+                const unit = getLastBreakpointAttribute({
+                        target: `${baseKey}-unit`,
+                        breakpoint,
+                        attributes,
+                });
+
+                acc[side] = {
+                        value: value ?? '0',
+                        unit: value === 'auto' ? '' : unit || 'px',
+                };
+
+                return acc;
+        }, {});
+
+const SpacingControl = ({
+        attributes = {},
+        breakpoint = 'general',
+        onChange = () => {},
+        prefix = '',
+        disableMargin = false,
+        label,
+}) => {
+        const spacingValue = {
+                ...(disableMargin ? {} : { margin: buildSpacingGroup(attributes, 'margin', breakpoint, prefix) }),
+                padding: buildSpacingGroup(attributes, 'padding', breakpoint, prefix),
+        };
+
+        const handleChange = updated => {
+                const updates = {};
+
+                ['margin', 'padding'].forEach(type => {
+                        if (disableMargin && type === 'margin') return;
+
+                        spacingSides.forEach(side => {
+                                const nextValue = updated?.[type]?.[side];
+                                if (!nextValue) return;
+
+                                const baseKey = `${prefix}${type}-${side}`;
+                                const valueKey = `${baseKey}-${breakpoint}`;
+                                const unitKey = `${baseKey}-unit-${breakpoint}`;
+
+                                updates[valueKey] = nextValue.value ?? '';
+                                updates[unitKey] =
+                                        nextValue.value === 'auto'
+                                                ? ''
+                                                : nextValue.unit || 'px';
+                        });
+                });
+
+                onChange(updates);
+        };
+
+        return (
+                <BaseControl label={label} className='maxi-spacing-control'>
+                        <SpacingField
+                                value={spacingValue}
+                                onChange={handleChange}
+                                disableMargin={disableMargin}
+                                disablePadding={false}
+                        />
+                </BaseControl>
+        );
+};
+
+export default SpacingControl;

--- a/src/components/spacing-field/editor.scss
+++ b/src/components/spacing-field/editor.scss
@@ -1,0 +1,505 @@
+/* =========================================
+   RESPONSIVE TABS WRAPPER
+   ========================================= */
+.maxi-responsive-tabs-control {
+    margin-bottom: 16px;
+    
+    &:has(+ .maxi-spacing-field) {
+        margin-bottom: 8px;
+    }
+}
+
+/* =========================================
+   MAIN INPUT FIELD (ON CANVAS)
+   This is the box you click to open the popover
+   ========================================= */
+.maxi-spacing-field {
+    display: grid;
+    width: 100%;
+    /* Grid Layout: Left Button | gap | Left Input | Center | Right Input | gap | Right Button */
+    grid-template-columns: 36px 4px 36px 1fr 36px 4px 36px;
+    grid-template-rows: 24px 4px 24px 1fr 24px 4px 24px;
+    
+    /* POSITIONING CONTEXT */
+    position: relative; 
+    z-index: 1;
+
+    /* =========================================
+       SECTION A: MARGIN BOX (Outer Blue/Green)
+       ========================================= */
+    &__margin {
+        /* --- Container Styles --- */
+        display: grid;
+        width: 100%;
+        padding: 4px;        
+        height: 190px;
+        grid-area: 1 / 1 / -1 / -1;
+        
+        /* Grid Template for the Margin Box */
+        grid-template-columns: 36px 1fr 36px;
+        grid-template-rows: 24px minmax(16px, 1fr) 24px;
+        grid-template-areas:
+            '. top .'
+            'left . right'
+            '. bottom .';
+            
+        border: 1.5px solid var(--maxi-secondary-color);
+        background: var(--maxi-whisper-green);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+
+        /* FIX 2: Force Margin Text to be Green */
+        color: var(--maxi-primary-color);
+        
+        button, .components-button, .maxi-spacing-popover__trigger {
+            color: var(--maxi-primary-color) !important;
+        }
+
+        /* -------------------------------------- */
+        /* INDIVIDUAL MARGIN CONTROLS          */
+        /* -------------------------------------- */
+
+        /* 3. MARGIN TOP Value */
+        > [style*="grid-area: top"] {
+            align-self: start; 
+            justify-self: center;
+        }
+
+        /* 4. MARGIN RIGHT Value */
+        > [style*="grid-area: right"] {
+             writing-mode: vertical-lr; 
+             transform: rotate(180deg);
+             white-space: nowrap;
+             place-self: center; 
+             max-height: 100%;
+             display: flex;
+             align-items: center;
+             justify-content: center;
+             margin-right: -10px;
+        }
+
+        /* 5. MARGIN BOTTOM Value */
+        > [style*="grid-area: bottom"] {
+            align-self: end;
+            justify-self: center;
+        }
+
+        /* 6. MARGIN LEFT Value */
+        > [style*="grid-area: left"] {
+             writing-mode: vertical-lr; 
+             transform: rotate(180deg);
+             white-space: nowrap;
+             place-self: center; 
+             max-height: 100%;
+             display: flex;
+             align-items: center;
+             justify-content: center;
+             margin-left: -10px;
+        }
+    }
+
+    /* =========================================
+       SECTION B: PADDING BOX (Inner White)
+       ========================================= */
+    &__padding {
+        display: grid;
+        width: 105%;
+        height: 110px;
+        grid-area: 3 / 3 / span 3 / span 3;
+        grid-template-columns: 30px 1fr 30px;
+        grid-template-rows: 22px minmax(16px, 1fr) 22px;
+        grid-template-areas:
+            ". top ."
+            "left . right"
+            ". bottom .";
+        justify-self: center;
+        align-self: center;
+        
+        /* Custom Styling from user request */
+        border: 2px dotted var(--maxi-blue-text);
+        background: var(--maxi-blue-bg);
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+        margin-top: 10px;
+        position: relative; 
+
+        /* FIX: Force Padding Text to be Blue */
+        color: var(--maxi-blue-text); 
+
+        button, .components-button, .maxi-spacing-popover__trigger {
+             color: var(--maxi-blue-text) !important;
+             font-weight: 700;
+        }
+
+        /* -------------------------------------- */
+        /* INDIVIDUAL PADDING CONTROLS         */
+        /* -------------------------------------- */
+
+        /* 3. PADDING TOP Value */
+        > [style*="grid-area: top"] {
+            align-self: start;
+            justify-self: center;
+            margin-top: 3px;
+        }
+
+        /* 4. PADDING RIGHT Value */
+        > [style*="grid-area: right"] {
+             writing-mode: vertical-lr; 
+             transform: rotate(180deg);
+             white-space: nowrap;
+             place-self: center; 
+             max-height: 100%;
+             display: flex;
+             align-items: center;
+             justify-content: center;
+        }
+
+        /* 5. PADDING BOTTOM Value */
+        > [style*="grid-area: bottom"] {
+            align-self: end;
+            justify-self: center;
+        }
+
+        /* 6. PADDING LEFT Value */
+        > [style*="grid-area: left"] {
+             writing-mode: vertical-lr; 
+             transform: rotate(180deg);
+             white-space: nowrap;
+             place-self: center; 
+             max-height: 100%;
+             display: flex;
+             align-items: center;
+             justify-content: center;
+        }
+    }
+
+    /* =========================================
+       SECTION C: SHARED ELEMENTS (Labels & Links)
+       ========================================= */
+       
+    /* --- Labels (Text: "MARGIN", "PADDING") --- */
+    &__label {
+        position: absolute;
+        font-size: 12px;
+        font-weight: 700 !important;
+        color: var(--maxi-primary-color) !important; 
+        z-index: 1;
+        letter-spacing: 0.5px;
+        text-align: left;
+        padding-left: 2px;
+
+        /* Specific Margin Label Position */
+        &--margin {
+            top: 15px;
+            left: 10px;
+        }
+
+        /* Specific Padding Label Position */
+        &--padding {
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%); /* Perfectly centers it */
+            text-align: center;
+            padding: 0;
+            width: 100%;
+            pointer-events: none;    
+            color: var(--maxi-blue-text) !important;
+            font-weight: 700 !important;
+        }
+    }
+
+    /* --- Link Buttons (Chain Icons) --- */
+    &__link-button {
+        position: absolute;
+        z-index: 2;
+        min-width: auto !important;
+        width: 24px; 
+        height: 24px;
+        padding: 0 !important;
+        
+        /* --- NEW BUTTON STYLE --- */
+        background: var(--maxi-white);
+        border: 1px solid var(--maxi-grey-light);
+        border-radius: 4px; 
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        
+        color: var(--maxi-grey-dark);
+        transition: all 0.2s ease;
+
+        svg {
+            width: 14px; 
+            height: 14px;
+        }
+
+        &:hover {
+            color: var(--maxi-primary-color);
+            background: var(--maxi-white);
+            border-color: var(--maxi-grey-light);
+        }
+
+        &.is-linked {
+            color: var(--maxi-primary-color);
+            background: var(--maxi-white);
+            border-color: var(--maxi-grey-light);
+        }
+
+        /* Specific Margin Link Position */
+        &--margin {
+            top: 12px;
+            right: 6px;
+        }
+
+        /* Specific Padding Link Position */
+        &--padding {
+            top: 3px;
+            right: 4px;
+            left: auto;      
+            transform: none; 
+        }
+    }
+}
+
+
+/* =========================================
+   2. POPOVER COMPONENT (THE DROPDOWN)
+   This is the white box that appears when you click
+   ========================================= */
+.maxi-spacing-popover {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* Reset wrapper position */
+    position: static !important; 
+
+    /* The clickable numbers in the main UI that open the popover */
+    &__trigger {
+        background: transparent;
+        color: var(--maxi-grey-dark);
+        font-size: 13px;
+        font-weight: 500;
+        cursor: ns-resize;
+        min-width: 36px;
+        height: 24px;
+        padding: 0;
+        border: none;
+        transition: color 0.2s ease;
+
+        &:hover {
+            color: var(--maxi-primary-color);
+        }
+    }
+
+    /* --- The Main Popover Container --- */
+    &__panel {
+        /* Define fixed width & reset defaults */
+        min-width: 250px;
+        max-width: 250px;
+        padding: 0;
+        border-radius: 8px;
+        
+        /* FIX: Semi-transparent background with blur */
+        background: rgba(255, 255, 255, 0.55) !important;
+        backdrop-filter: blur(5px);
+        
+        border: 1px solid var(--maxi-grey-light);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        color: var(--maxi-grey-dark);
+        
+        /* --- FIX: Position Fixed to Right Sidebar Area --- */
+        position: fixed !important;
+        top: 70% !important; 
+        right: 20px !important;  /* Anchors firmly to the sidebar area */
+        left: auto !important;   /* Prevents it from going to page center */
+        transform: translateY(-50%) !important; /* Vertically Centers it */
+        z-index: 100000 !important;
+        margin: 0 !important;
+        
+        /* Reset bottom */
+        bottom: auto !important;
+        
+        /* --- FIX: Override WP min-content width & Add Spacing --- */
+        .components-popover__content {
+            /* FIX: Remove the default solid white background from WP so the transparent parent shows */
+            background: transparent !important;
+            
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            width: 100% !important; 
+            padding: 16px; 
+            box-sizing: border-box;
+            position: relative; /* Ensure absolute children position relative to this */
+            
+            /* --- CRITICAL: ALLOW CLOSE BUTTON TO SIT OUTSIDE --- */
+            overflow: visible !important; 
+        }
+    }
+
+    /* --- SECTION A: Header (Label + Input Box + Close Button) --- */
+    &__header {
+        display: flex;
+        flex-direction: row; 
+        align-items: flex-start; /* Changed from center to flex-start */
+        justify-content: space-between; 
+        gap: 8px;
+        width: 100%;
+        margin: 0; 
+        padding: 0;
+        border: none;
+    }
+
+    /* "Left", "Right", "Top" Label */
+    &__label {
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+        color: var(--maxi-grey-dark);
+        text-align: left;
+        padding-left: 2px;
+        padding-top: 6px; /* Align with input */
+        flex: 0 0 auto; 
+    }
+
+    /* The Input Box Container (Number + Unit) */
+    &__inputs {
+        display: flex;
+        align-items: center;
+        border: 1px solid var(--maxi-grey-light);
+        border-radius: 4px;
+        background: var(--maxi-white);
+        width: 60%; 
+        margin: 0; 
+        transition: border-color 0.2s ease;
+
+        &:hover, &:focus-within {
+             border-color: var(--maxi-primary-color);
+        }
+    }
+
+    /* The Typed Number Input */
+    &__number {
+        flex: 1;
+        height: 32px;
+        border: 0;
+        padding: 5px 8px;
+        font-size: 14px;
+        color: var(--maxi-grey-dark);
+        border-radius: 4px 0 0 4px;
+        text-align: left;
+        min-width: 0;
+        background: transparent;
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    /* The "PX/Rem" Dropdown */
+    &__unit-select {
+        min-width: 50px;
+        border-left: 1px solid var(--maxi-grey-light);
+
+        .components-base-control__field {
+            margin: 0;
+        }
+
+        select {
+            height: 32px;
+            border: 0;
+            border-radius: 0 4px 4px 0;
+            padding: 5px 4px 5px 8px;
+            font-size: 12px;
+            background: transparent;
+            cursor: pointer;
+            width: 100%;
+            color: var(--maxi-grey-dark);
+
+            &:focus {
+                outline: none;
+            }
+        }
+    }
+
+    /* Close Button with Custom Circle-X Icon */
+    &__close {
+        min-width: auto !important;
+        width: 24px;
+        height: 24px;
+        padding: 0 !important;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        
+        /* --- CHANGED: POSITIONED OUTSIDE --- */
+        position: absolute;
+        top: -10px;    /* Pulls it up outside the box */
+        right: -10px;  /* Pulls it right outside the box */
+        margin: 0;
+        z-index: 10;
+        
+        background: transparent;
+        border: none;
+        transition: transform 0.2s ease;
+        flex-shrink: 0;
+
+        svg {
+            width: 24px;
+            height: 24px;
+            transition: opacity 0.2s ease;
+            /* Add drop shadow so it is visible against white/grey backgrounds */
+            filter: drop-shadow(0 2px 3px rgba(0,0,0,0.15));
+        }
+
+        &:hover {
+            transform: scale(1.1);
+        }
+    }
+
+    /* --- SECTION B: Presets (The Buttons) --- */
+    &__common-values {
+        display: flex;
+        flex-direction: row; 
+        gap: 4px; 
+        width: 100%;
+        margin-top: 0;
+    }
+
+    /* Individual Preset Button */
+    &__common-value {
+        /* DEFAULT STATE (Inactive): White BG, Grey Border (Outlined) */
+        background: var(--maxi-white);
+        color: var(--maxi-grey-dark);
+        border: 1px solid var(--maxi-grey-light);
+        
+        text-align: center;
+        padding: 0;
+        cursor: pointer;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+        transition: all 0.2s ease;
+        
+        /* Layout flex properties */
+        flex: 1; 
+        min-width: 0; 
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        /* HOVER STATE: Tinted Green */
+        &:hover {
+            background: var(--maxi-whisper-green);
+            color: var(--maxi-primary-color);
+            border-color: var(--maxi-primary-color);
+        }
+
+        /* ACTIVE STATE: Tinted Green + Bold (Matches 'Solid' style) */
+        &.is-active {
+            background: var(--maxi-whisper-green);
+            color: var(--maxi-primary-color);
+            border-color: var(--maxi-primary-color);
+            font-weight: 600;
+        }
+    }
+}

--- a/src/components/spacing-field/editor.scss
+++ b/src/components/spacing-field/editor.scss
@@ -32,7 +32,7 @@
         display: grid;
         width: 100%;
         padding: 4px;        
-        height: 190px;
+        height: 175px;
         grid-area: 1 / 1 / -1 / -1;
         
         /* Grid Template for the Margin Box */
@@ -118,7 +118,6 @@
         border: 2px dotted var(--maxi-blue-text);
         background: var(--maxi-blue-bg);
         box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
-        margin-top: 10px;
         position: relative; 
 
         /* FIX: Force Padding Text to be Blue */
@@ -188,7 +187,7 @@
 
         /* Specific Margin Label Position */
         &--margin {
-            top: 15px;
+            top: 8px;
             left: 10px;
         }
 
@@ -245,7 +244,7 @@
 
         /* Specific Margin Link Position */
         &--margin {
-            top: 12px;
+            top: 6px;
             right: 6px;
         }
 

--- a/src/components/spacing-field/index.js
+++ b/src/components/spacing-field/index.js
@@ -1,0 +1,157 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { link, linkOff } from '@wordpress/icons';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import SpacingPopover from './spacing-popover';
+import ResponsiveTabsControl from '@components/responsive-tabs-control';
+
+/**
+ * Styles
+ */
+import './editor.scss';
+
+const SIDES = ['top', 'right', 'bottom', 'left'];
+
+// --- Helpers ---
+
+const normalizeValue = (spacingValue) => ({
+    value: spacingValue?.value ?? '0',
+    unit: spacingValue?.unit ?? 'px',
+});
+
+const buildSpacingGroup = (group) => ({
+    top: normalizeValue(group?.top),
+    right: normalizeValue(group?.right),
+    bottom: normalizeValue(group?.bottom),
+    left: normalizeValue(group?.left),
+});
+
+const areSidesLinked = (group) => {
+    if (!group) return true;
+    const { top, right, bottom, left } = group;
+    // Check if every side matches 'top'
+    return [right, bottom, left].every(side => 
+        side?.value === top?.value && side?.unit === top?.unit
+    );
+};
+
+const SpacingField = ({
+    value = {},
+    onChange = () => {},
+    disableMargin = false,
+    disablePadding = false,
+    breakpoint = 'general',
+    noResponsiveTabs = false,
+}) => {
+    // 1. Memoize value calculation to ensure stability
+    // We use the spread operator logic exactly like your original code 
+    // to ensure we don't pass 'undefined' keys.
+    const nextValue = useMemo(() => ({
+        ...(disableMargin ? {} : { margin: buildSpacingGroup(value?.margin) }),
+        ...(disablePadding ? {} : { padding: buildSpacingGroup(value?.padding) }),
+    }), [value, disableMargin, disablePadding]);
+
+    // 2. Initialize Linked State intelligently
+    // We check the incoming values once on mount.
+    const [marginLinked, setMarginLinked] = useState(() => areSidesLinked(value?.margin));
+    const [paddingLinked, setPaddingLinked] = useState(() => areSidesLinked(value?.padding));
+
+    // 3. Centralized Change Handler
+    const handleUpdate = useCallback((type, side, inputVal) => {
+        const parsedValue = inputVal?.value ?? '';
+        const isAuto = parsedValue === 'auto';
+        const isLinked = type === 'margin' ? marginLinked : paddingLinked;
+        
+        // Get the current group (e.g. nextValue.margin)
+        const currentGroup = nextValue[type];
+
+        let updatedGroup;
+
+        if (isLinked) {
+            // Update all sides
+            updatedGroup = {};
+            SIDES.forEach(s => {
+                updatedGroup[s] = {
+                    value: parsedValue,
+                    unit: isAuto ? '' : inputVal?.unit || 'px',
+                };
+            });
+        } else {
+            // Update single side
+            updatedGroup = {
+                ...currentGroup,
+                [side]: {
+                    value: parsedValue,
+                    unit: isAuto ? '' : inputVal?.unit || 'px',
+                },
+            };
+        }
+
+        // Return the structure exactly as the parent expects
+        onChange({
+            ...nextValue,
+            [type]: updatedGroup,
+        });
+    }, [marginLinked, paddingLinked, nextValue, onChange]);
+
+    // 4. Reusable Render Function (kept internal for safety)
+    const renderControlGroup = (type, isLinked, onToggle) => {
+        // Guard clause: if this group doesn't exist in nextValue (e.g. disabled), don't render
+        if (!nextValue[type]) return null;
+
+        return (
+            <div className={`maxi-spacing-field__${type}`}>
+                <div className={`maxi-spacing-field__label maxi-spacing-field__label--${type}`}>
+                    {type.toUpperCase()}
+                </div>
+                <Button
+                    icon={isLinked ? link : linkOff}
+                    onClick={onToggle}
+                    className={classnames(
+                        'maxi-spacing-field__link-button',
+                        `maxi-spacing-field__link-button--${type}`,
+                        isLinked && 'is-linked'
+                    )}
+                    label={isLinked ? 'Unlink sides' : 'Link sides'}
+                    isSmall
+                />
+                {SIDES.map((side) => (
+                    <SpacingPopover
+                        key={`${type}-${side}`}
+                        spacingValue={nextValue[type][side]}
+                        gridArea={side}
+                        onChange={(val) => handleUpdate(type, side, val)}
+                    />
+                ))}
+            </div>
+        );
+    };
+
+    const controls = (
+        <div className={classnames('maxi-spacing-field', 'relative')}>
+            {!disableMargin && renderControlGroup('margin', marginLinked, () => setMarginLinked(!marginLinked))}
+            {!disablePadding && renderControlGroup('padding', paddingLinked, () => setPaddingLinked(!paddingLinked))}
+        </div>
+    );
+
+    if (noResponsiveTabs) return controls;
+
+    return (
+        <ResponsiveTabsControl breakpoint={breakpoint}>
+            {controls}
+        </ResponsiveTabsControl>
+    );
+};
+
+export default SpacingField;

--- a/src/components/spacing-field/spacing-popover.js
+++ b/src/components/spacing-field/spacing-popover.js
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { Button, Popover, SelectControl } from '@wordpress/components';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+// Custom close icon SVG
+const CloseIcon = () => (
+	<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+		<path fill="var(--maxi-primary-color)" d="M12 2a10 10 0 1010 10A10 10 0 0012 2zm3.21 11.79a1 1 0 010 1.42 1 1 0 01-1.42 0L12 13.41l-1.79 1.8a1 1 0 01-1.42 0 1 1 0 010-1.42l1.8-1.79-1.8-1.79a1 1 0 011.42-1.42l1.79 1.8 1.79-1.8a1 1 0 011.42 1.42L13.41 12z"></path>
+	</svg>
+);
+
+const units = ['px', '%', 'em', 'ch', 'rem', 'vw', 'vh', 'auto'];
+const commonValues = ['auto', '0', '10', '40', '80'];
+
+const SpacingPopover = ({ spacingValue, onChange, gridArea }) => {
+	const buttonRef = useRef();
+	const [isOpen, setIsOpen] = useState(false);
+	const [startVal, setStartVal] = useState(null);
+
+	const handleStart = useCallback(event => {
+		setStartVal(event.clientY);
+	}, []);
+
+	useEffect(() => {
+		const handleUpdate = event => {
+			if (startVal === null) return;
+			const snapshot = Math.trunc((event.clientY - startVal) / 50);
+			const numericValue = parseInt(spacingValue?.value || '0', 10);
+			if (Number.isNaN(numericValue)) return;
+			onChange({
+				...spacingValue,
+				value: (numericValue - snapshot).toString(),
+			});
+		};
+
+		const handleEnd = () => setStartVal(null);
+
+		document.addEventListener('mousemove', handleUpdate);
+		document.addEventListener('mouseup', handleEnd);
+		return () => {
+			document.removeEventListener('mousemove', handleUpdate);
+			document.removeEventListener('mouseup', handleEnd);
+		};
+	}, [startVal, spacingValue, onChange]);
+
+	const currentValue = spacingValue?.value ?? '0';
+	const currentUnit = spacingValue?.unit || (currentValue === 'auto' ? '' : 'px');
+
+	return (
+		<div className='maxi-spacing-popover' style={{ gridArea }}>
+			<Button
+				ref={buttonRef}
+				className='maxi-spacing-popover__trigger'
+				onMouseDown={handleStart}
+				onClick={() => setIsOpen(true)}
+				aria-expanded={isOpen}
+			>
+				{currentValue || '0'}
+				{currentValue !== 'auto' && currentUnit ? currentUnit : ''}
+			</Button>
+			{isOpen && (
+				<Popover
+					anchor={buttonRef.current}
+					placement='bottom'
+					onClose={() => setIsOpen(false)}
+					className='maxi-spacing-popover__panel'
+				>
+					<div className='maxi-spacing-popover__header'>
+						<div className='maxi-spacing-popover__label'>
+							{gridArea.charAt(0).toUpperCase() + gridArea.slice(1)}
+						</div>
+						<div className='maxi-spacing-popover__inputs'>
+							<input
+								type='text'
+								value={currentValue}
+								onChange={event =>
+									onChange({
+										...spacingValue,
+										value: event.target.value,
+									})
+								}
+								className='maxi-spacing-popover__number'
+							/>
+							<SelectControl
+								hideLabelFromVision
+								label='Unit'
+								className='maxi-spacing-popover__unit-select'
+								value={currentUnit}
+								onChange={newUnit =>
+									onChange({
+										...spacingValue,
+										unit: newUnit,
+									})
+								}
+								options={units.map(unit => ({
+									label: unit,
+									value: unit,
+								}))}
+							/>
+						</div>
+						<Button
+							icon={<CloseIcon />}
+							onClick={() => setIsOpen(false)}
+							className='maxi-spacing-popover__close'
+							label='Close'
+							isSmall
+						/>
+					</div>
+					<div className='maxi-spacing-popover__common-values'>
+						{commonValues.map(val => (
+							<Button
+								key={val}
+								onClick={() =>
+									onChange({
+										...spacingValue,
+										value: val,
+									})
+								}
+								className={classnames(
+									'maxi-spacing-popover__common-value',
+									val === currentValue && 'is-active'
+								)}
+							>
+								{val === '0' ? '↻ 0' : val}
+							</Button>
+						))}
+					</div>
+				</Popover>
+			)}
+		</div>
+	);
+};
+
+export default SpacingPopover;

--- a/src/css/backend-variables.scss
+++ b/src/css/backend-variables.scss
@@ -31,6 +31,8 @@
 	--maxi-light-blue-alt: #7fbddc; /* Alternative blue accent */
 	--maxi-highlight-color: #f066ff; /* Vibrant highlight/punctuation */
 	--maxi-light-yellow: #f7f5df; /* Gentle light yellow for accents */
+	--maxi-blue-text:#05c9ff;
+	--maxi-blue-bg:rgba(5,201,255,.1);
 
 	/* New Accent Brand Colors */
 	--maxi-orange-red: #ff4500; /* Vibrant orange-red */

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -20,7 +20,7 @@ import SettingTabsControl from '@components/setting-tabs-control';
 import TypographyControl from '@components/typography-control';
 import ToggleSwitch from '@components/toggle-switch';
 import AdvancedNumberControl from '@components/advanced-number-control';
-import PaddingControl from '@components/padding-control';
+import SpacingControl from '@components/spacing-control';
 import handleDeletedCustomColor from '@extensions/style-cards/customColorsUtils';
 import {
 	processSCAttribute,
@@ -306,15 +306,25 @@ const SCAccordion = props => {
 						/>
 					)
 				)}
-			{ifNavigationTab && (
-				<>
-					<PaddingControl
-						{...processSCAttributes(SC, 'padding', groupAttr)}
-						label={__('Item padding', 'maxi-blocks')}
-						onChange={obj => onChangeValue(obj, groupAttr)}
-						breakpoint={breakpoint}
-						disableAuto
-					/>
+			{ifNavigationTab &&
+				(() => {
+					const paddingAttributes = processSCAttributes(
+						SC,
+						'padding',
+						groupAttr
+					);
+
+					return (
+						<>
+							<SpacingControl
+								attributes={paddingAttributes}
+								label={__('Item padding', 'maxi-blocks')}
+								breakpoint={breakpoint}
+								onChange={obj =>
+									onChangeValue(obj, groupAttr)
+								}
+								disableMargin
+							/>
 					<ToggleSwitch
 						// eslint-disable-next-line @wordpress/i18n-no-collapsible-whitespace
 						label={__(
@@ -406,7 +416,9 @@ const SCAccordion = props => {
 						</>
 					)}
 				</>
-			)}
+					);
+				})()
+			}
 		</>
 	);
 };

--- a/src/extensions/relations/getCanvasSettings.js
+++ b/src/extensions/relations/getCanvasSettings.js
@@ -12,8 +12,7 @@ import {
 	BoxShadowControl,
 	FullSizeControl,
 	InfoBox,
-	MarginControl,
-	PaddingControl,
+	SpacingControl,
 } from '@components';
 import {
 	getBlockBackgroundStyles,
@@ -213,8 +212,7 @@ const getCanvasSettings = ({ name }) => [
 		attrGroupName: ['margin', 'padding'],
 		component: props => (
 			<>
-				<MarginControl {...props} />
-				<PaddingControl {...props} />
+				<SpacingControl {...props} />
 			</>
 		),
 		helper: props => getMarginPaddingStyles(props),


### PR DESCRIPTION
Introduces a unified SpacingControl component to handle both margin and padding settings, replacing separate MarginControl and PaddingControl usage across the codebase. Adds new SpacingField and SpacingPopover components for improved UI/UX, updates relevant imports, and refactors affected files to use the new control. Also includes related style updates and variable additions for consistent design.

# Description

<!---
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
--->

Fixes # (issue)

# How Has This Been Tested?

<!---
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.
--->

# Test checklist

<!--- Please remove the unnecessary checkbox --->

**_ Front/Back Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type

**_ Pre-Code Testing _**

-   [ ] Test the component in normal state in sidebar
-   [ ] Test the component in hover state in sidebar (if hover exists)
-   [ ] Check that the settings work on frontend
-   [ ] Check that backend works and saves the settings after the editor reload
-   [ ] Same 1-4 points for the toolbar
-   [ ] Same 1-4 points on responsive
-   [ ] Test the block inside the grid (Container + Row + Column)
-   [ ] Test the block as a standalone block
-   [ ] Duplicate the block, test that the settings of the first do not affect the second
-   [ ] Test with 2 blocks of the same type
-   [ ] Check no commented code and no unnecessary imports
-   [ ] Standards of the project have been followed
-   [ ] No errors/warnings on console

# Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings/errors
-   [ ] I have added/updated tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified Spacing control with responsive tabs, per-side editing, link/unlink toggle, presets, and drag-to-adjust; new spacing field and popover UI components.

* **Refactor**
  * Replaced separate margin and padding controls with the new Spacing control across inspector panels, style cards, and canvas settings.

* **Style**
  * Added comprehensive spacing-field styles and two new theme CSS variables for blue text/background.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->