### PR TITLE
Set advanced tab index dynamically in DC component

### DIFF
--- a/src/components/toolbar/components/dynamic-content/index.js
+++ b/src/components/toolbar/components/dynamic-content/index.js
@@ -38,11 +38,16 @@ const DC = props => {
 		'maxi-blocks/divider-maxi': 'divider',
 	};
 
+	// Text block has Advanced tab at index 1, others at index 2 (due to Canvas tab)
+	const advancedTab = blockName === 'maxi-blocks/text-maxi' ? 1 : 2;
+
 	return (
 		<ToolbarPopover
 			className='toolbar-item__dynamic-content'
 			tooltip={__('Dynamic Content', 'maxi-blocks')}
 			icon={toolbarDynamicContent}
+			advancedOptions='dynamic content'
+			tab={advancedTab}
 		>
 			<DynamicContent
 				className='toolbar-item__dynamic-content__popover toolbar-item__dynamic-content__popover'


### PR DESCRIPTION
Adjusts the advanced tab index in the ToolbarPopover based on the block type, setting it to 1 for text blocks and 2 for others. This ensures the Advanced tab appears in the correct position depending on the block.

Fixes https://github.com/maxi-blocks/maxi-blocks/issues/6108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced toolbar advanced options functionality with improved context-aware tab selection based on content block type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->