### PR TITLE
Remove cache notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ coverage
 # Ignore Claude files
 CLAUDE.md
 
+# Ignore PHP CS Fixer config
+**/.php-cs-fixer.dist.php
+

--- a/core/admin/notices.js
+++ b/core/admin/notices.js
@@ -49,32 +49,5 @@ document.addEventListener('DOMContentLoaded', function () {
 				})
 				.catch(error => console.error('Error:', error));
 		}
-
-		if (
-			event.target.closest('#maxi-plugin-update-notice .notice-dismiss')
-		) {
-			fetch(
-				maxiBlocks.rest_url.replace(
-					'dismiss-notice',
-					'dismiss-plugin-update-notice'
-				),
-				{
-					method: 'POST',
-					headers: {
-						'X-WP-Nonce': maxiBlocks.nonce,
-						'Content-Type': 'application/json',
-					},
-				}
-			)
-				.then(response => {
-					if (response.status === 204) {
-						// Successfully dismissed, hide the notice
-						document.querySelector(
-							'#maxi-plugin-update-notice'
-						).style.display = 'none';
-					}
-				})
-				.catch(error => console.error('Error:', error));
-		}
 	});
 });

--- a/plugin.php
+++ b/plugin.php
@@ -203,63 +203,12 @@ function maxi_blocks_after_update($upgrader_object, $options)
             if ($plugin == plugin_basename(__FILE__)) {
                 // Reset the dismissal option
                 update_option('maxi_blocks_db_notice_dismissed', 'no');
-                update_option('maxi_plugin_update_notice_dismissed', 'no');
                 break;
             }
         }
     }
 }
 add_action('upgrader_process_complete', 'maxi_blocks_after_update', 10, 2);
-
-//======================================================================
-// Clear cache notice after plugin update
-//======================================================================
-
-add_action('admin_init', 'maxi_check_plugin_version_update');
-
-function maxi_check_plugin_version_update()
-{
-    $current_version = MAXI_PLUGIN_VERSION;
-    $stored_version = get_option('maxi_plugin_version', '0');
-
-    if (version_compare($current_version, $stored_version, '!=')) {
-        add_action('admin_notices', 'maxi_plugin_update_notice');
-        update_option('maxi_plugin_update_notice_dismissed', 'no');
-    }
-}
-
-function maxi_plugin_update_notice()
-{
-    if (get_option('maxi_plugin_update_notice_dismissed') === 'yes') {
-        return;
-    }
-
-    echo '<div class="notice notice-warning is-dismissible" id="maxi-plugin-update-notice">';
-    echo '<p>MaxiBlocks plugin has been updated. Please clear your browser and plugin caches to ensure the best performance. <a href="https://maxiblocks.com/go/clearing-caches" target="_blank">Learn more</a></p>';
-    echo '</div>';
-
-    add_action('admin_footer', 'maxi_blocks_enqueue_notice_scripts'); // Reuse the existing function to enqueue scripts
-}
-
-function maxi_blocks_register_plugin_update_notice_route()
-{
-    register_rest_route('maxi-blocks/v1', '/dismiss-plugin-update-notice', [
-        'methods' => 'POST',
-        'callback' => 'maxi_blocks_dismiss_plugin_update_notice',
-        'permission_callback' => function () {
-            return current_user_can('manage_options');
-        },
-    ]);
-}
-add_action('rest_api_init', 'maxi_blocks_register_plugin_update_notice_route');
-
-function maxi_blocks_dismiss_plugin_update_notice()
-{
-    update_option('maxi_plugin_update_notice_dismissed', 'yes');
-    // Update the stored plugin version to the current version to prevent the notice from showing again until the next update
-    update_option('maxi_plugin_version', MAXI_PLUGIN_VERSION);
-    return new WP_REST_Response(null, 204);
-}
 
 //======================================================================
 // Init


### PR DESCRIPTION
# Description

Removes "MaxiBlocks plugin has been updated. Please clear your browser and plugin caches to ensure the best performance" notice.


# How Has This Been Tested?

Change the plugin version in plugin.php to test that it's not showing any more.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the plugin update notification feature that previously displayed in the WordPress admin dashboard, including all associated dismissal mechanisms.

* **Chores**
  * Updated development configuration to ignore code formatting tool outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->