### PR TITLE
Improve z-index handling and responsive tabs in style cards

### DIFF
--- a/src/components/font-family-selector/editor.scss
+++ b/src/components/font-family-selector/editor.scss
@@ -28,6 +28,8 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 	.maxi-font-family-selector__control {
 		&__menu {
+			position: absolute;
+			z-index: 200001;
 			border: 1.5px solid var(--maxi-grey-light);
 			border-radius: 0;
 			box-shadow: none;

--- a/src/components/select-control/editor.scss
+++ b/src/components/select-control/editor.scss
@@ -81,6 +81,7 @@ body.maxi-blocks--active {
 				position: absolute;
 				top: -8px;
 				left: 8px;
+				z-index: 1 !important;
 				font-size: 10px !important;
 				color: var(--maxi-grey-dark);
 				font-style: normal;

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -40,7 +40,7 @@
 				transition: all 0.5s ease;
 
 				&[aria-pressed='true'] {
-					border-bottom: 1.5px solid var(--maxi-black) !important;
+					border-bottom: 1.5px solid var(--maxi-black);
 					background-color: var(--maxi-whisper-green);
 				}
 			}

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -27,7 +27,7 @@
 		padding: 0 5px !important;
 		pointer-events: none !important;
 		box-sizing: border-box !important;
-		z-index: 999 !important;
+		z-index: 1 !important;
 	}
 
 	// Shared flexbox center pattern

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useState, useContext } from '@wordpress/element';
+import { useState, useContext, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -338,6 +338,7 @@ const TypographyControl = props => {
 		isStyleCards = false,
 		disablePalette = false,
 		disableFontFamily = false,
+		disableResponsiveTabs = false,
 		clientId,
 		styleCardPrefix,
 		allowLink = false,
@@ -689,8 +690,11 @@ const TypographyControl = props => {
 		return getIsValid(value, true) ? value : 1;
 	};
 
+	const Wrapper = disableResponsiveTabs ? Fragment : ResponsiveTabsControl;
+	const wrapperProps = disableResponsiveTabs ? {} : { breakpoint };
+
 	return (
-		<ResponsiveTabsControl breakpoint={breakpoint}>
+		<Wrapper {...wrapperProps}>
 			<div className={classes}>
 				{/* When linkOnly is enabled, render only LinkOptions */}
 				{linkOnly && allowLink && (
@@ -1921,7 +1925,7 @@ const TypographyControl = props => {
 					</>
 				)}
 			</div>
-		</ResponsiveTabsControl>
+		</Wrapper>
 	);
 };
 

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -932,3 +932,11 @@ html[dir='rtl'] {
 		}
 	}
 }
+
+// Fix z-index for font-family dropdown menu in style cards
+// React-select can portal menu to body, so we need a global rule
+// Scoped to maxi-blocks context to avoid affecting other libraries
+body.maxi-blocks--active [class*="menu"][class*="css-"],
+.maxi-style-cards__popover [class*="menu"][class*="css-"] {
+	z-index: 999999 !important;
+}

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -913,7 +913,7 @@ html[dir='rtl'] {
 		.maxi-tabs-control__button {
 			flex: 1;
 			min-width: 52px;
-			padding:4px 8px;
+			padding: 4px 8px;
 			border: 1.5px solid var(--maxi-grey-light) !important;
 			border-radius: 5px;
 			background-color: var(--maxi-white);
@@ -958,5 +958,5 @@ html[dir='rtl'] {
 // Scoped to maxi-blocks context to avoid affecting other libraries
 body.maxi-blocks--active [class*="menu"][class*="css-"],
 .maxi-style-cards__popover [class*="menu"][class*="css-"] {
-	z-index: 999999 !important;
+	z-index: 100 !important;
 }

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -1,3 +1,9 @@
+// Fix z-index for font-family dropdown menu in style cards
+// React-select can portal menu to body, so we need a global rule
+[class*="menu"][class*="css-"] {
+	z-index: 999999 !important;
+}
+
 .has-tooltip {
 	.tooltip {
 		display: none;
@@ -713,7 +719,15 @@ body .maxi-style-cards__popover {
 		}
 	}
 	.maxi-font-family-selector {
-		z-index: 1;
+		z-index: 10;
+		position: relative;
+
+		// Ensure the dropdown menu appears above everything
+		.maxi-font-family-selector__control__menu {
+			position: absolute;
+			z-index: 99999 !important;
+			background: var(--maxi-white);
+		}
 	}
 	.components-range-control
 		.components-base-control__field
@@ -867,5 +881,56 @@ html[dir='rtl'] {
 
 	&:hover svg {
 		stroke: var(--maxi-primary-color) !important;
+	}
+}
+.maxi-style-cards-headings-tabs {
+	.maxi-tabs-control {
+		display: flex;
+		gap: 4px;
+		padding: 0;
+		margin-bottom: 8px;
+
+		.maxi-tabs-control__button {
+			flex: 1;
+			min-width: 32px;
+			max-width: 40px;
+			height: 28px;
+			padding: 4px 8px;
+			border: 1.5px solid var(--maxi-grey-light);
+			border-radius: 5px;
+			background-color: var(--maxi-white);
+			color: var(--maxi-grey-dark);
+			font-size: 12px;
+			font-weight: 400;
+			text-align: center;
+			cursor: pointer;
+			transition: all 0.3s ease;
+
+			&:hover {
+				background-color: var(--maxi-whisper-green);
+				border-color: var(--maxi-grey);
+				color: var(--maxi-black);
+			}
+
+			&[aria-pressed='true'] {
+				background-color: var(--maxi-pastel-green);
+				border-color: var(--maxi-primary-color);
+				color: var(--maxi-primary-color);
+				font-weight: 700;
+			}
+		}
+	}
+
+	.maxi-tabs-content {
+		padding: 0;
+		
+		.maxi-tab-content__box {
+			padding: 0;
+			border: none;
+			
+			&:after {
+				display: none;
+			}
+		}
 	}
 }

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -1,7 +1,36 @@
-// Fix z-index for font-family dropdown menu in style cards
-// React-select can portal menu to body, so we need a global rule
-[class*="menu"][class*="css-"] {
-	z-index: 999999 !important;
+// ============================================
+// Variables & Mixins
+// ============================================
+$grey-light: var(--maxi-grey-light);
+$grey-dark: var(--maxi-grey-dark);
+$white: var(--maxi-white);
+$primary: var(--maxi-primary-color);
+$border-style: 1.5px solid $grey-light;
+$radius-pill: 20px;
+$transition-fast: all 0.2s ease;
+$transition: all 0.3s ease;
+
+@mixin flex-center {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+@mixin action-button {
+	@include flex-center;
+	border: $border-style;
+	border-radius: $radius-pill;
+	padding: 8px;
+	color: $grey-dark;
+	transition: $transition;
+}
+
+// Placeholder for shared button styles
+%card-button-base {
+	@include action-button;
+	&:disabled {
+		opacity: 0.3;
+	}
 }
 
 .has-tooltip {
@@ -40,9 +69,7 @@
 	.maxi-responsive-close {
 		position: absolute;
 		right: 10px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
+		@include flex-center;
 		height: 20px !important;
 		width: 20px !important;
 		padding: 0 0 1px !important;
@@ -213,7 +240,6 @@ body .maxi-style-cards__popover {
 					& > div {
 						&:not(.flexbox-fix) {
 							margin-right: 0 !important;
-							//justify-content: end;
 							svg {
 								border-radius: 0 !important;
 							}
@@ -248,19 +274,16 @@ body .maxi-style-cards__popover {
 		margin-bottom: 8px;
 
 		&__box {
-			display: flex;
+			@include flex-center;
 			width: 32px;
 			height: 32px;
 			padding: 0;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $border-style;
 			margin: 0;
 			border-radius: 50% !important;
-			background-color: var(--maxi-white);
+			background-color: $white;
 			cursor: pointer;
-			transition: all 0.2s;
-			align-items: center;
-			justify-content: center;
-			cursor: pointer;
+			transition: $transition-fast;
 
 			&:hover {
 				background: var(--maxi-white);
@@ -286,17 +309,15 @@ body .maxi-style-cards__popover {
 
 		&__box {
 			position: relative;
-			display: flex;
+			@include flex-center;
 			width: 32px;
 			height: 32px;
 			padding: 0;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $border-style;
 			border-radius: 50% !important;
 			background-color: #fff;
 			cursor: pointer;
-			transition: all 0.2s;
-			align-items: center;
-			justify-content: center;
+			transition: $transition-fast;
 
 			&:hover {
 				background: var(--maxi-white);
@@ -350,7 +371,6 @@ body .maxi-style-cards__popover {
 			display: none;
 			align-items: center;
 			justify-content: center;
-			border: none !important;
 			font-size: 20px;
 			font-weight: bold;
 			line-height: 24px;
@@ -414,10 +434,9 @@ body .maxi-style-cards__popover {
 			height: 24px;
 			padding: 0;
 			display: flex;
-			justify-content: center;
+			justify-content: space-around;
 			border-radius: 50%;
 			transition: all 0.3s;
-			justify-content: space-around;
 
 			&:hover:not(:disabled) {
 				background: var(--maxi-white);
@@ -470,17 +489,8 @@ body .maxi-style-cards__popover {
 			position: relative;
 			button:not(.maxi-reset-button):not(.maxi-color-control__palette-box):not(.maxi-style-cards__custom-color-presets__remove-button),
 			a.components-button {
-				&:disabled {
-					opacity: 0.3;
-				}
-				display: flex;
-				align-items: center;
-				justify-content: center;
+				@extend %card-button-base;
 				transition: all 0.5s;
-				border: 1.5px solid var(--maxi-grey-light);
-				border-radius: 20px;
-				padding: 8px;
-				color: var(--maxi-grey-dark);
 				line-height: 90%;
 			}
 		}
@@ -587,9 +597,7 @@ body .maxi-style-cards__popover {
 			}
 		}
 		&__actions {
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 			margin-bottom: 8px;
 			column-gap: 8px;
 
@@ -602,9 +610,7 @@ body .maxi-style-cards__popover {
 			}
 		}
 		&__ie {
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 			margin-bottom: 0;
 			width: calc(35% - 13px);
 
@@ -618,9 +624,7 @@ body .maxi-style-cards__popover {
 			}
 		}
 		&__save {
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 			margin-bottom: 8px;
 
 			button {

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -5,15 +5,46 @@ $grey-light: var(--maxi-grey-light);
 $grey-dark: var(--maxi-grey-dark);
 $white: var(--maxi-white);
 $primary: var(--maxi-primary-color);
-$border-style: 1.5px solid $grey-light;
+$black: var(--maxi-black);
+$border-val: 1.5px;
+$border-style: $border-val solid $grey-light;
 $radius-pill: 20px;
+$radius-sm: 5px;
 $transition-fast: all 0.2s ease;
 $transition: all 0.3s ease;
+$control-spacing: 8px;
+
+// Breakpoint map - single source of truth
+$breakpoints: (
+	'xs': 347px,
+	'sm': 768px,
+	'md': 782px,
+	'xxl': 2500px
+);
 
 @mixin flex-center {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+}
+
+@mixin respond-to($breakpoint) {
+	$width: map-get($breakpoints, $breakpoint);
+	@if $breakpoint == 'xxl' {
+		@media only screen and (min-width: $width) { @content; }
+	} @else {
+		@media only screen and (max-width: $width) { @content; }
+	}
+}
+
+@mixin rtl {
+	html[dir='rtl'] & { @content; }
+}
+
+@mixin control-row {
+	margin-bottom: $control-spacing;
+	display: flex;
+	flex-direction: column;
 }
 
 @mixin action-button {
@@ -25,6 +56,24 @@ $transition: all 0.3s ease;
 	transition: $transition;
 }
 
+// Preset box mixin for color presets
+@mixin preset-box-base {
+	@include flex-center;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	border: $border-style;
+	border-radius: 50% !important;
+	background-color: $white;
+	cursor: pointer;
+	transition: $transition-fast;
+	
+	&:hover {
+		background: $white;
+		border-color: var(--maxi-grey);
+	}
+}
+
 // Placeholder for shared button styles
 %card-button-base {
 	@include action-button;
@@ -32,6 +81,7 @@ $transition: all 0.3s ease;
 		opacity: 0.3;
 	}
 }
+
 
 .has-tooltip {
 	.tooltip {
@@ -139,7 +189,7 @@ $transition: all 0.3s ease;
 	display: flex;
 }
 .maxi-style-cards__settings {
-	padding: 0 !important;
+	padding: 0;
 
 	.maxi-style-cards__sc-cancel-save {
 		display: flex;
@@ -158,7 +208,7 @@ $transition: all 0.3s ease;
 		margin: 0 0 5px 0;
 
 		b {
-			font-weight: 700 !important;
+			font-weight: 700;
 		}
 	}
 }
@@ -198,7 +248,7 @@ body .maxi-style-cards__popover {
 		background-color: var(--maxi-whisper-green) !important;
 		opacity: 1;
 		color: var(--maxi-primary-color) !important;
-		transition: all 0.3s ease !important;
+		transition: $transition;
 	}
 
 	.maxi-accordion-control__item {
@@ -274,21 +324,9 @@ body .maxi-style-cards__popover {
 		margin-bottom: 8px;
 
 		&__box {
-			@include flex-center;
-			width: 32px;
-			height: 32px;
-			padding: 0;
-			border: $border-style;
+			@include preset-box-base;
 			margin: 0;
-			border-radius: 50% !important;
-			background-color: $white;
-			cursor: pointer;
-			transition: $transition-fast;
 
-			&:hover {
-				background: var(--maxi-white);
-				border-color: var(--maxi-grey);
-			}
 			&--active {
 				border: 1.5px solid var(--maxi-primary-color);
 			}
@@ -308,21 +346,9 @@ body .maxi-style-cards__popover {
 		margin-bottom: 8px;
 
 		&__box {
+			@include preset-box-base;
 			position: relative;
-			@include flex-center;
-			width: 32px;
-			height: 32px;
-			padding: 0;
-			border: $border-style;
-			border-radius: 50% !important;
-			background-color: #fff;
-			cursor: pointer;
-			transition: $transition-fast;
-
-			&:hover {
-				background: var(--maxi-white);
-				border-color: var(--maxi-grey);
-			}
+			background-color: #fff; // Override for custom presets
 
 			&--active {
 				border: 2px solid var(--maxi-primary-color);
@@ -684,7 +710,7 @@ body .maxi-style-cards__popover {
 		outline: none;
 		box-shadow: none;
 		&-bigger {
-			overflow: scroll !important;
+			overflow: scroll;
 			padding-bottom: 7px;
 		}
 		> * {
@@ -710,11 +736,11 @@ body .maxi-style-cards__popover {
 		&__decoration,
 		&__orientation,
 		&__direction {
-			margin-bottom: 8px;
+			@include control-row;
 		}
 		&__word-spacing,
 		&__size {
-			margin-top: 8px;
+			margin-top: $control-spacing;
 		}
 	}
 	.maxi-toggle-switch {
@@ -796,34 +822,24 @@ body .maxi-style-cards__popover {
 		border-radius: 5px !important;
 	}
 }
-@media only screen and (max-width: 768px) {
-	body {
-		.maxi-responsive-selector {
-			.maxi-style-cards__popover {
-				max-height: 90vh !important;
-			}
-		}
+@include respond-to('sm') {
+	body .maxi-responsive-selector .maxi-style-cards__popover {
+		max-height: 90vh !important;
 	}
 }
-@media only screen and (max-width: 782px) {
-	body {
-		&:not(.is-fullscreen-mode, .folded)
-			.maxi-responsive-selector
-			.maxi-style-cards__popover {
-			margin: 148px 0 0 25px;
-		}
+
+@include respond-to('md') {
+	body:not(.is-fullscreen-mode):not(.folded) .maxi-responsive-selector .maxi-style-cards__popover {
+		margin: 148px 0 0 25px;
 	}
 }
-@media only screen and (max-width: 347px) {
-	.maxi-responsive-selector {
-		.maxi-style-cards__popover {
-			.components-popover__content {
-				margin-left: -25px;
-				left: 100%;
-				transform: none;
-				min-width: 309px;
-			}
-		}
+
+@include respond-to('xs') {
+	.maxi-responsive-selector .maxi-style-cards__popover .components-popover__content {
+		margin-left: -25px;
+		left: 100%;
+		transform: none;
+		min-width: 309px;
 	}
 }
 /*******************************
@@ -858,18 +874,18 @@ html[dir='rtl'] {
 	width: 100%;
 	margin-top: 8px;
 	padding: 8px;
-	border: 1px solid #e0e0e0;
+	border: 1px solid var(--maxi-grey-light) !important;
 	border-radius: 4px;
 	font-size: 13px;
 
 	&:focus {
 		outline: none;
-		border-color: #007cba;
-		box-shadow: 0 0 0 1px #007cba;
+		border-color: var(--maxi-primary-color);
+		box-shadow: 0 0 0 1px var(--maxi-primary-color);
 	}
 
 	&::placeholder {
-		color: #757575;
+		color: var(--maxi-grey-dark);
 	}
 }
 .maxi-style-cards__sc__more-sc--delete {

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -892,15 +892,13 @@ html[dir='rtl'] {
 
 		.maxi-tabs-control__button {
 			flex: 1;
-			min-width: 32px;
-			max-width: 40px;
-			height: 28px;
-			padding: 4px 8px;
-			border: 1.5px solid var(--maxi-grey-light);
+			min-width: 52px;
+			padding:4px 8px;
+			border: 1.5px solid var(--maxi-grey-light) !important;
 			border-radius: 5px;
 			background-color: var(--maxi-white);
 			color: var(--maxi-grey-dark);
-			font-size: 12px;
+			font-size: 14px;
 			font-weight: 400;
 			text-align: center;
 			cursor: pointer;
@@ -908,13 +906,13 @@ html[dir='rtl'] {
 
 			&:hover {
 				background-color: var(--maxi-whisper-green);
-				border-color: var(--maxi-grey);
-				color: var(--maxi-black);
+				border: 1.5px solid var(--maxi-primary-color) !important;
+				color: var(--maxi-primary-color);
 			}
 
 			&[aria-pressed='true'] {
 				background-color: var(--maxi-pastel-green);
-				border-color: var(--maxi-primary-color);
+				border: 1.5px solid var(--maxi-primary-color) !important;
 				color: var(--maxi-primary-color);
 				font-weight: 700;
 			}

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -755,7 +755,7 @@ body .maxi-style-cards__popover {
 		// Ensure the dropdown menu appears above everything
 		.maxi-font-family-selector__control__menu {
 			position: absolute;
-			z-index: 99999 !important;
+			z-index: 100 !important;
 			background: var(--maxi-white);
 		}
 	}

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -16,6 +16,7 @@ import AccordionControl from '@components/accordion-control';
 import Button from '@components/button';
 import ColorControl from '@components/color-control';
 import Icon from '@components/icon';
+import ResponsiveTabsControl from '@components/responsive-tabs-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import TypographyControl from '@components/typography-control';
 import ToggleSwitch from '@components/toggle-switch';
@@ -231,6 +232,7 @@ const SCAccordion = props => {
 		onChangeValue,
 		disableTypography = false,
 		disableOpacity = false,
+		disableResponsiveTabs = false,
 	} = props;
 
 	const ifParagraphOrHeading = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].some(
@@ -275,6 +277,7 @@ const SCAccordion = props => {
 					disableFormats
 					disableCustomFormats
 					disableFontFamily={breakpoint !== 'general'}
+					disableResponsiveTabs={disableResponsiveTabs}
 				/>
 			)}
 			{breakpoint === 'general' &&
@@ -563,6 +566,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 						SC={SC}
 						SCStyle={SCStyle}
 						onChangeValue={onChangeValue}
+						disableResponsiveTabs
 					/>
 				),
 				classNameItem: `maxi-blocks-sc__type--h${item}`,
@@ -1210,10 +1214,13 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 							label: __('Headings globals', 'maxi-blocks'),
 							classNameItem: 'maxi-blocks-sc__type--heading',
 							content: (
-								<SettingTabsControl
-									hasBorder
-									items={headingItems()}
-								/>
+								<ResponsiveTabsControl breakpoint={breakpoint}>
+									<SettingTabsControl
+										className="maxi-style-cards-headings-tabs"
+										hasBorder
+										items={headingItems()}
+									/>
+								</ResponsiveTabsControl>
 							),
 						},
 						breakpoint === 'general' && {


### PR DESCRIPTION
Fixes the drop menu in the SC font selector 
<img width="372" height="442" alt="chrome_clSljaLoGe" src="https://github.com/user-attachments/assets/297b5ce3-fe72-4862-bdd3-acf7b2e93779" />

Also changed the h tag buttons a little

<img width="359" height="165" alt="image" src="https://github.com/user-attachments/assets/145e3867-3825-4e74-a535-995a09b0bfba" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted stacking/order of dropdowns, labels and menus (z-index tweaks) and relaxed a tab border override to better respect theming.

* **New Features**
  * Heading typography now uses responsive tabs by default, with a new option to disable responsive behavior and preserve legacy rendering.

* **Style**
  * Introduced tokens and mixins to streamline card, button, tab and typography styling for more consistent, responsive UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->