### PR TITLE
Refactor SCSS to use backend variables and mixins

### DIFF
--- a/core/admin/admin.scss
+++ b/core/admin/admin.scss
@@ -1,3 +1,4 @@
+@import '../../src/css/backend-variables.scss';
 @import './variables';
 
 body.toplevel_page_maxi-blocks-dashboard {
@@ -30,12 +31,12 @@ body.toplevel_page_maxi-blocks-dashboard {
 			margin: 30px auto 0;
 			border-radius: 25px;
 			& * {
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+				font-family: $f !important;
 			}
 		}
 	}
 	.maxi-dashboard_header {
-		position: relative;
+		position: $pr;
 		z-index: 1;
 		display: flex;
 		justify-content: flex-start;
@@ -53,7 +54,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 		}
 
 		.nav-tab-wrapper {
-			position: relative;
+			position: $pr;
 			z-index: 1;
 			padding: 12px 39px 10px;
 			margin-top: 0;
@@ -62,15 +63,15 @@ body.toplevel_page_maxi-blocks-dashboard {
 			margin-right: auto;
 
 			.maxi-dashboard_nav-tab {
-				position: relative;
-				background: transparent;
+				position: $pr;
+				background: $tr;
 				border: none;
 				font-size: 20px;
 				margin: 0;
 				padding: 8px 16px;
 				color: var(--maxi-admin-black-text);
 				font-weight: 400;
-				transition: all 0.5s ease;
+				transition: $t;
 				outline: none;
 				box-shadow: none;
 
@@ -80,7 +81,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 
 				&:hover {
 					color: var(--maxi-admin-pink-hover);
-					background: transparent;
+					background: $tr;
 					border: none;
 				}
 
@@ -168,7 +169,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 				&__validation-message {
 					width: 100%;
 					&.api-loading {
-						color: var(--maxi-secondary-color);
+						color: $sc;
 					}
 					&.api-error {
 						color: var(--maxi-orange-red);
@@ -257,7 +258,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 				}
 				a {
 					color: var(--maxi-admin-green);
-					transition: all 0.4s ease;
+					transition: $t;
 					&:hover {
 						color: var(--maxi-admin-purple-hover);
 					}
@@ -347,7 +348,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 				}
 			}
 			.maxi-dashboard_main-content_accordion {
-				position: relative;
+				position: $pr;
 				z-index: 2;
 				// max-width: clamp(280px, 95%, 1000px);
 				width: 95%;
@@ -392,10 +393,10 @@ body.toplevel_page_maxi-blocks-dashboard {
 						padding: 22px 22px 22px 32px;
 						margin-bottom: -1px;
 						font-weight: 700;
-						cursor: pointer;
+						cursor: $ptr;
 						background: var(--maxi-admin-white);
 						border-radius: 8px;
-						transition: all 0.3s ease;
+						transition: $t;
 
 						h3 {
 							font-size: 20px !important;
@@ -457,7 +458,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 								border-color: var(--maxi-admin-border-light);
 								max-height: 10000vh;
 								padding: 25px 25px 20px 34px;
-								transition: all 0.5s ease-in-out;
+								transition: $t;
 							}
 						}
 					}
@@ -532,11 +533,11 @@ body.toplevel_page_maxi-blocks-dashboard {
 								}
 							}
 							&__toggle {
-								position: relative;
-								cursor: pointer;
+								position: $pr;
+								cursor: $ptr;
 
 								input[type='checkbox'] {
-									position: absolute;
+									position: $pa;
 									z-index: 1;
 									top: 0;
 									left: 0;
@@ -550,8 +551,8 @@ body.toplevel_page_maxi-blocks-dashboard {
 									&:focus
 										+ .maxi-toggle-switch__toggle__track {
 										border-radius: 12px;
-										box-shadow: 0 0 0 1px var(--maxi-grey);
-										outline: 2px solid transparent;
+										box-shadow: 0 0 0 1px $g;
+										outline: 2px solid $tr;
 									}
 
 									&:checked
@@ -573,18 +574,18 @@ body.toplevel_page_maxi-blocks-dashboard {
 									vertical-align: top;
 									width: 44px;
 									height: 24px;
-									background-color: var(--maxi-white);
+									background-color: $w;
 									background-image: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.8 8"><path d="M8.43.22A1 1 0 0 0 7 .37L2.93 5.48 1.72 4.21a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.41l2 2.1h.05a.83.83 0 0 0 .16.09l.1.06A1.15 1.15 0 0 0 3 8a.93.93 0 0 0 .4-.09l.11-.07a.71.71 0 0 0 .18-.12s0 0 0-.06l4.8-6A1 1 0 0 0 8.43.22Z"/></svg>'),
 										url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="m5.6 4 2.55-2.55A.85.85 0 1 0 7 .25L4.4 2.8 1.85.25a.85.85 0 0 0-1.2 1.2L3.2 4 .65 6.55a.85.85 0 0 0 0 1.2.83.83 0 0 0 .6.25.82.82 0 0 0 .6-.25.82.82 0 0 0 .6-.25L4.4 5.2 7 7.75a.82.82 0 0 0 .6.25.83.83 0 0 0 .6-.25.85.85 0 0 0 0-1.2Z" transform="translate(-.4)"/></svg>');
 									background-repeat: no-repeat, no-repeat;
 									background-position: 8px center, 24px center;
 									background-size: 10px auto, 10px auto;
-									border: 1px solid var(--maxi-grey-light);
+									border: $bl;
 									border-radius: 12px;
 									transition: 0.2s background ease;
 								}
 								&__thumb {
-									position: absolute;
+									position: $pa;
 									top: 3px;
 									left: 3px;
 									display: block;
@@ -592,7 +593,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 									width: 18px;
 									height: 18px;
 									background-color: var(--maxi-admin-white);
-									border: 1px solid var(--maxi-grey-light);
+									border: $bl;
 									border-radius: 50%;
 									transition: 0.1s transform ease;
 								}
@@ -649,7 +650,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 
 					.header-row td {
 						font-weight: bold;
-						background: var(--maxi-primary-color);
+						background: $pc;
 					}
 
 					.status-ok span {
@@ -660,7 +661,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 						font-weight: 700;
 						border-radius: 26px;
 						text-decoration: none;
-						position: relative;
+						position: $pr;
 
 						&::before {
 							content: '\2713'; /* Unicode for check mark */
@@ -678,7 +679,7 @@ body.toplevel_page_maxi-blocks-dashboard {
 						border-radius: 3px;
 						font-size: 14px;
 						font-weight: 700;
-						position: relative;
+						position: $pr;
 
 						&::before {
 							content: '✖'; /* Unicode for cross mark */
@@ -713,9 +714,9 @@ body.toplevel_page_maxi-blocks-dashboard {
 					margin: 0;
 					line-height: 136%;
 					a {
-						color: var(--maxi-primary-color);
+						color: $pc;
 						&:hover {
-							transition: all 0.4s ease;
+							transition: $t;
 							opacity: 0.5;
 						}
 					}
@@ -896,13 +897,13 @@ body.site-editor-php
 	text-decoration: none;
 	border-radius: 26px;
 	font-weight: 500;
-	transition: all 0.4s ease;
+	transition: $t;
 }
 
 .maxi-dashboard_setup-wizard-button:hover {
 	background-color: var(--maxi-admin-black-text);
 	color: var(--maxi-admin-white);
-	transition: all 0.4s ease;
+	transition: $t;
 }
 
 .maxi-dashboard_setup-wizard-button:focus {
@@ -952,7 +953,7 @@ body.site-editor-php
 				// Universal hover for all .button variants
 				&:hover {
 					background: var(--maxi-admin-green) !important;
-					transition: all 0.5s ease;
+					transition: $t;
 				}
 
 				&.quick-start {
@@ -967,11 +968,11 @@ body.site-editor-php
 					border: none;
 					padding: 5px 25px;
 					transition: background 0.1s ease, transform 0.3s ease;
-					transition: all 0.5s ease;
+					transition: $t;
 
 					&:hover {
 						background: var(--maxi-admin-light-orange) !important;
-						transition: all 0.5s ease;
+						transition: $t;
 					}
 				}
 			}
@@ -1009,14 +1010,14 @@ body.site-editor-php
 			grid-template-columns: repeat(3, 1fr);
 			gap: 24px 24px;
 			margin: 30px 0;
-			position: relative;
+			position: $pr;
 
 			// &::before {
 			// }
 
 			.video-item {
 				text-align: left;
-				position: relative;
+				position: $pr;
 				z-index: 2;
 				transition: border 0.3s ease;
 				border: 2px solid var(--maxi-admin-border-light);
@@ -1077,12 +1078,12 @@ body.site-editor-php
 				box-shadow: none;
 				overflow: hidden;
 				transition: background 0.3s ease, transform 0.2s ease;
-				transition: all 0.5s ease;
+				transition: $t;
 
 				&:hover {
 					background: var(--maxi-admin-green) !important;
 					color: var(--maxi-admin-white);
-					transition: all 0.5s ease;
+					transition: $t;
 				}
 			}
 		}
@@ -1132,7 +1133,7 @@ body.site-editor-php
 				transition: background 0.3s ease, transform 0.2s ease;
 
 				&:hover {
-					background: var(--maxi-primary-color) !important;
+					background: $pc !important;
 					color: var(--maxi-admin-white);
 				}
 			}
@@ -1643,7 +1644,7 @@ p.maxi-license-help-text {
 		input[type='file'] {
 			padding: 8px 0;
 			font-size: 13px;
-			cursor: pointer;
+			cursor: $ptr;
 
 			&::file-selector-button {
 				padding: 6px 12px;
@@ -1652,7 +1653,7 @@ p.maxi-license-help-text {
 				border: 1px solid var(--maxi-admin-grey);
 				border-radius: 4px;
 				font-size: 13px;
-				cursor: pointer;
+				cursor: $ptr;
 				transition: background 0.15s ease, border-color 0.15s ease;
 
 				&:hover {
@@ -1809,7 +1810,7 @@ p.maxi-license-help-text {
 		.button-link-delete {
 			color: var(--maxi-admin-orange-hover);
 			text-decoration: none;
-			cursor: pointer;
+			cursor: $ptr;
 			background: none;
 			border: none;
 			padding: 4px 8px;

--- a/core/admin/starter-sites/src/components/base-control/editor.scss
+++ b/core/admin/starter-sites/src/components/base-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../../src/css/backend-variables.scss';
 .maxi-base-control {
 	&__disable {
 		opacity: 0.3;

--- a/core/admin/starter-sites/src/components/text-control/editor.scss
+++ b/core/admin/starter-sites/src/components/text-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-text-control {
 	.maxi-base-control__field {
 		flex-wrap: wrap;
@@ -8,15 +9,15 @@ body.maxi-blocks--active .maxi-text-control {
 		max-height: unset !important;
 		padding: 2px 8px;
 		border-radius: 5px;
-		background-color: var(--maxi-grey);
-		border: 1px solid var(--maxi-grey-light);
+		background-color: $g;
+		border: $bl;
 		font-size: 13px;
-		color: var(--maxi-black);
+		color: $bk;
 		font-weight: 500;
 		flex: 1;
 
 		&:focus {
-			border-color: var(--maxi-grey);
+			border-color: $g;
 		}
 	}
 
@@ -39,17 +40,17 @@ body.maxi-blocks--active .maxi-text-control {
 	}
 	&__second-style {
 		.maxi-base-control__field {
-			position: relative;
+			position: $pr;
 			margin-top: 12px;
 		}
 		.maxi-base-control__label {
-			position: absolute;
+			position: $pa;
 			top: -8px;
 			left: 8px;
 			font-size: 10px !important;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 			font-style: normal;
-			background: var(--maxi-white);
+			background: $w;
 			padding: 0 5px;
 			pointer-events: none;
 			box-sizing: border-box;

--- a/core/admin/starter-sites/src/components/text-input/editor.scss
+++ b/core/admin/starter-sites/src/components/text-input/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../../src/css/backend-variables.scss';
 body.maxi-blocks--active {
 	.maxi-text-input {
 		border: none;
@@ -6,7 +7,7 @@ body.maxi-blocks--active {
 		padding: 0;
 		margin: 0;
 		width: 100%;
-		background-color: transparent;
+		background-color: $tr;
 
 		&:focus {
 			border: none;

--- a/core/admin/starter-sites/src/components/toggle-switch/editor.scss
+++ b/core/admin/starter-sites/src/components/toggle-switch/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../../src/css/backend-variables.scss';
 body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	.maxi-toggle-switch__toggle {
 		&__track {
@@ -5,14 +6,14 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 		}
 		input[type='checkbox'] {
 			&:focus + .maxi-toggle-switch__toggle__track {
-				box-shadow: 0 0 0 1px var(--maxi-secondary-color);
+				box-shadow: 0 0 0 1px $sc;
 			}
 		}
 	}
 }
 
 .maxi-toggle-switch {
-	position: relative;
+	position: $pr;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -21,8 +22,8 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 	&--is-checked {
 		.maxi-toggle-switch__toggle__thumb {
-			background-color: var(--maxi-primary-color);
-			border-color: var(--maxi-primary-color);
+			background-color: $pc;
+			border-color: $pc;
 			transform: translateX(20px);
 		}
 	}
@@ -32,15 +33,15 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			margin-bottom: 0;
 		}
 		&__label {
-			cursor: pointer;
+			cursor: $ptr;
 		}
 	}
 	&__toggle {
-		position: relative;
-		cursor: pointer;
+		position: $pr;
+		cursor: $ptr;
 
 		input[type='checkbox'] {
-			position: absolute;
+			position: $pa;
 			z-index: 1;
 			top: 0;
 			left: 0;
@@ -53,7 +54,7 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			&:focus + .maxi-toggle-switch__toggle__track {
 				border-radius: 12px;
 
-				outline: 1px solid transparent;
+				outline: 1px solid $tr;
 			}
 		}
 		&__track {
@@ -63,27 +64,27 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			vertical-align: top;
 			width: 44px;
 			height: 24px;
-			background-color: var(--maxi-white);
+			background-color: $w;
 			background-image: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.8 8"><path fill="rgb(147, 147, 147)" d="M8.43.22A1 1 0 0 0 7 .37L2.93 5.48 1.72 4.21a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.41l2 2.1h.05a.83.83 0 0 0 .16.09l.1.06A1.15 1.15 0 0 0 3 8a.93.93 0 0 0 .4-.09l.11-.07a.71.71 0 0 0 .18-.12s0 0 0-.06l4.8-6A1 1 0 0 0 8.43.22Z"/></svg>'),
 				url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path fill="rgb(147, 147, 147)" d="m5.6 4 2.55-2.55A.85.85 0 1 0 7 .25L4.4 2.8 1.85.25a.85.85 0 0 0-1.2 1.2L3.2 4 .65 6.55a.85.85 0 0 0 0 1.2.83.83 0 0 0 .6.25.82.82 0 0 0 .6-.25L4.4 5.2 7 7.75a.82.82 0 0 0 .6.25.83.83 0 0 0 .6-.25.85.85 0 0 0 0-1.2Z" transform="translate(-.4)"/></svg>');
 			background-repeat: no-repeat, no-repeat;
 			background-position: 8px center, 24px center;
 			background-size: 10px auto, 10px auto;
-			border: 1px solid var(--maxi-grey);
+			border: 1px solid $g;
 			border-radius: 12px;
 			outline: 0;
 			transition: 0.2s background ease;
 		}
 		&__thumb {
-			position: absolute;
+			position: $pa;
 			top: 3px;
 			left: 3px;
 			display: block;
 			box-sizing: border-box;
 			width: 18px;
 			height: 18px;
-			background-color: var(--maxi-white);
-			border: 1px solid var(--maxi-grey);
+			background-color: $w;
+			border: 1px solid $g;
 			border-radius: 50%;
 			transition: 0.1s transform ease;
 		}

--- a/core/admin/starter-sites/src/library/style.scss
+++ b/core/admin/starter-sites/src/library/style.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 :root {
 	/* Core Builder */
 	/* Core Builder */
@@ -116,7 +117,7 @@
 
 	.maxi-preview {
 		.maxi-cloud-toolbar {
-			position: relative !important;
+			position: $pr !important;
 			top: 0;
 			z-index: 10000;
 			height: 50px;
@@ -134,29 +135,29 @@
 				font-size: 14px;
 				font-weight: 500;
 				text-decoration: none;
-				cursor: pointer;
+				cursor: $ptr;
 				transition: all 0.2s ease;
 
 				&-preview {
-					background-color: var(--maxi-black);
-					color: var(--maxi-white);
+					background-color: $bk;
+					color: $w;
 					border: none;
 					min-width: 200px;
 
 					&:hover {
 						opacity: 1;
-						background-color: var(--maxi-cloud-primary);
+						background-color: $cp;
 					}
 				}
 
 				&-import {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-white);
+					background-color: $cp;
+					color: $w;
 					border: none;
 					min-width: 200px;
 					&:hover {
 						opacity: 1;
-						background-color: var(--maxi-cloud-primary);
+						background-color: $cp;
 					}
 				}
 			}
@@ -172,9 +173,9 @@
 				column-gap: 17px;
 				width: 33.33%;
 				h2 {
-					color: var(--maxi-black);
+					color: $bk;
 					font-size: 16px;
-					font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+					font-family: $f !important;
 					font-weight: 500;
 					letter-spacing: -0.5px;
 					margin-bottom: 0;
@@ -186,7 +187,7 @@
 					span {
 						font-size: 16px;
 						font-weight: 500;
-						color: var(--maxi-black);
+						color: $bk;
 					}
 					&:hover {
 						box-shadow: inset 0 0 0 2px var(--maxi-admin-pink-hover);
@@ -196,7 +197,7 @@
 					width: 2px;
 					height: 16px;
 					margin: 0 -8px;
-					background-color: var(--maxi-grey-light);
+					background-color: $gl;
 					font-size: 0;
 				}
 			}
@@ -206,7 +207,7 @@
 				justify-content: flex-end;
 				width: 33.33%;
 				margin-right: 10px;
-				transition: all 0.4s ease !important;
+				transition: $t !important;
 				.maxi-cloud-toolbar__button {
 					padding: 9px 10px;
 					border: none !important;
@@ -218,7 +219,7 @@
 					&:hover {
 						box-shadow: inset 0 0 0 2px var(--maxi-admin-pink-hover);
 						svg {
-							fill: var(--maxi-cloud-primary);
+							fill: $cp;
 						}
 					}
 				}
@@ -231,15 +232,15 @@
 			}
 
 			&::-webkit-scrollbar-track {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 
 			&::-webkit-scrollbar-thumb {
-				background: var(--maxi-grey);
+				background: $g;
 			}
 
 			&::-webkit-scrollbar-thumb:hover {
-				background: var(--maxi-grey);
+				background: $g;
 			}
 		}
 	}
@@ -266,7 +267,7 @@
 
 				.maxi-cloud-container__preview-tablet__label,
 				.maxi-cloud-container__preview-mobile__label {
-					position: absolute;
+					position: $pa;
 					z-index: 1000;
 					top: 72px;
 					left: 0;
@@ -274,8 +275,8 @@
 					max-width: 400px;
 					border-radius: 50%;
 					margin: 0 auto;
-					color: var(--maxi-white);
-					background: var(--maxi-cloud-primary);
+					color: $w;
+					background: $cp;
 					font-size: 16px;
 					text-align: center;
 				}
@@ -303,9 +304,9 @@
 				align-items: center;
 				justify-content: center;
 				width: 100%;
-				color: var(--maxi-black) !important;
-				background: var(--maxi-grey-light);
-				border: 1px dashed var(--maxi-grey);
+				color: $bk !important;
+				background: $gl;
+				border: 1px dashed $g;
 				padding: 2rem;
 				transition: all 0.5s;
 
@@ -318,19 +319,19 @@
 				width: calc(16.6666666667% - 5px);
 				height: auto;
 				padding: 0;
-				border: 2px solid var(--maxi-grey-light);
+				border: 2px solid $gl;
 				border-radius: 5px;
 				margin: 0 5px 5px 0;
-				cursor: pointer;
+				cursor: $ptr;
 
 				&--active {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 				&:last-child {
 					margin-right: 0;
 				}
 				&:hover {
-					background-color: var(--maxi-grey-light);
+					background-color: $gl;
 				}
 				svg {
 					width: 100%;
@@ -340,42 +341,42 @@
 			}
 		}
 		&__preview {
-			position: relative;
+			position: $pr;
 			width: 100%;
 			height: 66px;
 			flex: 1;
-			color: var(--maxi-black) !important;
-			background: var(--maxi-grey-light);
+			color: $bk !important;
+			background: $gl;
 			padding: 5px;
-			border: 1px dashed var(--maxi-grey);
+			border: 1px dashed $g;
 			margin-left: 5px;
 			margin-right: 5px;
 
 			&__icon {
 				svg {
 					stroke-width: 1;
-					stroke: var(--maxi-black);
+					stroke: $bk;
 					* {
 						stroke-width: 1;
-						stroke: var(--maxi-black);
+						stroke: $bk;
 					}
 				}
 			}
 			&__shape {
 				svg {
 					max-height: 100%;
-					fill: var(--maxi-black);
+					fill: $bk;
 					* {
-						fill: var(--maxi-black);
+						fill: $bk;
 					}
 				}
 			}
 			&--remove {
-				position: absolute;
+				position: $pa;
 				top: -12px;
 				right: -8px;
 				width: 20px;
-				cursor: pointer;
+				cursor: $ptr;
 			}
 			& > div {
 				display: flex;
@@ -385,7 +386,7 @@
 
 				svg {
 					pattern ~ path {
-						fill: var(--maxi-cloud-primary);
+						fill: $cp;
 					}
 				}
 			}
@@ -407,7 +408,7 @@
 		height: 100%;
 		margin-top: 0;
 		padding: 0 0 0;
-		background: var(--maxi-white);
+		background: $w;
 
 		&::before {
 			margin: 0;
@@ -426,20 +427,20 @@
 				font-size: 1rem;
 			}
 			.components-button {
-				position: absolute;
+				position: $pa;
 				right: 4px;
 				left: auto;
 				top: 4px;
 				padding: 0;
 				box-shadow: none;
 				svg {
-					fill: var(--maxi-cloud-primary);
+					fill: $cp;
 					width: 38px;
 					height: 38px;
 				}
 				&:hover {
 					svg {
-						fill: var(--maxi-black);
+						fill: $bk;
 					}
 				}
 			}
@@ -448,20 +449,20 @@
 	div.maxi-cloud-toolbar {
 		border-top-left-radius: 10px !important;
 		border-top-right-radius: 10px !important;
-		background-color: var(--maxi-white);
+		background-color: $w;
 	}
 	.components-modal__screen-overlay.maxi-open-preview {
 		.components-modal__content {
 			min-height: auto;
 			height: 90%;
-			border: 20px solid var(--maxi-black);
-			background-color: var(--maxi-black);
+			border: 20px solid $bk;
+			background-color: $bk;
 			cursor: auto;
 		}
 	}
 
 	.spinner {
-		position: relative;
+		position: $pr;
 		display: none; // TEMPORARY
 		height: 100px;
 		width: 100px;
@@ -469,16 +470,16 @@
 		&:before,
 		&:after {
 			content: '';
-			position: absolute;
+			position: $pa;
 			right: 0;
 			top: 0;
 			bottom: 0;
 			left: 0;
 			box-sizing: border-box;
-			border-bottom: 6px solid var(--maxi-cloud-primary);
-			border-left: 6px solid transparent;
-			border-right: 6px solid var(--maxi-cloud-primary);
-			border-top: 6px solid var(--maxi-cloud-primary);
+			border-bottom: 6px solid $cp;
+			border-left: 6px solid $tr;
+			border-right: 6px solid $cp;
+			border-top: 6px solid $cp;
 			border-radius: 50%;
 			margin: auto;
 			transform-origin: center center;
@@ -505,10 +506,10 @@
 		width: 99.6%;
 		height: 46px;
 
-		//border-bottom: 1px solid var(--maxi-grey-light);
+		//border-bottom: $bl;
 		margin: 0;
-		background-color: var(--maxi-white);
-		font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+		background-color: $w;
+		font-family: $f !important;
 		font-size: 16px;
 		font-weight: 500;
 		line-height: 1;
@@ -521,11 +522,11 @@
 			margin-right: 20px;
 			column-gap: 15px;
 			input.maxi-text-control__input {
-				transition: all 0.4s ease !important;
-				background-color: var(--maxi-white) !important;
+				transition: $t !important;
+				background-color: $w !important;
 				border-right: none !important;
 				&:hover {
-					border-color: var(--maxi-cloud-primary) !important;
+					border-color: $cp !important;
 				}
 			}
 		}
@@ -536,35 +537,35 @@
 			align-items: center;
 			justify-content: center;
 			padding: 0;
-			background-color: transparent;
-			color: var(--maxi-cloud-primary);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			background-color: $tr;
+			color: $cp;
+			font-family: $f !important;
 			text-decoration: none;
 			font-size: 14px;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: 0.1s;
 
 			svg {
 				width: 12px;
 				height: 12px;
-				background-color: var(--maxi-cloud-primary);
+				background-color: $cp;
 				padding: 2px;
 				margin-right: 5px;
 				border-radius: 50%;
 
 				path {
-					fill: var(--maxi-cloud-primary);
-					stroke: var(--maxi-white);
+					fill: $cp;
+					stroke: $w;
 				}
 			}
 
 			&:hover {
 				opacity: 1 !important;
-				color: var(--maxi-black);
+				color: $bk;
 				svg {
-					background-color: var(--maxi-black);
+					background-color: $bk;
 					path {
-						fill: var(--maxi-black);
+						fill: $bk;
 					}
 				}
 			}
@@ -588,7 +589,7 @@
 		justify-content: space-between;
 		height: calc(100% - 0px);
 		margin: 0;
-		background: var(--maxi-white);
+		background: $w;
 
 		.ais-ClearRefinements {
 			margin: 0 8px;
@@ -596,27 +597,27 @@
 		.ais-InfiniteHits-loadMore,
 		.ais-ClearRefinements-button {
 			padding: 10px;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 30px;
 			margin-top: 8px;
-			background-color: var(--maxi-cloud-primary-light);
-			color: var(--maxi-black);
+			background-color: $cpl;
+			color: $bk;
 			font-size: 14px;
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			font-family: $f !important;
 			font-weight: 400;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: 0.1s;
 			outline: 0;
 			&:not(&--disabled) {
 				&:hover {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-white);
+					background-color: $cp;
+					color: $w;
 				}
 			}
 
 			&--disabled {
-				background-color: var(--maxi-grey-light);
-				color: var(--maxi-grey);
+				background-color: $gl;
+				color: $g;
 				cursor: not-allowed;
 			}
 		}
@@ -628,10 +629,10 @@
 			border-width: 0 !important;
 
 			&_main-wrap {
-				position: absolute;
+				position: $pa;
 				width: 100%;
 				height: 100%;
-				background: var(--maxi-cloud-primary-whisper);
+				background: $cpw;
 				overflow-y: auto;
 			}
 
@@ -648,7 +649,7 @@
 					width: 100%;
 					height: auto;
 					border-radius: 20px;
-					border: 15px solid var(--maxi-white);
+					border: 15px solid $w;
 				}
 			}
 
@@ -660,7 +661,7 @@
 				h2 {
 					font-size: 26px;
 					line-height: 36px;
-					color: var(--maxi-black);
+					color: $bk;
 					font-weight: 700;
 					font-family: 'Inter';
 					margin: 0 0 15px;
@@ -668,7 +669,7 @@
 				}
 				h3 {
 					line-height: 24px;
-					color: var(--maxi-black);
+					color: $bk;
 					font-weight: 700 !important;
 					font-family: 'Inter';
 				}
@@ -680,7 +681,7 @@
 			}
 
 			&_description {
-				color: var(--maxi-grey);
+				color: $g;
 				line-height: 1.5;
 				margin: 0 0 25px;
 				font-size: 16px;
@@ -709,30 +710,30 @@
 				font-size: 14px;
 				font-weight: 700;
 				text-decoration: none;
-				cursor: pointer;
+				cursor: $ptr;
 				transition: all 0.2s ease;
 				min-width: 200px;
 				border: none !important;
 
 				&-preview {
-					background-color: var(--maxi-black);
-					color: var(--maxi-white);
+					background-color: $bk;
+					color: $w;
 					border: none;
 
 					&:hover {
 						opacity: 1;
-						background-color: var(--maxi-cloud-primary);
+						background-color: $cp;
 					}
 				}
 
 				&-import {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-white);
+					background-color: $cp;
+					color: $w;
 					border: none;
 
 					&:hover {
 						opacity: 1;
-						background-color: var(--maxi-black);
+						background-color: $bk;
 					}
 				}
 			}
@@ -741,21 +742,21 @@
 				margin-bottom: 30px;
 				&:not(:last-child) {
 					padding: 6% 10%;
-					background-color: var(--maxi-white);
+					background-color: $w;
 					border-radius: 20px;
 				}
 
 				h3 {
 					font-size: 17px;
-					color: var(--maxi-black);
-					border-bottom: 2px solid var(--maxi-cloud-primary-whisper);
+					color: $bk;
+					border-bottom: 2px solid $cpw;
 					margin-bottom: 10px;
 					padding-bottom: 6px;
 				}
 			}
 
 			&_item {
-				border-bottom: 2px solid var(--maxi-cloud-primary-whisper);
+				border-bottom: 2px solid $cpw;
 				margin-bottom: 5px;
 
 				img {
@@ -768,7 +769,7 @@
 					display: block;
 					font-size: 16px;
 					padding: 2px 0px 9px;
-					color: var(--maxi-grey);
+					color: $g;
 					font-weight: 500;
 					font-family: 'Inter';
 				}
@@ -789,30 +790,30 @@
 		&__details-popup_wrap > div {
 			height: 100%;
 			width: 100%;
-			position: relative;
-			background-color: var(--maxi-white);
+			position: $pr;
+			background-color: $w;
 		}
 		&__accordion {
-			background-color: var(--maxi-white);
-			border-top: 1px solid var(--maxi-grey-light);
-			border-bottom: 1px solid var(--maxi-grey-light);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			background-color: $w;
+			border-top: $bl;
+			border-bottom: $bl;
+			font-family: $f !important;
 			&__title {
-				position: relative;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				position: $pr;
+				border-bottom: $bl;
 				border-radius: 0;
-				background: var(--maxi-white);
+				background: $w;
 				font-size: 12px;
 				font-weight: 400;
 				padding: 6px;
 				box-shadow: none;
 				margin-bottom: 0;
-				cursor: pointer;
+				cursor: $ptr;
 				font-size: 12px;
 
 				&:after {
 					content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" x="0" y="0" version="1.1" viewBox="0 0 9 13" xml:space="preserve"><g class="st0"><path d="M.9 1.2C.9.2 2.1-.2 2.7.4L8 5.7c.4.4.4 1.1 0 1.5l-5.3 5.3c-.7.7-1.8.2-1.8-.8V1.2z" class="st1"/> </g></svg>');
-					position: absolute;
+					position: $pa;
 					top: 50%;
 					right: 12px;
 					width: 6px;
@@ -845,11 +846,11 @@
 							margin-right: 5px;
 						}
 						&__input[type='checkbox'] {
-							background: var(--maxi-grey-light);
+							background: $gl;
 							border: none;
 						}
 						&__input[type='checkbox']:checked {
-							background: var(--maxi-cloud-primary);
+							background: $cp;
 							border: none;
 						}
 					}
@@ -867,7 +868,7 @@
 			}
 		}
 		&__content-svg-shape {
-			position: relative;
+			position: $pr;
 			width: 100%;
 
 			.maxi-cloud-container__content-svg-shape__button {
@@ -875,26 +876,26 @@
 				height: 31px;
 				min-width: 88px;
 				padding: 6px 18px;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 				border-radius: 0;
-				color: var(--maxi-black);
-				background-color: var(--maxi-white);
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+				color: $bk;
+				background-color: $w;
+				font-family: $f !important;
 				font-size: 12px;
 				font-weight: normal;
 				text-align: center;
 				text-decoration: none;
 				box-shadow: none;
-				cursor: pointer;
+				cursor: $ptr;
 				&:hover,
 				&___pressed {
-					border-bottom: 2px solid var(--maxi-cloud-primary) !important;
+					border-bottom: 2px solid $cp !important;
 					font-weight: 500;
 				}
 			}
 
 			&__search-bar {
-				position: absolute;
+				position: $pa;
 				margin-top: 0px;
 				right: 20px;
 				display: flex;
@@ -913,16 +914,16 @@
 					overflow: hidden;
 
 					.ais-SearchBox-form {
-						position: relative;
+						position: $pr;
 						overflow: hidden;
 
 						.ais-SearchBox-input {
 							width: 100%;
-							border: 1px solid var(--maxi-grey-light);
+							border: $bl;
 							border-radius: 20px !important;
 							box-shadow: 0 5px 15px 0 rgba(119, 119, 119, 0.1);
 							padding: 0.5rem 2rem;
-							color: var(--maxi-black);
+							color: $bk;
 							font-weight: bold;
 							height: 45px !important;
 						}
@@ -930,30 +931,30 @@
 							display: none;
 						}
 						.ais-SearchBox-loadingIndicator {
-							position: relative;
+							position: $pr;
 							top: 10px;
 						}
 						.ais-SearchBox-reset {
-							position: absolute;
+							position: $pa;
 							top: 50%;
 							right: 70px;
 							border: none;
 							background: none;
 							transform: translateY(-50%);
-							cursor: pointer;
+							cursor: $ptr;
 						}
 						.ais-SearchBox-submit {
-							position: absolute;
+							position: $pa;
 							top: 0;
 							right: 0;
 							height: 100%;
 							padding: 11px 1rem;
 							border: none;
-							background: var(--maxi-cloud-primary);
-							color: var(--maxi-white);
+							background: $cp;
+							color: $w;
 							font-weight: bold;
 							transition: all 0.5s;
-							cursor: pointer;
+							cursor: $ptr;
 
 							&:hover {
 								opacity: 0.8;
@@ -968,7 +969,7 @@
 
 					strong {
 						margin-right: 3px;
-						color: var(--maxi-cloud-primary);
+						color: $cp;
 					}
 				}
 			}
@@ -990,12 +991,12 @@
 				grid-template-columns: repeat(10, 1fr);
 
 				.ais-InfiniteHits-item {
-					position: relative;
+					position: $pr;
 					border: none !important;
 					box-shadow: none !important;
 
 					.maxi-cloud-masonry-card {
-						position: relative;
+						position: $pr;
 						z-index: 1;
 						transition: all 0.5s;
 						padding: 6px;
@@ -1008,7 +1009,7 @@
 							}
 						}
 						&__svg-container {
-							position: relative;
+							position: $pr;
 							z-index: 1;
 							display: flex;
 							align-items: center;
@@ -1024,18 +1025,18 @@
 								transition: 0.3s;
 							}
 							&__code {
-								background-color: transparent !important;
+								background-color: $tr !important;
 								text-align: center;
 								width: 64px;
 								margin-bottom: 5px;
 								margin-top: 10px;
 							}
 							span {
-								position: relative;
+								position: $pr;
 								padding: 8px 7px;
-								border: 2px solid var(--maxi-cloud-primary);
+								border: 2px solid $cp;
 								border-radius: 0;
-								color: var(--maxi-black);
+								color: $bk;
 								font-family: 'Inter', Helvetica, Arial, Lucida,
 									sans-serif !important;
 								font-weight: 400;
@@ -1044,20 +1045,20 @@
 								opacity: 0;
 								&:before {
 									content: '';
-									position: absolute;
+									position: $pa;
 									z-index: -1;
 									top: 0;
 									left: 0;
 									display: block;
 									width: 100%;
 									height: 100%;
-									background-color: var(--maxi-cloud-primary);
+									background-color: $cp;
 									transition: 0.3s;
 									opacity: 0;
 								}
 								&:hover {
 									transition-delay: 0s !important;
-									color: var(--maxi-white);
+									color: $w;
 									&::before {
 										opacity: 1;
 									}
@@ -1067,15 +1068,15 @@
 
 						&:after {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: 0;
 							left: 0;
 							right: 0;
 							top: 0;
 							bottom: 0;
 							display: block;
-							border: 1px solid var(--maxi-grey-light);
-							background-color: var(--maxi-white);
+							border: $bl;
+							background-color: $w;
 							transition: 0.3s;
 						}
 
@@ -1083,7 +1084,7 @@
 							g[data-stroke],
 							path[data-stroke],
 							svg[data-stroke] {
-								stroke: var(--maxi-black);
+								stroke: $bk;
 							}
 						}
 					}
@@ -1094,7 +1095,7 @@
 			&__sidebar {
 				overflow-x: hidden;
 				> ul {
-					border-top: 1px solid var(--maxi-grey-light);
+					border-top: $bl;
 					margin-top: 0;
 				}
 			}
@@ -1113,15 +1114,15 @@
 				}
 
 				&::-webkit-scrollbar-track {
-					background: var(--maxi-white);
+					background: $w;
 				}
 
 				&::-webkit-scrollbar-thumb {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 
 				&::-webkit-scrollbar-thumb:hover {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 			}
 		}
@@ -1135,26 +1136,26 @@
 			width: 100%;
 			height: 100%;
 			align-content: flex-start;
-			position: relative;
-			border-bottom: 1px solid var(--maxi-grey-light);
-			border-top: 1px solid var(--maxi-grey-light);
-			border-right: 1px solid var(--maxi-grey-light);
+			position: $pr;
+			border-bottom: $bl;
+			border-top: $bl;
+			border-right: $bl;
 
 			&__sidebar {
-				position: relative;
+				position: $pr;
 				z-index: 2;
-				border-right: 1px solid var(--maxi-grey-light);
-				border-left: 1px solid var(--maxi-grey-light);
-				background-color: var(--maxi-white);
+				border-right: $bl;
+				border-left: $bl;
+				background-color: $w;
 				//	border-top-left-radius: 8px;
 				overflow: hidden;
 			}
 
 			.maxi-cloud-container__patterns__top-menu {
-				position: relative;
+				position: $pr;
 				z-index: 1;
 				grid-column: 2 / -1;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				& > div {
 					&:not(.ais-Menu) {
 						width: 194px;
@@ -1164,32 +1165,32 @@
 			}
 
 			&__sidebar {
-				border-right: 1px solid var(--maxi-grey-light);
-				border-left: 1px solid var(--maxi-grey-light);
-				background-color: var(--maxi-white);
+				border-right: $bl;
+				border-left: $bl;
+				background-color: $w;
 				//border-top-left-radius: 8px;
 				overflow: hidden;
 				.top-Menu {
 					display: flex;
 					margin-bottom: 8px;
 					.maxi-cloud-container__content-svg-shape__button {
-						position: relative;
+						position: $pr;
 						z-index: 1;
 						width: 100%;
 						height: 31px;
 						padding: 6px 18px;
 						border: none;
-						border-bottom: 1px solid var(--maxi-grey-light);
-						border-right: 1px solid var(--maxi-grey-light);
+						border-bottom: $bl;
+						border-right: $bl;
 						border-radius: 0;
 						margin-right: 0;
-						color: var(--maxi-black);
-						background-color: transparent;
+						color: $bk;
+						background-color: $tr;
 						font-family: 'Inter', Helvetica, Arial, Lucida,
 							sans-serif !important;
 						font-size: 12px;
 						font-weight: normal;
-						cursor: pointer;
+						cursor: $ptr;
 						outline: 0;
 						&:last-child {
 							margin-right: 0;
@@ -1200,14 +1201,14 @@
 						}
 						&::before {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: -1;
 							left: -1px;
 							right: -1px;
 							top: -1px;
 							bottom: -1px;
 							display: block;
-							background-color: var(--maxi-cloud-primary);
+							background-color: $cp;
 							-webkit-transition: 0.1s;
 							-o-transition: 0.1s;
 							transition: 0.1s;
@@ -1215,14 +1216,14 @@
 						}
 						&:after {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: 1;
 							left: -1px;
 							top: -1px;
 							bottom: -1px;
 							display: block;
 							width: 1px;
-							background-color: var(--maxi-white);
+							background-color: $w;
 							opacity: 0;
 						}
 						&:first-child {
@@ -1231,7 +1232,7 @@
 							}
 						}
 						&___pressed {
-							color: var(--maxi-white);
+							color: $w;
 							font-weight: 500;
 							border-bottom: 1px solid;
 							&::after {
@@ -1243,19 +1244,19 @@
 						}
 						&___inactive {
 							pointer-events: none !important;
-							color: var(--maxi-grey);
+							color: $g;
 							&:after {
 								top: 50%;
 								left: 50%;
 								width: 109%;
 								height: 1px;
-								background-color: var(--maxi-grey-light);
+								background-color: $gl;
 								transform: translate(-50%, -50%) rotate(-21deg);
 								opacity: 1;
 							}
 						}
 						&:hover {
-							color: var(--maxi-white);
+							color: $w;
 							&::before {
 								opacity: 1;
 							}
@@ -1272,33 +1273,33 @@
 					.ais-SearchBox-form {
 						width: auto;
 						margin: 9px 8px;
-						position: relative;
+						position: $pr;
 
 						.ais-SearchBox-submit {
 							display: none;
 						}
 						.ais-SearchBox-reset {
-							background-color: var(--maxi-white) !important;
+							background-color: $w !important;
 							background: none;
 							border: none;
 							border-radius: 50%;
 							bottom: 2px;
-							color: var(--maxi-black);
-							cursor: pointer;
+							color: $bk;
+							cursor: $ptr;
 							font-size: 13px;
 							font-weight: 500;
 							outline: 0;
 							padding: 0;
-							position: absolute;
+							position: $pa;
 							right: 7px;
 							top: 2px;
-							transition: all 0.4s ease !important;
+							transition: $t !important;
 							width: 26px;
 							&:hover {
-								color: var(--maxi-cloud-primary);
+								color: $cp;
 							}
 							svg {
-								position: absolute;
+								position: $pa;
 								top: 50%;
 								left: 50%;
 								transform: translate(-50%, -50%);
@@ -1308,17 +1309,17 @@
 							display: block;
 							width: 100%;
 							padding: 8px 15px;
-							border: 1px solid var(--maxi-grey-light);
+							border: $bl;
 							border-radius: 20px !important;
-							background: var(--maxi-white);
-							color: var(--maxi-black);
+							background: $w;
+							color: $bk;
 							font-family: 'Inter', Helvetica, Arial, Lucida,
 								sans-serif !important;
 							font-size: 12px;
 							transition: all 0.5s;
 							&:hover,
 							&:focus {
-								border-color: var(--maxi-grey-light);
+								border-color: $gl;
 								box-shadow: none;
 								outline: none;
 							}
@@ -1326,12 +1327,12 @@
 					}
 				}
 				.components-checkbox-control {
-					font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+					font-family: $f !important;
 					font-size: 11px;
 					font-weight: 400;
 					&__input {
 						border-radius: 0;
-						border-color: var(--maxi-grey-light);
+						border-color: $gl;
 						margin: 0;
 					}
 					&__input-container {
@@ -1351,12 +1352,12 @@
 						box-shadow: none;
 					}
 					&__label {
-						color: var(--maxi-grey-light);
+						color: $gl;
 					}
 					.components-base-control__help {
 						margin: 0 8px 8px;
 						font-size: 12px;
-						color: var(--maxi-grey-light);
+						color: $gl;
 					}
 					&.use-placeholer-all-images {
 						.components-base-control__field {
@@ -1372,7 +1373,7 @@
 					justify-content: space-between;
 					margin: 0;
 					padding: 0;
-					border-bottom: 1px solid var(--maxi-grey-light) !important;
+					border-bottom: $bl !important;
 					align-items: center;
 					.maxi-toggle {
 						float: right;
@@ -1384,7 +1385,7 @@
 							height: 24px !important;
 							vertical-align: top;
 							width: 44px !important;
-							border: 1px solid var(--maxi-grey-light) !important;
+							border: $bl !important;
 							background-color: var(
 								--maxi-white-1-color
 							) !important;
@@ -1397,7 +1398,7 @@
 									top: 3px !important;
 									left: 1px;
 									path {
-										fill: var(--maxi-black);
+										fill: $bk;
 									}
 								}
 								&:first-child {
@@ -1412,7 +1413,7 @@
 							left: 3px;
 							height: 18px !important;
 							width: 18px !important;
-							border: 1px solid var(--maxi-grey-light) !important;
+							border: $bl !important;
 							box-shadow: none !important;
 							transition: transform 0.3s !important;
 						}
@@ -1428,11 +1429,11 @@
 					}
 					&--selected {
 						a {
-							background-color: var(--maxi-cloud-primary-whisper);
+							background-color: $cpw;
 
 							.ais-RefinementList-count,
 							.ais-RefinementList-labelText {
-								color: var(--maxi-cloud-primary);
+								color: $cp;
 							}
 
 							&:focus {
@@ -1446,7 +1447,7 @@
 						padding-top: 3px;
 						padding: 8px;
 						box-shadow: none;
-						color: var(--maxi-black);
+						color: $bk;
 						font-family: 'Inter', Helvetica, Arial, Lucida,
 							sans-serif !important;
 						font-weight: 500;
@@ -1456,11 +1457,11 @@
 						outline: none;
 
 						&:focus {
-							box-shadow: inset 0 0 0 1px var(--maxi-black);
+							box-shadow: inset 0 0 0 1px $bk;
 						}
 
 						&:hover {
-							background-color: var(--maxi-cloud-primary-whisper);
+							background-color: $cpw;
 							box-shadow: none;
 						}
 						.ais-RefinementList-checkbox {
@@ -1499,14 +1500,14 @@
 							}
 							a {
 								&:hover {
-									background-color: var(--maxi-white);
-									color: var(--maxi-cloud-primary);
+									background-color: $w;
+									color: $cp;
 								}
 							}
 							&--selected {
 								a {
-									background-color: var(--maxi-white);
-									color: var(--maxi-cloud-primary);
+									background-color: $w;
+									color: $cp;
 									&:hover {
 										background-color: var(
 											--maxi-cloud-primary-whisper
@@ -1528,7 +1529,7 @@
 					}
 					& > ul {
 						clear: both;
-						background-color: var(--maxi-cloud-primary-whisper);
+						background-color: $cpw;
 						margin: 0;
 						padding: 0;
 						border-top: 0;
@@ -1536,7 +1537,7 @@
 							border: none;
 							padding: 0;
 							margin-bottom: 0;
-							position: relative;
+							position: $pr;
 							& > a {
 								padding: 4px 15px !important;
 							}
@@ -1572,23 +1573,23 @@
 						column-gap: 10px;
 					}
 					&-item {
-						position: relative;
+						position: $pr;
 						display: flex;
 						flex-direction: column;
 						width: 100%;
 						margin-bottom: 0;
 						margin-top: -1px;
 						a {
-							position: relative;
+							position: $pr;
 							z-index: 1;
 							width: 100%;
 							height: 31px;
 							padding: 5px 8px;
-							border: 1px solid transparent;
+							border: 1px solid $tr;
 							border-radius: 5px;
 							box-shadow: none;
-							color: var(--maxi-black);
-							background-color: var(--maxi-cloud-primary-whisper);
+							color: $bk;
+							background-color: $cpw;
 							font-family: 'Inter', Helvetica, Arial, Lucida,
 								sans-serif !important;
 							font-size: 12px;
@@ -1596,12 +1597,12 @@
 							text-align: center;
 							text-decoration: none;
 							&:hover {
-								border-color: var(--maxi-grey-light);
+								border-color: $gl;
 							}
 						}
 						&--selected {
 							a {
-								border-color: var(--maxi-grey-light);
+								border-color: $gl;
 								font-weight: 500;
 							}
 						}
@@ -1611,7 +1612,7 @@
 			&__search-bar,
 			&__top-menu {
 				&__wrap {
-					position: absolute;
+					position: $pa;
 					left: 230px;
 					top: 7px;
 					display: flex;
@@ -1622,7 +1623,7 @@
 					display: block;
 					font-weight: 400;
 					font-size: 14px;
-					color: var(--maxi-black);
+					color: $bk;
 				}
 				.ais-Menu {
 					&-list {
@@ -1631,31 +1632,31 @@
 					}
 					&-item {
 						display: flex;
-						position: relative;
+						position: $pr;
 						flex-direction: column;
 						width: 100%;
 						margin-bottom: 0;
 						margin-top: -1px;
 						border-right: none !important;
 						&:last-child {
-							position: absolute;
+							position: $pa;
 							right: -317px;
-							border-right: 1px solid var(--maxi-grey-light) !important;
-							border-left: 1px solid var(--maxi-grey-light);
+							border-right: $bl !important;
+							border-left: $bl;
 						}
 						a {
-							position: relative;
+							position: $pr;
 							z-index: 1;
 							width: 100%;
 							height: 31px;
 							padding: 6px 8px;
-							border-bottom: 1px solid var(--maxi-grey-light);
-							border-top: 1px solid var(--maxi-grey-light);
-							border-right: 1px solid var(--maxi-grey-light);
+							border-bottom: $bl;
+							border-top: $bl;
+							border-right: $bl;
 							border-radius: 0;
 							box-shadow: none;
-							color: var(--maxi-black);
-							background-color: var(--maxi-white);
+							color: $bk;
+							background-color: $w;
 							font-family: 'Inter', Helvetica, Arial, Lucida,
 								sans-serif !important;
 							font-size: 12px;
@@ -1664,31 +1665,31 @@
 							text-decoration: none;
 							&:before {
 								content: '';
-								position: absolute;
+								position: $pa;
 								left: -1px;
 								right: -1px;
 								top: -1px;
 								bottom: -1px;
 								display: block;
-								background-color: var(--maxi-cloud-primary);
+								background-color: $cp;
 								z-index: -1;
 								transition: 0.1s;
 								opacity: 0;
 							}
 							&:after {
 								content: '';
-								position: absolute;
+								position: $pa;
 								z-index: 1;
 								left: -1px;
 								top: -1px;
 								bottom: -1px;
 								width: 1px;
 								display: block;
-								background-color: var(--maxi-white);
+								background-color: $w;
 								opacity: 0;
 							}
 							&:hover {
-								color: var(--maxi-white);
+								color: $w;
 								&::before {
 									opacity: 1;
 								}
@@ -1709,7 +1710,7 @@
 				&--selected {
 					a {
 						font-weight: 500;
-						color: var(--maxi-white);
+						color: $w;
 
 						&::before {
 							opacity: 1;
@@ -1732,7 +1733,7 @@
 			height: 10px;
 			.ais-Menu {
 				display: block;
-				position: absolute;
+				position: $pa;
 				left: 230px;
 				max-width: 450px;
 				margin-top: -38px;
@@ -1745,12 +1746,12 @@
 					}
 					&:first-child {
 						a {
-							border-left: 1px solid var(--maxi-grey-light);
+							border-left: $bl;
 						}
 					}
 					&:last-child {
 						a {
-							border-right: 1px solid var(--maxi-grey-light);
+							border-right: $bl;
 						}
 					}
 				}
@@ -1760,19 +1761,19 @@
 				width: auto;
 				height: 31px;
 				padding: 6px 18px;
-				background-color: var(--maxi-cloud-primary-whisper);
-				color: var(--maxi-black);
-				border: 1px solid var(--maxi-cloud-primary);
-				transition: all 0.4s ease !important;
+				background-color: $cpw;
+				color: $bk;
+				border: 1px solid $cp;
+				transition: $t !important;
 				z-index: 100000;
 				font-size: 13px;
 				font-weight: 400;
-				cursor: pointer;
+				cursor: $ptr;
 				border-radius: 30px;
 				&:hover {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-white);
-					border-color: var(--maxi-cloud-primary);
+					background-color: $cp;
+					color: $w;
+					border-color: $cp;
 				}
 			}
 			&__button-connect-pro {
@@ -1786,14 +1787,14 @@
 			&__text_pro {
 				margin: 0;
 				.maxi-username:hover {
-					cursor: pointer;
+					cursor: $ptr;
 				}
 				.maxi-network-license-notice {
 					a {
-						color: var(--maxi-cloud-primary);
-						transition: all 0.4s ease;
+						color: $cp;
+						transition: $t;
 						&:hover {
-							color: var(--maxi-grey-dark);
+							color: $gd;
 						}
 					}
 				}
@@ -1808,17 +1809,17 @@
 					border-radius: 0 !important;
 					border-top-left-radius: 30px !important;
 					border-bottom-left-radius: 30px !important;
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 				}
 
 				.maxi-text-control__input::placeholder {
-					color: var(--maxi-grey-light);
+					color: $gl;
 				}
 				span {
-					position: absolute;
+					position: $pa;
 					padding: 0 5px;
-					color: var(--maxi-cloud-primary);
-					background: var(--maxi-white);
+					color: $cp;
+					background: $w;
 					font-style: italic;
 					font-size: 12px;
 					margin-top: -5px;
@@ -1827,13 +1828,13 @@
 			}
 		}
 		.ais-InfiniteHits-list {
-			position: relative;
+			position: $pr;
 			grid-template-columns: repeat(5, 1fr);
 			margin-top: 0;
 
 			.ais-InfiniteHits-item {
-				background: var(--maxi-white);
-				border: 1px solid var(--maxi-grey-light);
+				background: $w;
+				border: $bl;
 				padding: 0;
 				transition: 0.3s;
 				animation: 1s ease-out 0s 1 opacityAnimation;
@@ -1855,11 +1856,11 @@
 						&:hover {
 							border-radius: 10px;
 							-webkit-box-shadow: 0 0 0 1px
-								var(--maxi-cloud-primary-light);
+								$cpl;
 							box-shadow: 0 0 0 1px
-								var(--maxi-cloud-primary-light);
+								$cpl;
 							background: var(--maxi-off-white) !important;
-							cursor: pointer;
+							cursor: $ptr;
 						}
 					}
 				}
@@ -1868,8 +1869,8 @@
 			.maxi-cloud-masonry-card__image {
 				border: none;
 				padding: 0;
-				background: var(--maxi-white);
-				border: 1px solid var(--maxi-grey-light);
+				background: $w;
+				border: $bl;
 				border-radius: 10px;
 			}
 		}
@@ -1895,9 +1896,9 @@
 		&__sidebar {
 			.ais-RefinementList-item,
 			.ais-HierarchicalMenu-item {
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				&:first-child {
-					border-top: 1px solid var(--maxi-grey-light);
+					border-top: $bl;
 				}
 				.maxi-toggle-switch {
 					margin-bottom: 8px;
@@ -1930,20 +1931,20 @@
 	&__patterns {
 		.ais-InfiniteHits-list {
 			.ais-InfiniteHits-item {
-				background: var(--maxi-cloud-primary-whisper);
+				background: $cpw;
 				&-pro {
-					background: var(--maxi-cloud-primary-whisper);
+					background: $cpw;
 				}
 				&:hover {
-					border-color: var(--maxi-cloud-primary);
-					box-shadow: 0 0 0 1px var(--maxi-cloud-primary);
+					border-color: $cp;
+					box-shadow: 0 0 0 1px $cp;
 					.maxi-cloud-masonry-card__button {
-						border-color: var(--maxi-cloud-primary);
-						box-shadow: 0 0 0 1px var(--maxi-cloud-primary);
-						color: var(--maxi-cloud-primary);
+						border-color: $cp;
+						box-shadow: 0 0 0 1px $cp;
+						color: $cp;
 					}
 					&-go-pro {
-						color: var(--maxi-white);
+						color: $w;
 					}
 				}
 			}
@@ -1960,7 +1961,7 @@
 		.ais-InfiniteHits-list {
 			.ais-InfiniteHits-item {
 				&:hover {
-					border-color: var(--maxi-grey-light) !important;
+					border-color: $gl !important;
 					box-shadow: none !important;
 				}
 			}
@@ -1972,17 +1973,17 @@
 			padding: 0;
 			border: none;
 			margin-right: 15px;
-			color: var(--maxi-black);
-			background-color: transparent;
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			color: $bk;
+			background-color: $tr;
+			font-family: $f !important;
 			font-size: 12px;
 			font-weight: normal;
-			cursor: pointer;
+			cursor: $ptr;
 			&:last-child {
 				margin-right: 0;
 			}
 			&___pressed {
-				color: var(--maxi-cloud-primary);
+				color: $cp;
 				font-weight: 500;
 				border-bottom: 1px solid;
 			}
@@ -2001,31 +2002,31 @@
 			&#maxi-show_button__theme {
 				&:before {
 					content: '';
-					position: absolute;
+					position: $pa;
 					left: -1px;
 					right: -1px;
 					top: -1px;
 					bottom: -1px;
 					display: block;
-					background-color: var(--maxi-cloud-primary);
+					background-color: $cp;
 					z-index: -1;
 					transition: 0.1s;
 					opacity: 0;
 				}
 				&:after {
 					content: '';
-					position: absolute;
+					position: $pa;
 					z-index: 1;
 					left: -1px;
 					top: -1px;
 					bottom: -1px;
 					width: 1px;
 					display: block;
-					background-color: var(--maxi-white);
+					background-color: $w;
 					opacity: 0;
 				}
 				&:hover {
-					color: var(--maxi-white);
+					color: $w;
 					&::before {
 						opacity: 1;
 					}
@@ -2036,40 +2037,40 @@
 			}
 			&:hover,
 			&.ais-Menu-item--selected {
-				background-color: var(--maxi-cloud-primary);
-				color: var(--maxi-white);
-				border-color: var(--maxi-cloud-primary) !important;
+				background-color: $cp;
+				color: $w;
+				border-color: $cp !important;
 				&::after,
 				&::before {
 					opacity: 1 !important;
 				}
 			}
 		}
-		position: relative;
+		position: $pr;
 		outline: none !important;
 		min-width: 88px;
 		height: 31px;
 		padding: 7px 14px;
 		line-height: 16px;
-		border-bottom: 1px solid var(--maxi-grey-light);
-		border-top: 1px solid var(--maxi-grey-light);
+		border-bottom: $bl;
+		border-top: $bl;
 		border-right: none;
 		border-radius: 0;
 		box-shadow: none;
-		color: var(--maxi-black);
-		background-color: var(--maxi-white);
-		font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+		color: $bk;
+		background-color: $w;
+		font-family: $f !important;
 		font-size: 12px;
 		font-weight: 400;
 		text-align: center;
 		text-decoration: none;
-		cursor: pointer;
+		cursor: $ptr;
 		&#maxi-show_button__theme {
-			border-right: 1px solid var(--maxi-grey-light);
+			border-right: $bl;
 		}
 	}
 	.ais-Menu {
-		position: absolute;
+		position: $pa;
 		left: 320px;
 		display: block;
 		margin-top: -10px;
@@ -2085,14 +2086,14 @@
 			}
 			&:first-child {
 				a {
-					border-left: 1px solid var(--maxi-grey-light);
+					border-left: $bl;
 				}
 			}
 		}
 	}
 	&__button-go-pro,
 	&__button-connect-pro {
-		position: absolute;
+		position: $pa;
 		top: 7px;
 		right: 100px;
 		width: auto;
@@ -2103,36 +2104,36 @@
 		line-height: 18px;
 		text-decoration: none !important;
 		font-family: inherit;
-		cursor: pointer;
+		cursor: $ptr;
 		margin: 0;
-		background-color: var(--maxi-cloud-primary);
-		color: var(--maxi-white);
-		border: 1px solid var(--maxi-cloud-primary);
+		background-color: $cp;
+		color: $w;
+		border: 1px solid $cp;
 		border-radius: 5px;
 		transition: 0.1s;
 		font-size: 13px;
 		font-weight: 400;
 		&:hover {
-			background-color: var(--maxi-cloud-primary-whisper);
-			color: var(--maxi-black);
-			border-color: var(--maxi-grey-light);
+			background-color: $cpw;
+			color: $bk;
+			border-color: $gl;
 		}
 		&.download-button {
 			right: 182px;
 			display: flex;
 			align-items: center;
 			padding: 6px 13px !important;
-			border-color: var(--maxi-cloud-primary);
-			box-shadow: 0 0 0 0 var(--maxi-cloud-primary);
-			background-color: var(--maxi-cloud-primary);
-			color: var(--maxi-white);
+			border-color: $cp;
+			box-shadow: 0 0 0 0 $cp;
+			background-color: $cp;
+			color: $w;
 			&:hover {
-				border: 1px solid var(--maxi-grey-light);
-				background-color: var(--maxi-cloud-primary-whisper);
-				color: var(--maxi-black) !important;
+				border: $bl;
+				background-color: $cpw;
+				color: $bk !important;
 				svg {
 					path {
-						fill: var(--maxi-black) !important;
+						fill: $bk !important;
 					}
 				}
 			}
@@ -2156,8 +2157,8 @@
 
 	.ais-InfiniteHits-item {
 		margin: 0 0 1rem 0;
-		background-color: var(--maxi-white);
-		position: relative;
+		background-color: $w;
+		position: $pr;
 
 		.maxi-cloud-masonry-card {
 			&__button-icon,
@@ -2176,7 +2177,7 @@
 					align-items: center;
 					margin-bottom: 8px;
 					.maxi-cloud-masonry__serial-tag {
-						color: var(--maxi-black);
+						color: $bk;
 						font-weight: 500;
 						font-size: 14px;
 						font-family: 'Inter', Helvetica, Arial, Lucida,
@@ -2200,42 +2201,42 @@
 				display: inline-flex;
 				height: 30px;
 				padding: 0 15px;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 				border-radius: 0;
 				margin: 0 5px 0 0;
-				background-color: var(--maxi-cloud-primary-whisper);
+				background-color: $cpw;
 				font-size: 13px;
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
-				color: var(--maxi-black);
+				font-family: $f !important;
+				color: $bk;
 				transition: all 0.1s;
 				line-height: 28px;
 				font-weight: 400;
-				cursor: pointer;
+				cursor: $ptr;
 				&:hover {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-white) !important;
+					background-color: $cp;
+					color: $w !important;
 				}
 			}
 
 			&__tags {
 				display: flex;
 				justify-content: space-between;
-				position: absolute;
+				position: $pa;
 				top: 10px;
 				right: 8px;
 
 				&__tag {
-					position: relative;
+					position: $pr;
 					z-index: 1;
 					display: inline-block;
 					min-width: 26px;
 					padding: 0;
-					color: var(--maxi-black);
+					color: $bk;
 					font-size: 14px;
 					font-weight: bold;
 					text-transform: capitalize;
 					text-align: center;
-					font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+					font-family: $f !important;
 					&-pro {
 						color: var(--maxi-cloud-hover);
 					}
@@ -2265,15 +2266,15 @@
 			}
 
 			&::-webkit-scrollbar-track {
-				background: var(--maxi-cloud-primary-whisper);
+				background: $cpw;
 			}
 
 			&::-webkit-scrollbar-thumb {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 
 			&::-webkit-scrollbar-thumb:hover {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 		}
 	}
@@ -2282,19 +2283,19 @@
 .maxi-cloud-container .maxi-cloud-container__sc {
 	&__content-patterns,
 	&__content-sc {
-		background-color: var(--maxi-white);
+		background-color: $w;
 		margin: 6px 15px;
 		.ais-Stats {
 			margin-bottom: 0;
-			border-bottom: 1px solid var(--maxi-grey-light);
+			border-bottom: $bl;
 		}
 		.ais-Stats-text {
-			color: var(--maxi-black);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			color: $bk;
+			font-family: $f !important;
 			font-weight: 500;
 			font-size: 12px;
 			strong {
-				color: var(--maxi-cloud-primary);
+				color: $cp;
 			}
 		}
 	}
@@ -2306,7 +2307,7 @@
 		&__content-patterns {
 			margin: 0 !important;
 			padding: 0;
-			background-color: var(--maxi-white);
+			background-color: $w;
 		}
 
 		.maxi-cloud-container__sc__content-sc {
@@ -2339,15 +2340,15 @@
 				}
 
 				&::-webkit-scrollbar-track {
-					background: var(--maxi-cloud-primary-whisper);
+					background: $cpw;
 				}
 
 				&::-webkit-scrollbar-thumb {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 
 				&::-webkit-scrollbar-thumb:hover {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 			}
 		}
@@ -2373,15 +2374,15 @@
 				}
 
 				&::-webkit-scrollbar-track {
-					background: var(--maxi-cloud-primary-whisper);
+					background: $cpw;
 				}
 
 				&::-webkit-scrollbar-thumb {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 
 				&::-webkit-scrollbar-thumb:hover {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 			}
 		}
@@ -2398,15 +2399,15 @@
 			margin: 0;
 			.ais-Stats {
 				margin-bottom: 0;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 			}
 			.ais-Stats-text {
-				color: var(--maxi-black);
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+				color: $bk;
+				font-family: $f !important;
 				font-weight: 500;
 				font-size: 12px;
 				strong {
-					color: var(--maxi-cloud-primary);
+					color: $cp;
 				}
 			}
 		}
@@ -2422,7 +2423,7 @@
 	width: 10px !important;
 	bottom: 0;
 	right: 0;
-	position: absolute;
+	position: $pa;
 }
 .maxi-cloud-toolbar__logo {
 	margin-bottom: 0 !important;
@@ -2917,28 +2918,28 @@
 			}
 		}
 		.maxi-cloud-toolbar {
-			position: relative;
+			position: $pr;
 			height: 90px;
 			align-items: center;
 			&__help-button {
-				position: absolute;
+				position: $pa;
 				top: 17px;
 				right: 8px;
 			}
 			&__logo {
 				display: flex !important;
-				position: absolute;
+				position: $pa;
 				top: 7px;
 			}
 			&::before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 45px;
 				left: 0;
 				display: block;
 				width: 100%;
 				height: 1px;
-				background-color: var(--maxi-grey-light);
+				background-color: $gl;
 			}
 		}
 	}
@@ -2979,7 +2980,7 @@
 		min-height: 100%;
 		max-width: 100%;
 		.components-modal__content {
-			position: relative !important;
+			position: $pr !important;
 		}
 		.maxi-cloud-container__content-svg-shape .ais-InfiniteHits-list {
 			grid-template-columns: repeat(2, 1fr);
@@ -3001,7 +3002,7 @@
 						li {
 							width: 49%;
 							&:nth-child(2) {
-								border-top: 1px solid var(--maxi-grey-light);
+								border-top: $bl;
 							}
 							a {
 								font-size: 12px !important;
@@ -3053,7 +3054,7 @@
 					}
 				}
 				&__total {
-					position: absolute;
+					position: $pa;
 					top: -33px;
 					left: 35px;
 				}
@@ -3183,7 +3184,7 @@ html[dir='rtl'] {
 		transform: scaleX(-1);
 	}
 	.maxi-responsive-selector .action-buttons__button.style-card-button {
-		border-left: 1px solid var(--maxi-grey-light);
+		border-left: $bl;
 	}
 	.maxi-responsive-selector .action-buttons__help {
 		margin-left: 0;
@@ -3199,14 +3200,14 @@ body .maxi-hidden {
 .maxi-cloud-container {
 	&__import-popup {
 		&_main-wrap {
-			position: absolute;
+			position: $pa;
 			top: 0;
 			left: 0;
 			right: 0;
 			bottom: 0;
 			//width: 100%;
 			height: 100%;
-			background: var(--maxi-cloud-primary-whisper);
+			background: $cpw;
 			overflow-y: scroll;
 			padding: 40px;
 			max-height: 80vh; // Limit height to 80% of viewport
@@ -3233,7 +3234,7 @@ body .maxi-hidden {
 			h2 {
 				font-size: 26px !important;
 				line-height: 36px !important;
-				color: var(--maxi-black) !important;
+				color: $bk !important;
 				font-weight: 700 !important;
 				font-family: 'Inter' !important;
 				text-align: center;
@@ -3244,7 +3245,7 @@ body .maxi-hidden {
 			p {
 				font-size: 17px !important;
 				line-height: 27px !important;
-				color: var(--maxi-grey) !important;
+				color: $g !important;
 				font-weight: 400 !important;
 				font-family: 'Inter' !important;
 				text-align: center;
@@ -3264,40 +3265,40 @@ body .maxi-hidden {
 		&_toggle-all {
 			width: 15%;
 			margin: 0 auto 20px auto; // Add this to center horizontally
-			background-color: var(--maxi-black);
-			color: var(--maxi-white);
+			background-color: $bk;
+			color: $w;
 			padding: 11px 14px 2px 22px;
 			border-radius: 30px;
 			font-family: 'Inter' !important;
-			transition: all 0.5s ease !important;
+			transition: $t !important;
 			&:hover {
-				background-color: var(--maxi-cloud-primary);
-				color: var(--maxi-white);
+				background-color: $cp;
+				color: $w;
 			}
 		}
 
 		&_section {
-			background: var(--maxi-white);
+			background: $w;
 			padding: 15px 40px 30px 40px;
 			border-radius: 20px;
 
 			h3 {
 				font-size: 21px !important;
 				font-weight: 500 !important;
-				color: var(--maxi-black) !important;
+				color: $bk !important;
 				font-weight: 700 !important;
 				font-family: 'Inter' !important;
 				margin-top: 30px !important;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				padding-bottom: 13px;
 			}
 
 			&-description {
 				font-size: 14px !important;
 				line-height: 160%;
-				color: var(--maxi-grey) !important;
+				color: $g !important;
 				font-family: 'Inter' !important;
-				color: var(--maxi-grey) !important;
+				color: $g !important;
 				margin: 0 0 20px;
 				padding-top: 13px;
 			}
@@ -3307,23 +3308,23 @@ body .maxi-hidden {
 			.maxi-base-control__field {
 				margin-bottom: 10px;
 				flex-direction: row-reverse;
-				transition: all 0.5s ease !important;
+				transition: $t !important;
 				label {
 					margin-left: 15px;
 					font-size: 16px !important;
-					color: var(--maxi-black) !important;
+					color: $bk !important;
 					font-weight: 700 !important;
 					font-family: 'Inter' !important;
-					transition: all 0.5s ease !important;
+					transition: $t !important;
 				}
 				&:hover {
 					label.maxi-base-control__label {
-						color: var(--maxi-cloud-primary) !important;
+						color: $cp !important;
 					}
 
 					input[type='checkbox'],
 					.maxi-toggle-switch__toggle__track {
-						border: 1.5px solid var(--maxi-cloud-primary) !important;
+						border: 1.5px solid $cp !important;
 					}
 				}
 			}
@@ -3334,10 +3335,10 @@ body .maxi-hidden {
 			align-items: flex-start;
 			flex-direction: column;
 			padding: 15px 0;
-			border-bottom: 1px solid var(--maxi-grey-light);
+			border-bottom: $bl;
 			font-size: 14px !important;
 			line-height: 160%;
-			color: var(--maxi-grey) !important;
+			color: $g !important;
 			font-family: 'Inter' !important;
 
 			&:last-child {
@@ -3348,14 +3349,14 @@ body .maxi-hidden {
 			p {
 				font-size: 14px !important;
 				line-height: 160%;
-				color: var(--maxi-grey) !important;
+				color: $g !important;
 				margin: 4px 0 0 0px;
 				font-family: 'Inter' !important;
 			}
 			> p {
 				font-size: 14px !important;
 				line-height: 160%;
-				color: var(--maxi-grey) !important;
+				color: $g !important;
 				font-family: 'Inter' !important;
 			}
 		}
@@ -3370,28 +3371,28 @@ body .maxi-hidden {
 
 		&_status-text {
 			font-size: 16px;
-			border: solid 2px var(--maxi-cloud-primary);
+			border: solid 2px $cp;
 			padding: 5px;
 		}
 
 		&_button {
 			&-import {
 				border-radius: 20px !important;
-				background-color: var(--maxi-black);
+				background-color: $bk;
 				border: none !important;
-				color: var(--maxi-white);
+				color: $w;
 				padding: 15px 80px;
 				border-radius: 60px !important;
 				font-size: 14px;
 				font-weight: 500;
-				cursor: pointer;
+				cursor: $ptr;
 				transition: all 0.2s ease;
 				font-weight: 700 !important;
 				font-family: 'Inter' !important;
 				margin: 0 auto; // Add this to center horizontally
 
 				&:hover:not(:disabled) {
-					background-color: var(--maxi-cloud-primary);
+					background-color: $cp;
 				}
 
 				&:disabled {
@@ -3434,11 +3435,11 @@ body .maxi-hidden {
 			font-size: 13px;
 
 			a {
-				color: var(--maxi-cloud-primary);
+				color: $cp;
 				text-decoration: underline;
 
 				&:hover {
-					color: var(--maxi-cloud-primary);
+					color: $cp;
 				}
 			}
 		}

--- a/src/blocks/accordion-maxi/editor.scss
+++ b/src/blocks/accordion-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 [class*='maxi-border-status-active'],
 [class*='maxi-background-status-active'],
 [class*='maxi-box-shadow-status-active'],
@@ -11,15 +12,15 @@
 
 .maxi-skin-control__reveal-action-tabs {
 	.components-button {
-		background: var(--maxi-white);
+		background: $w;
 		border: none;
 		border-radius: 10px;
 		padding: 6px 12px;
 		margin: 0;
 		min-width: 70px;
 		height: 30px;
-		box-shadow: 0 0 0 1px var(--maxi-grey-light);
-		color: var(--maxi-grey-dark);
+		box-shadow: 0 0 0 1px $gl;
+		color: $gd;
 		transition: all 0.2s ease;
 
 		&:first-child {
@@ -30,16 +31,16 @@
 		}
 
 		&:hover {
-			background: var(--maxi-white);
-			box-shadow: 0 0 0 1px var(--maxi-primary-color);
-			color: var(--maxi-primary-color);
+			background: $w;
+			box-shadow: 0 0 0 1px $pc;
+			color: $pc;
 		}
 
 		&:active,
 		&[aria-pressed='true'] {
-			background: var(--maxi-primary-color) !important;
-			box-shadow: 0 0 0 1px var(--maxi-primary-color) !important;
-			color: var(--maxi-white) !important;
+			background: $pc !important;
+			box-shadow: 0 0 0 1px $pc !important;
+			color: $w !important;
 		}
 	}
 }
@@ -48,15 +49,15 @@
 }
 .maxi-icon-control__position {
 	.maxi-tabs-control__button {
-		background: var(--maxi-white);
-		border: 1.5px solid var(--maxi-grey-light);
+		background: $w;
+		border: $bg;
 		border-radius: 6px !important;
 		padding: 6px 6px;
 		margin-right: 2px !important;
 		min-width: 65px;
 		height: 30px !important;
 		box-shadow: none;
-		color: var(--maxi-grey-dark);
+		color: $gd;
 		transition: all 0.2s ease;
 		text-align: center;
 		justify-content: center;
@@ -68,23 +69,23 @@
 			margin-left: 0px !important;
 		}
 		&:last-child {
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 		}
 
 		&:hover {
-			background: var(--maxi-white);
+			background: $w;
 			box-shadow: none;
-			background: var(--maxi-pastel-green) !important;
-			color: var(--maxi-black);
+			background: $pg !important;
+			color: $bk;
 		}
 
 		&:active,
 		&--selected,
 		&[aria-pressed='true'] {
-			background: var(--maxi-whisper-green) !important;
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			background: $wg !important;
+			border: $bg !important;
 			box-shadow: none;
-			color: var(--maxi-grey-dark) !important;
+			color: $gd !important;
 			font-weight: 700;
 		}
 	}

--- a/src/blocks/accordion-maxi/style.scss
+++ b/src/blocks/accordion-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-block {
 	display: flex;
 	flex-direction: column;

--- a/src/blocks/button-maxi/editor.scss
+++ b/src/blocks/button-maxi/editor.scss
@@ -1,28 +1,29 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-sidebar {
 	.maxi-button-default-styles {
 		display: flex;
 		flex-wrap: wrap;
 
 		.maxi-default-styles-control__button {
-			position: relative;
+			position: $pr;
 			width: calc(100% / 3);
 			height: auto !important;
 			padding: 6px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 10px;
 			margin-bottom: 10px;
-			transition: all 0.4s ease;
+			transition: $t;
 
 			&:focus {
-				background: var(--maxi-grey);
+				background: $g;
 			}
 			&:hover {
-				border: 1.5px solid var(--maxi-primary-color);
-				background: var(--maxi-whisper-green);
+				border: 1.5px solid $pc;
+				background: $wg;
 
 				&::after {
 					content: '';
-					position: absolute;
+					position: $pa;
 					bottom: 0;
 					left: 0;
 					width: 100%;
@@ -31,7 +32,7 @@ body.maxi-blocks--active .maxi-sidebar {
 			&:nth-child(6) {
 				svg {
 					border-radius: 10px;
-					box-shadow: 0 0 8px 0 var(--maxi-grey);
+					box-shadow: 0 0 8px 0 $g;
 				}
 			}
 			&:nth-child(n + 7) {

--- a/src/blocks/button-maxi/style.scss
+++ b/src/blocks/button-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-button-block {
 	display: flex;
 	text-align: center;
@@ -18,7 +19,7 @@ body.maxi-blocks--active .maxi-button-block {
 		}
 	}
 	&__content {
-		position: relative;
+		position: $pr;
 		z-index: 1;
 		display: block;
 		order: 1;
@@ -26,7 +27,7 @@ body.maxi-blocks--active .maxi-button-block {
 		min-width: 1px;
 	}
 	&__button {
-		position: relative;
+		position: $pr;
 		display: flex;
 		align-items: center;
 		height: auto;

--- a/src/blocks/cloud-maxi/editor.scss
+++ b/src/blocks/cloud-maxi/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../src/css/backend-variables.scss';
 /**
  * Editor styles for the admin
  */
 
-$white: var(--maxi-white);
+$white: $w;
 
 .maxi-block-library__modal {
 	width: 80%;
@@ -10,11 +11,11 @@ $white: var(--maxi-white);
 	max-width: 90%;
 
 	.components-modal__content {
-		background: var(--maxi-cloud-primary-whisper);
+		background: $cpw;
 		padding: 0;
 		overflow-x: hidden;
 		min-height: 100%;
-		position: absolute;
+		position: $pa;
 		width: 100%;
 	}
 
@@ -32,7 +33,7 @@ $white: var(--maxi-white);
 	.components-tab-panel__tab-content {
 		background: $white;
 		padding: 35px;
-		border-top: 1px solid var(--maxi-grey-light);
+		border-top: $bl;
 	}
 
 	.components-tab-panel__tabs {
@@ -47,7 +48,7 @@ $white: var(--maxi-white);
 
 			&:hover {
 				background: $white;
-				cursor: pointer;
+				cursor: $ptr;
 			}
 		}
 	}
@@ -55,7 +56,7 @@ $white: var(--maxi-white);
 	.components-tab-panel__tabs .maxi-block-library__modal-active-tab {
 		font-weight: 600;
 		background: $white;
-		border: 1px solid var(--maxi-grey-light);
+		border: $bl;
 		border-bottom: none;
 	}
 
@@ -68,7 +69,7 @@ $white: var(--maxi-white);
 	}
 
 	.maxi-block-library__modal-header {
-		background: var(--maxi-grey-light);
+		background: $gl;
 		padding: 20px;
 		margin-bottom: 20px;
 		display: grid;
@@ -132,7 +133,7 @@ $white: var(--maxi-white);
 	.maxi-cloud-design {
 		text-align: center;
 		margin-bottom: 40px;
-		position: relative;
+		position: $pr;
 
 		img {
 			max-width: 100%;
@@ -147,24 +148,24 @@ $white: var(--maxi-white);
 			border-bottom: none;
 			padding: 0;
 			z-index: 5;
-			position: relative;
+			position: $pr;
 		}
 	}
 
 	.maxi-cloud-design-inside {
 		transition: 0.2s ease;
-		border: solid 1px var(--maxi-grey-light);
+		border: solid 1px $gl;
 
 		&:hover {
-			box-shadow: 0px 0px 0px 8px var(--maxi-grey-light);
+			box-shadow: 0px 0px 0px 8px $gl;
 		}
 	}
 
 	.maxi-cloud-design-info {
 		background: $white;
-		border-top: solid 1px var(--maxi-grey-light);
+		border-top: solid 1px $gl;
 		text-align: left;
-		position: relative;
+		position: $pr;
 		padding: 12px;
 
 		button {
@@ -195,24 +196,24 @@ $white: var(--maxi-white);
 	button.maxi-cloud-favorite-button:hover {
 		background: $white;
 		border: none;
-		box-shadow: inset 0 0 0 1px var(--maxi-grey-light),
+		box-shadow: inset 0 0 0 1px $gl,
 			inset 0 0 0 2px $white, 0 1px 1px rgba(25, 30, 35, 0.2);
 	}
 
 	.components-button-group
 		.components-button.maxi-cloud-favorite-button:focus {
-		box-shadow: inset 0 0 0 1px var(--maxi-grey-light),
+		box-shadow: inset 0 0 0 1px $gl,
 			inset 0 0 0 2px $white, 0 1px 1px rgba(25, 30, 35, 0.2);
 		background: $white;
 	}
 
 	button.components-button.is-default:active:enabled {
-		box-shadow: inset 0 0 0 1px var(--maxi-grey-light),
+		box-shadow: inset 0 0 0 1px $gl,
 			inset 0 0 0 2px $white;
 	}
 
 	.maxi-cloud-icon-favorite {
-		fill: var(--maxi-grey);
+		fill: $g;
 	}
 
 	.maxi-cloud-icon-favorite-active {
@@ -220,7 +221,7 @@ $white: var(--maxi-white);
 	}
 
 	.maxi-cloud-zoom-button {
-		position: absolute;
+		position: $pa;
 		top: 15px;
 		right: 15px;
 		background: $white;
@@ -245,7 +246,7 @@ $white: var(--maxi-white);
 	}
 
 	.maxi-block-library__modal__loading_message {
-		position: absolute;
+		position: $pa;
 		top: 0;
 		bottom: 0;
 		left: 0;
@@ -274,10 +275,10 @@ $white: var(--maxi-white);
 	justify-content: center;
 	width: 100%;
 	min-height: 120px;
-	color: var(--maxi-grey-dark);
-	background-color: var(--maxi-cloud-primary-whisper);
+	color: $gd;
+	background-color: $cpw;
 	font-size: 13px;
-	border: 1px solid var(--maxi-cloud-primary-light);
+	border: 1px solid $cpl;
 	border-radius: 10px;
 	box-shadow: none !important;
 	.components-placeholder__instructions {
@@ -290,13 +291,13 @@ $white: var(--maxi-white);
 
 	button.maxi-block-library__modal-button__placeholder {
 		overflow: hidden;
-		color: var(--maxi-white);
-		background: var(--maxi-cloud-primary);
+		color: $w;
+		background: $cp;
 		font-family: Inter, sans-serif;
 		font-size: 12px;
 		font-weight: 800;
 		padding: 22px 22px 22px 20px;
-		border: 1px solid var(--maxi-grey-light);
+		border: $bl;
 		transition: all 0.1s;
 		border-radius: 30px;
 		display: flex;
@@ -308,7 +309,7 @@ $white: var(--maxi-white);
 		}
 
 		&:hover {
-			background: var(--maxi-white) !important;
+			background: $w !important;
 			color: var(--maxi-cloud-primary-contrast) !important;
 			border-color: var(--maxi-tertiary-color);
 		}

--- a/src/blocks/cloud-maxi/style.scss
+++ b/src/blocks/cloud-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 /**
  * Layout styles
  * Loads on front end and back end

--- a/src/blocks/column-maxi/editor.scss
+++ b/src/blocks/column-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-column-size-control {
 	.components-base-control__field {
 		flex-direction: column;
@@ -16,7 +17,7 @@
 		&.has-child-selected {
 			&::after {
 				opacity: 1;
-				border-color: var(--maxi-primary-color) !important;
+				border-color: $pc !important;
 			}
 		}
 

--- a/src/blocks/column-maxi/style.scss
+++ b/src/blocks/column-maxi/style.scss
@@ -1,7 +1,8 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active div.maxi-column-block {
 	display: inline-flex;
 	flex-direction: column;
-	position: relative;
+	position: $pr;
 	height: auto;
 	margin: 0;
 	box-sizing: border-box;

--- a/src/blocks/container-maxi/components/shape-divider-control/editor.scss
+++ b/src/blocks/container-maxi/components/shape-divider-control/editor.scss
@@ -1,13 +1,14 @@
+@import '../../../../../src/css/backend-variables.scss';
 body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	.maxi-shape-divider-control {
 		&__shape-selector {
 			&__display {
-				border-color: var(--maxi-grey);
+				border-color: $g;
 
 				&:focus {
-					border-color: var(--maxi-secondary-color);
-					box-shadow: 0 0 0 1px var(--maxi-secondary-color);
-					outline: 2px solid transparent;
+					border-color: $sc;
+					box-shadow: 0 0 0 1px $sc;
+					outline: 2px solid $tr;
 				}
 			}
 		}
@@ -33,12 +34,12 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			&:focus,
 			&--selected {
 				border: none;
-				background-color: var(--maxi-white) !important;
+				background-color: $w !important;
 				box-shadow: none;
 				outline: none;
 
 				svg {
-					fill: var(--maxi-secondary-color);
+					fill: $sc;
 				}
 			}
 		}
@@ -51,15 +52,15 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			display: block;
 			width: 100%;
 			padding: 18px 0;
-			border: 1px solid var(--maxi-mid-green);
+			border: 1px solid $mg;
 			border-radius: 4px !important;
-			background-color: var(--maxi-whisper-green);
+			background-color: $wg;
 			text-align: center;
 			transition: all 0.5s;
-			cursor: pointer;
+			cursor: $ptr;
 
 			&:hover {
-				border-color: var(--maxi-grey);
+				border-color: $g;
 			}
 		}
 	}

--- a/src/blocks/container-maxi/editor.scss
+++ b/src/blocks/container-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-container-block {
 	margin: auto;
 

--- a/src/blocks/container-maxi/style.scss
+++ b/src/blocks/container-maxi/style.scss
@@ -1,7 +1,8 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-container-block {
 	display: flex;
 	flex-direction: column;
-	position: relative;
+	position: $pr;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 0;

--- a/src/blocks/divider-maxi/style.scss
+++ b/src/blocks/divider-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-divider-block {
 	display: flex;
 	justify-content: center;
@@ -16,7 +17,7 @@ body.maxi-blocks--active .maxi-divider-block {
 	}
 	hr {
 		border: 0;
-		position: relative;
+		position: $pr;
 		background: none;
 
 		&:before,

--- a/src/blocks/group-maxi/editor.scss
+++ b/src/blocks/group-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-group-block {
 	margin: auto;
 }

--- a/src/blocks/group-maxi/style.scss
+++ b/src/blocks/group-maxi/style.scss
@@ -1,7 +1,8 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-group-block {
 	display: flex;
 	flex-direction: column;
-	position: relative;
+	position: $pr;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 0;

--- a/src/blocks/image-maxi/components/hover-effect-control/editor.scss
+++ b/src/blocks/image-maxi/components/hover-effect-control/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-hover-effect-control__tabs {
 	.maxi-tabs-control__button {
 		padding: 0;
 		height: 40px;
 		width: 40px;
 		min-width: 40px;
-		background: var(--maxi-white);
-		border: 1.5px solid var(--maxi-grey-light);
+		background: $w;
+		border: $bg;
 		border-radius: 3px;
 		box-shadow: none;
 		line-height: 1;
@@ -24,30 +25,30 @@
 		&.is-active,
 		&.maxi-tabs-control__button--selected {
 			background: var(--maxi-mid-color);
-			border-color: var(--maxi-secondary-color);
-			color: var(--maxi-secondary-color);
+			border-color: $sc;
+			color: $sc;
 
 			svg {
 				path {
-					fill: var(--maxi-secondary-color);
+					fill: $sc;
 				}
 				stroke {
-					stroke: var(--maxi-secondary-color);
+					stroke: $sc;
 				}
 			}
 		}
 
 		&:hover {
-			background: var(--maxi-whisper-green);
-			border-color: var(--maxi-secondary-color);
-			color: var(--maxi-secondary-color);
+			background: $wg;
+			border-color: $sc;
+			color: $sc;
 
 			svg {
 				path {
-					fill: var(--maxi-secondary-color);
+					fill: $sc;
 				}
 				stroke {
-					stroke: var(--maxi-secondary-color);
+					stroke: $sc;
 				}
 			}
 		}
@@ -73,7 +74,7 @@
 	.maxi-tabs-control__button {
 		border-radius: 3px;
 		margin: 0; // Spacing handled by container gap
-		border: 1.5px solid var(--maxi-grey-light) !important;
+		border: $bg !important;
 		padding: 0; // Match top icons
 		height: 40px; // Uniform size
 		width: 40px; // Uniform size
@@ -91,12 +92,12 @@
 		// Active state: emphasize with secondary color border
 		&.is-active,
 		&.maxi-tabs-control__button--selected {
-			border-color: var(--maxi-secondary-color) !important;
+			border-color: $sc !important;
 		}
 
 		// Hover state: emphasize with secondary color border
 		&:hover {
-			border-color: var(--maxi-secondary-color) !important;
+			border-color: $sc !important;
 		}
 
 		svg {

--- a/src/blocks/image-maxi/editor.scss
+++ b/src/blocks/image-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 @import './components/hover-effect-control/editor';
 
 body.maxi-blocks--active .maxi-image-block {
@@ -23,16 +24,16 @@ body.maxi-blocks--active .maxi-image-block {
 	&__caption {
 		width: 100% !important;
 		padding-left: 1px;
-		border: 1.5px dashed transparent;
+		border: 1.5px dashed $tr;
 
 		&:hover,
 		&:focus {
-			border-color: var(--maxi-whisper-green);
+			border-color: $wg;
 		}
 	}
 
 	&__placeholder {
-		position: relative;
+		position: $pr;
 
 		.components-placeholder__label {
 			margin: 0;

--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -578,7 +578,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					transform: scale(1);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -591,7 +591,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					transform: scale(1.5);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -604,7 +604,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					transform: translateX(0);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -617,7 +617,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					transform: rotate(0);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -630,7 +630,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					filter: blur(0);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -643,7 +643,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					filter: grayscale(0);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -656,7 +656,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					filter: grayscale(100%);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -669,7 +669,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					filter: sepia(0);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,
@@ -682,7 +682,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 				img,
 				svg {
 					filter: sepia(100%);
-					transition: 0.3s ease-in-out;
+					@include transit;
 				}
 				&:hover {
 					img,

--- a/src/blocks/image-maxi/style.scss
+++ b/src/blocks/image-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active figure.maxi-image-block {
 	display: flex;
 	justify-content: center;
@@ -24,7 +25,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 	}
 	.maxi-image-block-wrapper {
 		display: flex;
-		position: relative;
+		position: $pr;
 		width: auto;
 		max-width: 100%;
 		max-height: inherit;
@@ -36,7 +37,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 			overflow: hidden;
 
 			.maxi-image-block__image {
-				position: absolute;
+				position: $pa;
 				top: 0;
 				left: 0;
 				max-width: none;
@@ -54,7 +55,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 	}
 	.maxi-image-block {
 		&__caption {
-			position: relative;
+			position: $pr;
 			margin: 0;
 			text-align: left;
 		}
@@ -63,7 +64,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 		background-color: #000;
 
 		&:not(.maxi-hover-effect__text__flip-horiz) {
-			position: absolute;
+			position: $pa;
 			top: 0;
 			left: 0;
 			right: 0;
@@ -544,7 +545,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 					);
 				}
 				.maxi-hover-details {
-					position: absolute;
+					position: $pa;
 					left: 0;
 					top: 0;
 					bottom: 0;
@@ -702,7 +703,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 			&__shine {
 				&:before {
 					content: '';
-					position: absolute;
+					position: $pa;
 					top: 0;
 					left: -75%;
 					z-index: 2;
@@ -725,7 +726,7 @@ body.maxi-blocks--active figure.maxi-image-block {
 			&__circle-shine {
 				&:before {
 					content: '';
-					position: absolute;
+					position: $pa;
 					top: 50%;
 					left: 50%;
 					z-index: 2;

--- a/src/blocks/list-item-maxi/editor.scss
+++ b/src/blocks/list-item-maxi/editor.scss
@@ -1,19 +1,20 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-list-item-block {
-	outline: 2px dashed var(--maxi-mid-green) !important;
+	outline: 2px dashed $mg !important;
 
 	&__has-text {
-		outline: 2px dashed transparent !important;
+		outline: 2px dashed $tr !important;
 
 		&:hover {
-			outline: 1.5px solid var(--maxi-mid-green) !important;
+			outline: 1.5px solid $mg !important;
 		}
 		&.is-selected {
-			outline: 1.5px solid var(--maxi-whisper-green) !important;
+			outline: 1.5px solid $wg !important;
 		}
 	}
 
 	.rich-text:focus * {
-		background-color: transparent !important;
+		background-color: $tr !important;
 	}
 	&__content {
 		a.maxi-list-item-block--link {
@@ -36,31 +37,31 @@
 
 		&:hover {
 			border-radius: 0 !important;
-			outline: 1.5px solid var(--maxi-mid-green) !important;
+			outline: 1.5px solid $mg !important;
 		}
 	}
 
 	&--backend {
 		&:hover {
 			border-radius: 0 !important;
-			outline: 1.5px solid var(--maxi-mid-green) !important;
+			outline: 1.5px solid $mg !important;
 		}
 	}
 }
 
 .maxi-text-block {
 	&__has-text {
-		outline: 1.5px dashed transparent !important;
+		outline: 1.5px dashed $tr !important;
 
 		&:hover {
-			outline: 1.5px dashed var(--maxi-primary-color) !important;
+			outline: 1.5px dashed $pc !important;
 		}
 		&.is-selected {
-			outline: 1.5px dashed var(--maxi-primary-color) !important;
+			outline: 1.5px dashed $pc !important;
 		}
 	}
 
 	.rich-text:focus * {
-		background-color: transparent !important;
+		background-color: $tr !important;
 	}
 }

--- a/src/blocks/list-item-maxi/style.scss
+++ b/src/blocks/list-item-maxi/style.scss
@@ -1,9 +1,10 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-list-item-block {
 	& * {
 		border-color: inherit;
 	}
 	&__content {
-		position: relative;
+		position: $pr;
 		margin: 0;
 	}
 	p:not([class*='__content']):not(.maxi-pane-block__title):not(.wp-block):not(.maxi-block--use-sc) {

--- a/src/blocks/map-maxi/editor.scss
+++ b/src/blocks/map-maxi/editor.scss
@@ -1,16 +1,17 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-map-block {
 	&__not-found {
 		padding: 5% 8%;
-		border: 1px solid var(--maxi-grey-light);
-		background-color: var(--maxi-whisper-green);
+		border: $bl;
+		background-color: $wg;
 		p {
 			max-width: 820px;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 			font-size: 16px;
 			font-family: Inter, sans-serif;
 			line-height: 1.5em;
 			a {
-				color: var(--maxi-secondary-color);
+				color: $sc;
 			}
 		}
 	}
@@ -21,7 +22,7 @@
 	}
 
 	&__alert {
-		position: absolute;
+		position: $pa;
 		bottom: 16px;
 		width: calc(100% - 32px);
 		left: 16px;
@@ -29,8 +30,8 @@
 		font-size: 13px;
 		padding: 0.5em;
 		text-align: center;
-		background: rgba(var(--maxi-black), 0.6);
-		color: var(--maxi-white);
+		background: rgba($bk, 0.6);
+		color: $w;
 		z-index: 9999;
 	}
 
@@ -66,22 +67,22 @@
 	&__popup {
 		&__content {
 			&__marker-remove {
-				position: absolute;
+				position: $pa;
 				right: 0;
 				bottom: -16px;
-				background: var(--maxi-primary-color);
+				background: $pc;
 				border-radius: 50%;
 				text-align: center;
-				transition: all 0.4s ease !important;
+				transition: $t !important;
 
 				span.dashicon {
 					&::before {
-						color: var(--maxi-white);
+						color: $w;
 					}
 				}
 				&:hover {
-					background: var(--maxi-black);
-					transition: all 0.4s ease !important;
+					background: $bk;
+					transition: $t !important;
 				}
 			}
 		}
@@ -90,13 +91,13 @@
 	&__search-box {
 		display: flex;
 		align-items: center;
-		background: var(--maxi-white);
-		color: var(--maxi-grey-dark);
-		position: absolute;
+		background: $w;
+		color: $gd;
+		position: $pa;
 		z-index: 999;
 		top: 0.5rem;
 		right: 0.5rem;
-		border: 1px solid var(--maxi-grey-dark);
+		border: 1px solid $gd;
 		padding: 0 0 0 0.5rem;
 		width: 280px;
 		max-width: calc(100% - 5rem);
@@ -111,9 +112,9 @@
 		}
 
 		.maxi-text-input[type='text'] {
-			background: transparent;
+			background: $tr;
 			border: none;
-			color: var(--maxi-black);
+			color: $bk;
 			box-shadow: none;
 			font-family: inherit;
 			padding: 0;
@@ -121,26 +122,26 @@
 		}
 
 		svg.dashicon {
-			fill: var(--maxi-black);
+			fill: $bk;
 		}
 
 		&__button {
-			border-top: 1px solid var(--maxi-grey-light);
+			border-top: $bl;
 			display: flex;
 			padding: 0.7rem 0;
 			margin: 0 0.5rem;
 		}
 
 		&-results {
-			position: absolute;
+			position: $pa;
 			z-index: 999;
-			background: var(--maxi-white);
+			background: $w;
 			top: 0;
 			transition: all 200ms ease-in-out;
 			max-width: calc(100% - 5rem);
 			top: 48px;
 			right: 0.5rem;
-			border: 1px solid var(--maxi-grey-dark);
+			border: 1px solid $gd;
 			width: 280px;
 			max-height: calc(100% - 70px);
 			overflow-y: auto;

--- a/src/blocks/map-maxi/style.scss
+++ b/src/blocks/map-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 @import '~leaflet/dist/leaflet.css';
 
 body.maxi-blocks--active .maxi-map-block {
@@ -21,8 +22,8 @@ body.maxi-blocks--active .maxi-map-block {
 	}
 
 	.leaflet-div-icon {
-		background-color: transparent;
-		border: transparent;
+		background-color: $tr;
+		border: $tr;
 		animation: animate-marker 400ms ease-in-out;
 	}
 
@@ -33,7 +34,7 @@ body.maxi-blocks--active .maxi-map-block {
 		display: block;
 		width: 17px;
 		height: 17px;
-		background-color: var(--maxi-white);
+		background-color: $w;
 		border-radius: 50%;
 		transition: 0.1s;
 		span {
@@ -42,9 +43,9 @@ body.maxi-blocks--active .maxi-map-block {
 			transition: 0.1s;
 		}
 		&:hover {
-			background-color: var(--maxi-grey-dark);
+			background-color: $gd;
 			span {
-				color: var(--maxi-white);
+				color: $w;
 			}
 		}
 	}
@@ -55,7 +56,7 @@ body.maxi-blocks--active .maxi-map-block {
 
 	.leaflet-popup-content-wrapper {
 		text-align: center;
-		background: transparent;
+		background: $tr;
 		box-shadow: none;
 	}
 
@@ -69,13 +70,13 @@ body.maxi-blocks--active .maxi-map-block {
 	&__popup {
 		width: 100%;
 		height: 100%;
-		position: relative;
+		position: $pr;
 		box-sizing: content-box !important;
 		left: 5px;
 		border-radius: 16px;
 
 		&__background {
-			position: absolute;
+			position: $pa;
 			width: 100%;
 			height: 100%;
 			z-index: -1;
@@ -86,7 +87,7 @@ body.maxi-blocks--active .maxi-map-block {
 		&__content {
 			min-width: 100px;
 			padding: 32px;
-			position: relative;
+			position: $pr;
 			z-index: 10;
 
 			&__title {
@@ -99,11 +100,11 @@ body.maxi-blocks--active .maxi-map-block {
 
 		&::before {
 			content: '';
-			position: absolute;
+			position: $pa;
 			width: 0;
 			height: 0;
 			border-style: solid;
-			border-color: transparent;
+			border-color: $tr;
 			bottom: 0;
 			left: 50%;
 			transform: translate(-50%, 100%);

--- a/src/blocks/number-counter-maxi/components/number-counter-control/editor.scss
+++ b/src/blocks/number-counter-maxi/components/number-counter-control/editor.scss
@@ -1,6 +1,7 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-number-counter-control {
 	&__alert-warning {
-		color: var(--maxi-grey-dark) !important;
+		color: $gd !important;
 		background: var(--maxi-light-yellow);
 		border: 1px solid var(--maxi-deep-golden);
 		padding: 0.5rem;

--- a/src/blocks/number-counter-maxi/style.scss
+++ b/src/blocks/number-counter-maxi/style.scss
@@ -1,9 +1,10 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-number-counter-block {
 	// This element doesn't exist anymore
 	display: flex;
 	.maxi-number-counter {
 		&__box {
-			position: relative;
+			position: $pr;
 			z-index: 2;
 			width: 100%;
 			max-width: 100%;
@@ -17,7 +18,7 @@ body.maxi-blocks--active .maxi-number-counter-block {
 			// Fixes issues coming from #4309 as the CSS is not migrated
 			svg + .maxi-number-counter__box__text {
 				text-align: center;
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 50%;
 				transform: translate(-50%, -50%);

--- a/src/blocks/pane-maxi/style.scss
+++ b/src/blocks/pane-maxi/style.scss
@@ -1,6 +1,7 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-pane-block {
 	&__header {
-		position: relative;
+		position: $pr;
 	}
 
 	&__header-content {
@@ -13,7 +14,7 @@ body.maxi-blocks--active .maxi-pane-block {
 	}
 
 	&__icon {
-		cursor: pointer;
+		cursor: $ptr;
 	}
 
 	&__line-container {

--- a/src/blocks/row-maxi/components/column-pattern/editor.scss
+++ b/src/blocks/row-maxi/components/column-pattern/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../../../src/css/backend-variables.scss';
 .components-column-pattern {
 	&__icon {
 		width: 100%;
 		height: 100%;
 		overflow: visible;
 		path {
-			fill: var(--maxi-white);
-			stroke: var(--maxi-grey-dark);
+			fill: $w;
+			stroke: $gd;
 			stroke-width: 1.5px !important;
 		}
 	}
@@ -15,7 +16,7 @@
 	&__templates {
 		margin-bottom: 5px;
 		& .components-column-pattern-apply_settings {
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			justify-content: center;
 		}
 	}
@@ -24,35 +25,35 @@
 		padding: 0 5px;
 
 		&:active {
-			color: var(--maxi-primary-color) !important;
+			color: $pc !important;
 		}
 
 		&:hover {
-			border-color: var(--maxi-primary-color);
-			color: var(--maxi-primary-color);
+			border-color: $pc;
+			color: $pc;
 			svg path {
-				stroke: var(--maxi-primary-color) !important;
+				stroke: $pc !important;
 			}
 		}
 
 		&[aria-pressed='true'] {
-			color: var(--maxi-primary-color);
-			border-color: var(--maxi-primary-color);
+			color: $pc;
+			border-color: $pc;
 			svg path {
-				stroke: var(--maxi-primary-color);
+				stroke: $pc;
 			}
 		}
 
 		&--toolbar {
 			&:hover {
 				svg path {
-					fill: var(--maxi-primary-color);
+					fill: $pc;
 				}
 			}
 
 			&[aria-pressed='true'] {
 				svg path {
-					fill: var(--maxi-primary-color);
+					fill: $pc;
 				}
 			}
 
@@ -66,9 +67,9 @@
 			margin-bottom: 10px;
 			margin-top: -10px;
 			&:hover {
-				background-color: var(--maxi-mid-green);
-				color: var(--maxi-white);
-				border-color: var(--maxi-primary-color);
+				background-color: $mg;
+				color: $w;
+				border-color: $pc;
 			}
 		}
 	}

--- a/src/blocks/row-maxi/editor.scss
+++ b/src/blocks/row-maxi/editor.scss
@@ -1,6 +1,7 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-row-block {
 	.editor-styles-wrapper & {
-		position: relative;
+		position: $pr;
 		flex-wrap: wrap;
 		z-index: 2;
 		width: 100%;
@@ -16,7 +17,7 @@
 
 			span {
 				font-size: 16px;
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+				font-family: $f !important;
 				font-weight: 700;
 			}
 		}
@@ -33,7 +34,7 @@
 			max-width: 1170px;
 			margin: 0 auto;
 			padding: 16px 1rem 36px 1rem;
-			background-color: transparent;
+			background-color: $tr;
 		}
 
 		&__button {
@@ -45,8 +46,8 @@
 
 				&:hover {
 					svg {
-						stroke: var(--maxi-primary-color);
-						fill: var(--maxi-white);
+						stroke: $pc;
+						fill: $w;
 						filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.3));
 					}
 				}
@@ -81,7 +82,7 @@
 	}
 
 	button svg {
-		transition: all 0.3s ease;
+		transition: $t;
 	}
 }
 

--- a/src/blocks/row-maxi/style.scss
+++ b/src/blocks/row-maxi/style.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-row-block {
-	position: relative;
+	position: $pr;
 	display: flex;
 	flex-direction: row;
 

--- a/src/blocks/search-maxi/editor.scss
+++ b/src/blocks/search-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-search-block {
 	align-items: center;
 	overflow: hidden;
@@ -30,15 +31,15 @@
 
 .maxi-skin-control__reveal-action-tabs {
 	.components-button {
-		background: var(--maxi-white);
+		background: $w;
 		border: none;
 		border-radius: 10px;
 		padding: 6px 12px;
 		margin: 0;
 		min-width: 70px;
 		height: 30px;
-		box-shadow: 0 0 0 1px var(--maxi-grey-light);
-		color: var(--maxi-grey-dark);
+		box-shadow: 0 0 0 1px $gl;
+		color: $gd;
 		transition: all 0.2s ease;
 
 		&:first-child {
@@ -49,16 +50,16 @@
 		}
 
 		&:hover {
-			background: var(--maxi-white);
-			box-shadow: 0 0 0 1px var(--maxi-primary-color);
-			color: var(--maxi-primary-color);
+			background: $w;
+			box-shadow: 0 0 0 1px $pc;
+			color: $pc;
 		}
 
 		&:active,
 		&[aria-pressed='true'] {
-			background: var(--maxi-whisper-green) !important;
-			box-shadow: 0 0 0 1px var(--maxi-mid-green) !important;
-			color: var(--maxi-grey-dark) !important;
+			background: $wg !important;
+			box-shadow: 0 0 0 1px $mg !important;
+			color: $gd !important;
 			font-weight: 700;
 		}
 	}

--- a/src/blocks/search-maxi/style.scss
+++ b/src/blocks/search-maxi/style.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-search-block {
-	position: relative;
+	position: $pr;
 	display: flex;
 	align-items: center;
 	height: auto;
@@ -73,7 +74,7 @@ body.maxi-blocks--active .maxi-search-block {
 		display: flex;
 		align-items: center;
 		z-index: 1;
-		cursor: pointer;
+		cursor: $ptr;
 		height: 100%;
 		aspect-ratio: 1 / 1;
 		justify-content: center;

--- a/src/blocks/slide-maxi/editor.scss
+++ b/src/blocks/slide-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .edit-post-visual-editor {
 	.maxi-slide-block.wp-block {
 		max-width: inherit;

--- a/src/blocks/slide-maxi/style.scss
+++ b/src/blocks/slide-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-slide-block {
 	display: inline-flex;
 	flex-direction: column;
@@ -5,7 +6,7 @@ body.maxi-blocks--active .maxi-slide-block {
 	justify-content: stretch;
 	box-sizing: border-box;
 	align-items: center;
-	position: relative;
+	position: $pr;
 	width: 100%;
 	height: 100%;
 	margin: 0;

--- a/src/blocks/slider-maxi/components/navigation-control/editor.scss
+++ b/src/blocks/slider-maxi/components/navigation-control/editor.scss
@@ -1,21 +1,22 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-icon-styles-control {
 	.maxi-tabs-control__button {
 		&--selected {
 			path {
-				fill: var(--maxi-secondary-color);
-				stroke: transparent;
+				fill: $sc;
+				stroke: $tr;
 			}
 			&[aria-label='color'] {
 				path {
 					&:first-child {
-						fill: var(--maxi-grey-light);
+						fill: $gl;
 					}
 				}
 			}
 			&[aria-label='border'] {
 				path {
-					fill: transparent;
-					stroke: var(--maxi-secondary-color);
+					fill: $tr;
+					stroke: $sc;
 				}
 			}
 		}
@@ -29,16 +30,16 @@
 		.maxi-tabs-control__button-none,
 		.maxi-tabs-control__button-solid,
 		.maxi-tabs-control__button-gradient {
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 4px;
-			color: var(--maxi-grey-dark);
-			background-color: var(--maxi-white);
+			color: $gd;
+			background-color: $w;
 			
 
 			&.maxi-tabs-control__button--selected {
-				border: 1px solid var(--maxi-primary-color);
-				color: var(--maxi-primary-color);
-				background-color: var(--maxi-whisper-green);
+				border: 1px solid $pc;
+				color: $pc;
+				background-color: $wg;
 			}
 		}
 	}

--- a/src/blocks/slider-maxi/editor.scss
+++ b/src/blocks/slider-maxi/editor.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-slider-block {
-	position: relative;
+	position: $pr;
 	width: 100%;
 	margin: auto;
 	padding: 0;
@@ -7,7 +8,7 @@
 	&__empty {
 		&.is-selected {
 			&::after {
-				border-color: var(--maxi-whisper-green) !important;
+				border-color: $wg !important;
 			}
 		}
 		&::after {

--- a/src/blocks/slider-maxi/style.scss
+++ b/src/blocks/slider-maxi/style.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-slider-block {
-	position: relative;
+	position: $pr;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
@@ -22,7 +23,7 @@ body.maxi-blocks--active .maxi-slider-block {
 		height: 100%;
 		padding: 0;
 		margin: 0;
-		position: relative;
+		position: $pr;
 
 		&--edit-view {
 			flex-direction: column;
@@ -39,7 +40,7 @@ body.maxi-blocks--active .maxi-slider-block {
 				&:not([data-slide-active='true']) {
 					opacity: 0;
 					pointer-events: none;
-					position: absolute;
+					position: $pa;
 					top: 0;
 					left: 0;
 					z-index: 0;
@@ -48,7 +49,7 @@ body.maxi-blocks--active .maxi-slider-block {
 				&[data-slide-active='true'] {
 					opacity: 1;
 					pointer-events: auto;
-					position: relative;
+					position: $pr;
 					z-index: 1;
 				}
 			}
@@ -56,7 +57,7 @@ body.maxi-blocks--active .maxi-slider-block {
 	}
 
 	&__arrow {
-		position: absolute;
+		position: $pa;
 		top: 50%;
 		transform: translateY(-50%);
 
@@ -68,18 +69,18 @@ body.maxi-blocks--active .maxi-slider-block {
 			left: 0px;
 		}
 		&:hover {
-			cursor: pointer;
+			cursor: $ptr;
 		}
 	}
 	.maxi-slider-block__dots {
 		display: flex;
-		position: absolute;
+		position: $pa;
 		transform: translateX(-50%);
 		svg {
-			position: absolute;
+			position: $pa;
 		}
 		.maxi-slider-block__dot:not(.maxi-slider-block__dot--active):hover {
-			cursor: pointer;
+			cursor: $ptr;
 		}
 	}
 }

--- a/src/blocks/svg-icon-maxi/editor.scss
+++ b/src/blocks/svg-icon-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-svg-icon-block {
 	&__placeholder {
 		z-index: 100;
@@ -6,28 +7,28 @@
 		justify-content: center;
 		width: 100%;
 		min-height: 120px;
-		color: var(--maxi-grey-dark);
-		background-color: var(--maxi-whisper-green);
+		color: $gd;
+		background-color: $wg;
 		font-size: 13px;
-		border: 1px solid var(--maxi-primary-color);
+		border: 1px solid $pc;
 		border-radius: 10px;
 		box-shadow: none !important;
 
 		.maxi-block-library__modal-button {
 			overflow: hidden;
-			color: var(--maxi-white);
-			background: var(--maxi-primary-color);
+			color: $w;
+			background: $pc;
 			font-family: Inter, sans-serif;
 			font-size: 12px;
 			font-weight: 800;
 			padding: 22px 22px 22px 10px;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			transition: all 0.1s;
 			border-radius: 30px;
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			transition: all 0.4s ease;
+			transition: $t;
 
 			svg {
 				width: 36px;
@@ -35,17 +36,17 @@
 				padding: 8px;
 
 				path {
-					fill: var(--maxi-white);
+					fill: $w;
 				}
 			}
 
 			&:hover {
-				background: var(--maxi-white) !important;
+				background: $w !important;
 				color: var(--maxi-cloud-primary-contrast) !important;
-				border-color: var(--maxi-primary-color);
+				border-color: $pc;
 
 				path {
-					fill: var(--maxi-primary-green) !important;
+					fill: $pgr !important;
 				}
 			}
 		}
@@ -76,22 +77,22 @@
 	&__replace-icon {
 		width: 30px;
 		height: 30px;
-		background: var(--maxi-white);
+		background: $w;
 		box-shadow: -3px 3px 6px 0px rgb(0 0 0 / 16%) !important;
 		visibility: visible;
-		transition: all 0.4s ease;
+		transition: $t;
 
 		svg {
-			fill: var(--maxi-secondary-color);
+			fill: $sc;
 			width: 15px;
 			height: 15px;
 		}
 
 		&:hover {
-			background-color: var(--maxi-pastel-green) !important;
-			transition: all 0.4s ease;
+			background-color: $pg !important;
+			transition: $t;
 			svg {
-				fill: var(--maxi-primary-color);
+				fill: $pc;
 			}
 		}
 	}

--- a/src/blocks/svg-icon-maxi/style.scss
+++ b/src/blocks/svg-icon-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-svg-icon-block {
 	display: flex;
 
@@ -6,7 +7,7 @@ body.maxi-blocks--active .maxi-svg-icon-block {
 		z-index: 20;
 
 		svg {
-			position: relative;
+			position: $pr;
 			z-index: 20;
 			display: block;
 			width: 100%;

--- a/src/blocks/text-maxi/editor.scss
+++ b/src/blocks/text-maxi/editor.scss
@@ -1,6 +1,7 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-text-block {
 	.rich-text:focus * {
-		background-color: transparent !important;
+		background-color: $tr !important;
 	}
 	> ol,
 	> ul {
@@ -11,7 +12,7 @@
 	&__content,
 	> ol,
 	> ul {
-		outline: 1.5px dashed var(--maxi-pastel-green) !important;
+		outline: 1.5px dashed $pg !important;
 
 		a.maxi-text-block--link {
 			text-decoration-skip-ink: auto;
@@ -27,7 +28,7 @@
 			.maxi-text-block__content,
 			> ol,
 			> ul {
-				outline: 1.5px dashed var(--maxi-grey-dark) !important;
+				outline: 1.5px dashed $gd !important;
 			}
 		}
 		&.is-selected {
@@ -40,7 +41,7 @@
 		.maxi-text-block__content,
 		> ol,
 		> ul {
-			outline: 1.5px dashed transparent !important;
+			outline: 1.5px dashed $tr !important;
 		}
 	}
 	&::after {

--- a/src/blocks/text-maxi/style.scss
+++ b/src/blocks/text-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-text-block {
 	& * {
 		border-color: inherit;
@@ -25,7 +26,7 @@ body.maxi-blocks--active .maxi-text-block {
 				// Old text-maxi support
 				&:not(:has(.maxi-list-item-block__content))::before {
 					content: '';
-					position: relative;
+					position: $pr;
 					display: inline-block;
 					line-height: 0.5;
 					vertical-align: middle;
@@ -78,7 +79,7 @@ body.maxi-blocks--active .maxi-text-block {
 		}
 	}
 	&__content {
-		position: relative;
+		position: $pr;
 		display: block;
 		margin: 0;
 	}

--- a/src/blocks/video-maxi/editor.scss
+++ b/src/blocks/video-maxi/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-control__item[data-name='popup settings'],
 .maxi-accordion-control__item[data-name='playback icon'] {
 	.maxi-library-modal__action-section__label {

--- a/src/blocks/video-maxi/style.scss
+++ b/src/blocks/video-maxi/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-video-block {
 	display: flex;
 	justify-content: center;
@@ -21,7 +22,7 @@
 	}
 
 	&__video-container {
-		position: relative;
+		position: $pr;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -44,7 +45,7 @@
 	}
 
 	&__overlay {
-		position: relative;
+		position: $pr;
 		display: grid;
 		grid-template-areas: 'video-overlay';
 		place-items: center;
@@ -53,7 +54,7 @@
 		height: 100%;
 
 		overflow: hidden;
-		cursor: pointer;
+		cursor: $ptr;
 	}
 
 	&__placeholder {
@@ -75,7 +76,7 @@
 
 	&__overlay-background,
 	&__select-overlay {
-		position: absolute;
+		position: $pa;
 		top: 0;
 		left: 0;
 		bottom: 0;
@@ -84,19 +85,19 @@
 	}
 
 	&__select-overlay {
-		background: transparent;
+		background: $tr;
 	}
 
 	&__play-button {
-		position: relative;
+		position: $pr;
 		z-index: 2;
 		grid-area: video-overlay;
 	}
 
 	&__close-button {
-		position: absolute;
+		position: $pa;
 
-		cursor: pointer;
+		cursor: $ptr;
 	}
 
 	&__video-container &__close-button {
@@ -126,9 +127,9 @@
 	}
 	input {
 		min-width: 200px;
-		border: 1px solid var(--maxi-grey-light) !important;
+		border: $bl !important;
 		padding: 2px 10px !important;
-		color: var(--maxi-grey-dark) !important;
+		color: $gd !important;
 		font-size: 12px;
 	}
 }

--- a/src/components/accordion-control/editor.scss
+++ b/src/components/accordion-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-control {
 	margin: 0px 0 1px;
 
@@ -20,7 +21,7 @@
 			&:after {
 				content: '';
 				z-index: 1;
-				position: absolute;
+				position: $pa;
 				width: 100%;
 				height: 1px;
 			}
@@ -38,35 +39,35 @@
 
 		&:last-child {
 			.maxi-accordion-control__item__button {
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 			}
 		}
 		&__button {
-			position: relative;
+			position: $pr;
 			z-index: 2;
 			display: flex;
 			align-items: center;
 			padding: 8px;
-			border-top: 1.5px solid var(--maxi-grey-light);
+			border-top: 1.5px solid $gl;
 			margin-bottom: 0px;
-			background: var(--maxi-white);
+			background: $w;
 			transition: background-color 0.5s, color 0.5s;
 
 			&:hover {
-				background: var(--maxi-whisper-green);
-				cursor: pointer;
-				color: var(--maxi-black);
+				background: $wg;
+				cursor: $ptr;
+				color: $bk;
 			}
 			&:active,
 			&:focus {
-				background: var(--maxi-pastel-green);
+				background: $pg;
 			}
 			&:before {
 				margin-right: 8px;
 			}
 			&:after {
 				content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5.783 9.578"><path fill="rgba(180, 180, 180, 0.9)" d="M5.783 4.758a.963.963 0 01-.283.684L1.651 9.295A.967.967 0 01.283 7.927l3.179-3.169L.293 1.59A.963.963 0 011.651.232L5.5 4.084a.963.963 0 01.283.674z" /></svg>');
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				right: 10px;
 				width: 6px;
@@ -80,7 +81,7 @@
 				}
 			}
 			&[aria-expanded='true'] {
-				background: var(--maxi-white);
+				background: $w;
 
 				&:after {
 					transform: translateY(-50%) rotate(90deg);
@@ -90,7 +91,7 @@
 		&--active {
 			&:before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 6px;
 				z-index: 1;
@@ -115,9 +116,9 @@
 			}
 		}
 		.maxi-accordion-control__item__button {
-			background: var(--maxi-white);
+			background: $w;
 			&:hover {
-				background: var(--maxi-pastel-green);
+				background: $pg;
 			}
 		}
 	}

--- a/src/components/advanced-css-control/editor.scss
+++ b/src/components/advanced-css-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-advanced-css-control {
 	&__example-wrapper {
 		width: 100%;

--- a/src/components/advanced-number-control/editor.scss
+++ b/src/components/advanced-number-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 /*===============================================
    ADVANCED NUMBER CONTROL COMPONENT
 ===============================================*/
@@ -15,7 +16,7 @@
 			border: none !important;
 			outline: none !important;
 			box-shadow: none !important;
-			background: transparent !important;
+			background: $tr !important;
 		}
 	}
 
@@ -32,13 +33,13 @@
 	}
 
 	&__input-wrapper {
-		position: relative;
+		position: $pr;
 		flex: none;
 		width: 55px !important;
 
 		// Focus state (Keyboard Accessibility)
 		&:focus-within {
-			outline: 2px solid var(--maxi-primary-color);
+			outline: 2px solid $pc;
 			outline-offset: 2px;
 		}
 	}
@@ -62,14 +63,14 @@
 
 		// Focus state (Keyboard Accessibility)
 		&:focus-visible {
-			outline: 2px solid var(--maxi-primary-color);
+			outline: 2px solid $pc;
 			outline-offset: 2px;
 		}
 	}
 
 	/*--- Spinner Controls ---*/
 	&__spinner-container {
-		position: absolute;
+		position: $pa;
 		right: 2px;
 		top: 50%;
 		transform: translateY(-48%);
@@ -80,13 +81,13 @@
 		// Divider line
 		&::before {
 			content: '';
-			position: absolute;
+			position: $pa;
 			left: -3px;
 			top: 50%;
 			transform: translateY(-50%);
 			width: 1px;
 			height: 18px;
-			background-color: var(--maxi-grey-light);
+			background-color: $gl;
 			pointer-events: none;
 		}
 	}
@@ -96,14 +97,14 @@
 		height: 12px;
 		padding: 0;
 		justify-content: center;
-		position: relative;
+		position: $pr;
 
-		background: transparent;
+		background: $tr;
 		border: none;
 		border-radius: 2px;
 
-		color: var(--maxi-grey);
-		cursor: pointer;
+		color: $g;
+		cursor: $ptr;
 		transition: all 200ms ease;
 
 		svg {
@@ -112,20 +113,20 @@
 		}
 
 		&--down {
-			border-top: 1px solid var(--maxi-grey);
+			border-top: 1px solid $g;
 		}
 
 		// Interactive States
 		&:focus-visible,
 		&:hover {
 			outline: none;
-			background: var(--maxi-whisper-green);
+			background: $wg;
 		}
 
 		&:hover {
-			color: var(--maxi-primary-color);
+			color: $pc;
 			svg {
-				color: var(--maxi-primary-color);
+				color: $pc;
 				border: none;
 			}
 		}
@@ -135,10 +136,10 @@
 		}
 
 		&:disabled {
-			color: var(--maxi-grey);
+			color: $g;
 			cursor: not-allowed;
 			&:hover {
-				background: transparent;
+				background: $tr;
 			}
 		}
 	}
@@ -146,7 +147,7 @@
 	/*--- Variants ---*/
 	&__second-style {
 		.maxi-base-control__field {
-			position: relative;
+			position: $pr;
 		}
 		.maxi-base-control__label,
 		.maxi-select-control__input {
@@ -206,7 +207,7 @@
 .maxi-advanced-number-control__controls-group {
 	display: flex;
 	align-items: center;
-	border: 1px solid var(--maxi-grey-light);
+	border: $bl;
 	border-radius: 5px;
 }
 

--- a/src/components/alignment-control/editor.scss
+++ b/src/components/alignment-control/editor.scss
@@ -1,29 +1,30 @@
+@import '../../../src/css/backend-variables.scss';
 body .maxi-alignment-control {
 	.maxi-tabs-control__button {
 		height: 32px;
 		padding: 8px;
 		width: 23%;
 		margin-right: 7px;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 		border-radius: 4px;
 		transition: background-color 0.4s ease, border-color 0.4s ease;
 
 		svg path {
-			fill: var(--maxi-black);
+			fill: $bk;
 			transition: fill 0.4s ease;
 		}
 
 		&:hover {
-			background-color: var(--maxi-whisper-green);
-			border-color: var(--maxi-secondary-color);
+			background-color: $wg;
+			border-color: $sc;
 
 			svg path {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 			}
 		}
 
 		&--selected svg path {
-			fill: var(--maxi-secondary-color);
+			fill: $sc;
 		}
 
 		&:first-child {
@@ -34,8 +35,8 @@ body .maxi-alignment-control {
 		}
 
 		&[aria-pressed='true'] {
-			background-color: var(--maxi-whisper-green);
-			border-color: var(--maxi-secondary-color);
+			background-color: $wg;
+			border-color: $sc;
 		}
 	}
 

--- a/src/components/arrow-control/editor.scss
+++ b/src/components/arrow-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-arrow-control {
 	.maxi-settingstab-control {
 		.maxi-tabs-control {
@@ -6,16 +7,16 @@
 			&__button {
 				margin-right: 5px;
 				border-radius: 4px;
-				border: 1.5px solid var(--maxi-grey-light);
-				transition: all 0.4s ease !important;
+				border: $bg;
+				transition: $t !important;
 				&:hover {
-					background-color: var(--maxi-whisper-green);
-					border-color: var(--maxi-primary-color) !important;
+					background-color: $wg;
+					border-color: $pc !important;
 				}
 				&[aria-pressed='true'] {
-					background-color: var(--maxi-whisper-green) !important;
-					border-color: var(--maxi-primary-color) !important;
-					color: var(--maxi-black) !important;
+					background-color: $wg !important;
+					border-color: $pc !important;
+					color: $bk !important;
 				}
 			}
 		}

--- a/src/components/arrow-displayer/style.scss
+++ b/src/components/arrow-displayer/style.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-block.maxi-block--has-arrow {
 	z-index: 1;
 
@@ -7,7 +8,7 @@ body.maxi-blocks--active .maxi-block.maxi-block--has-arrow {
 }
 
 .maxi-container-arrow {
-	position: absolute;
+	position: $pa;
 	top: 0;
 	left: 50%;
 	transform: translate(-50%);
@@ -20,7 +21,7 @@ body.maxi-blocks--active .maxi-block.maxi-block--has-arrow {
 		content: '';
 		width: 100%;
 		height: 100%;
-		position: absolute;
+		position: $pa;
 		box-sizing: content-box;
 		z-index: -1;
 		top: 0;
@@ -43,10 +44,10 @@ body.maxi-blocks--active .maxi-block.maxi-block--has-arrow {
 		display: none;
 		width: 80px;
 		height: 80px;
-		position: absolute;
+		position: $pa;
 		top: calc(100% + 3.5355rem);
 		transform: translate(-50%, -50%) rotate(45deg);
-		background-color: transparent;
+		background-color: $tr;
 		box-shadow: none !important;
 		z-index: -1;
 
@@ -54,7 +55,7 @@ body.maxi-blocks--active .maxi-block.maxi-block--has-arrow {
 			content: '';
 			width: 50%;
 			height: 50%;
-			position: absolute;
+			position: $pa;
 			top: -25%;
 			left: -25%;
 			transform: translate(-0.8px, -0.8px);

--- a/src/components/axis-control/editor.scss
+++ b/src/components/axis-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-axis-control {
 	margin-bottom: 10px;
 
@@ -20,31 +21,31 @@
 		min-width: 32px;
 		height: 32px;
 		padding: 0;
-		border: 1px solid var(--maxi-grey-light);
+		border: $bl;
 		border-radius: 0;
 		margin-bottom: 0;
 		opacity: 1 !important;
 		transition: all 0.5s;
-		cursor: pointer;
+		cursor: $ptr;
 	}
 
 	.maxi-tabs-control__button {
 		svg:not(.maxi-tabs-control__notification) path {
-			fill: transparent;
-			stroke: var(--maxi-grey-dark);
+			fill: $tr;
+			stroke: $gd;
 			transition: stroke 0.3s ease;
 		}
 
 		&:hover svg:not(.maxi-tabs-control__notification) path {
-			stroke: var(--maxi-secondary-color);
+			stroke: $sc;
 		}
 	}
 
 	.maxi-tabs-control__button--selected,
 	.maxi-tabs-control__button--selected {
 		svg:not(.maxi-tabs-control__notification) path {
-			fill: transparent;
-			stroke: var(--maxi-secondary-color);
+			fill: $tr;
+			stroke: $sc;
 		}
 	}
 }

--- a/src/components/axis-position-control/editor.scss
+++ b/src/components/axis-position-control/editor.scss
@@ -1,10 +1,11 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-control__item {
 	&[data-name='position'] {
 		.maxi-tabs-control {
 			.maxi-components-button {
 				&[aria-pressed='true'] {
-					background: var(--maxi-whisper-green);
-					color: var(--maxi-secondary-color);
+					background: $wg;
+					color: $sc;
 				}
 			}
 		}
@@ -17,7 +18,7 @@
 	justify-content: center;
 	height: 32px !important;
 	width: 40% !important;
-	border: 1.5px solid var(--maxi-grey-light) !important;
+	border: $bg !important;
 	border-radius: 4px !important;
 	transition: all 0.5s !important;
 	padding: 10px 15px !important;
@@ -25,13 +26,13 @@
 	left: auto;
 
 	&[aria-pressed='true'] {
-		background-color: var(--maxi-whisper-green);
-		border-color: var(--maxi-secondary-color);
+		background-color: $wg;
+		border-color: $sc;
 	}
 
 	&:hover {
-		background-color: var(--maxi-pastel-green);
-		stroke: var(--maxi-secondary-color);
+		background-color: $pg;
+		stroke: $sc;
 	}
 }
 

--- a/src/components/background-control/editor.scss
+++ b/src/components/background-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body .maxi-background-control {
 	padding-top: 8px;
 	.maxi-tabs-control__full-width {
@@ -9,16 +10,16 @@ body .maxi-background-control {
 		.maxi-tabs-control__button-none,
 		.maxi-tabs-control__button-solid,
 		.maxi-tabs-control__button-gradient {
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 4px;
-			color: var(--maxi-grey-dark);
-			background-color: var(--maxi-white);
+			color: $gd;
+			background-color: $w;
 			
 
 			&.maxi-tabs-control__button--selected {
-				border: 1px solid var(--maxi-primary-color);
-				color: var(--maxi-primary-color);
-				background-color: var(--maxi-whisper-green);
+				border: 1px solid $pc;
+				color: $pc;
+				background-color: $wg;
 			}
 		}
 	}
@@ -39,19 +40,19 @@ body .maxi-background-control {
 
 	.parallax-direction {
 		.maxi-tabs-control__button {
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 3px;
-			color: var(--maxi-grey-dark);
-			background-color: var(--maxi-white);
+			color: $gd;
+			background-color: $w;
 			width: 48px;
-			transition: all 0.4s ease !important;
+			transition: $t !important;
 
 			&[aria-pressed='true'],
 			&:active,
 			&:hover {
-				background-color: var(--maxi-whisper-green);
-				color: var(--maxi-secondary-color);
-				border: 1px solid var(--maxi-primary-color);
+				background-color: $wg;
+				color: $sc;
+				border: 1px solid $pc;
 			}
 		}
 	}
@@ -66,7 +67,7 @@ body .maxi-background-control {
 		margin-top: 0 !important;
 		.maxi-base-control__field {
 			margin-bottom: 8px !important;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 4px;
 		}
 	}
@@ -76,7 +77,7 @@ body .maxi-background-control {
 			width: 20px;
 			height: 20px;
 			margin: 3px 4px 0 0 !important;
-			border: 1px solid var(--maxi-black);
+			border: 1px solid $bk;
 			opacity: 1;
 			float: left;
 			border-radius: 0;
@@ -94,7 +95,7 @@ body .maxi-background-control {
 			margin: 0 0 8px;
 			display: flex;
 			align-items: center;
-			border: 1px solid var(--maxi-secondary-color);
+			border: 1px solid $sc;
 			z-index: 0;
 
 			.maxi-background-layer__title__text {
@@ -105,7 +106,7 @@ body .maxi-background-control {
 		}
 
 		&__content {
-			border: 1px solid var(--maxi-secondary-color);
+			border: 1px solid $sc;
 			border-radius: 0;
 			padding: 22px 8px 0;
 			margin: -23px -8px 8px;
@@ -127,7 +128,7 @@ body .maxi-background-control {
 				margin-bottom: 0;
 
 				.components-input-control__container:hover {
-					border-color: var(--maxi-primary-color) !important;
+					border-color: $pc !important;
 				}
 			}
 		}
@@ -147,7 +148,7 @@ body .maxi-background-control {
 					width: 15px;
 					height: 15px;
 					path {
-						fill: var(--maxi-black);
+						fill: $bk;
 					}
 				}
 			}
@@ -156,9 +157,9 @@ body .maxi-background-control {
 				width: 22px;
 				height: 22px;
 				margin: auto 5px auto 5px;
-				cursor: pointer;
-				position: relative;
-				transition: all 0.4s ease;
+				cursor: $ptr;
+				position: $pr;
+				transition: $t;
 
 				&:hover {
 					transform: scale(1.1);
@@ -171,16 +172,16 @@ body .maxi-background-control {
 
 				&--block {
 					path {
-						stroke: var(--maxi-black);
+						stroke: $bk;
 					}
 				}
 				&:after {
 					content: '';
 					display: block;
-					background-color: var(--maxi-grey-dark);
+					background-color: $gd;
 					width: 0;
 					height: 1px;
-					position: absolute;
+					position: $pa;
 					top: 50%;
 					left: 50%;
 					transform: translate(-50%, -50%) rotate(-45deg);
@@ -192,7 +193,7 @@ body .maxi-background-control {
 						width: 23px;
 					}
 					path {
-						stroke: var(--maxi-grey-dark);
+						stroke: $gd;
 					}
 				}
 			}
@@ -203,13 +204,13 @@ body .maxi-background-control {
 		width: 25px;
 		-webkit-transition: 0.3s ease all;
 		transition: 0.3s ease all;
-		cursor: pointer;
+		cursor: $ptr;
 		-webkit-transform-origin: center;
 		-ms-transform-origin: center;
 		transform-origin: center;
 		padding: 6px 0px;
-		border-right: 1px solid var(--maxi-secondary-color);
-		background-color: var(--maxi-white);
+		border-right: 1px solid $sc;
+		background-color: $w;
 		text-align: center;
 		border-radius: 5px 0px 0px 5px !important;
 
@@ -218,17 +219,17 @@ body .maxi-background-control {
 			height: 16px;
 			transform: rotate(-90deg);
 			path {
-				fill: var(--maxi-black);
+				fill: $bk;
 			}
 		}
 	}
 
 	.maxi-list-item-control__title__id:before {
 		content: counter(list-items-counter);
-		background: var(--maxi-whisper-green);
+		background: $wg;
 		display: block;
 		padding: 7px 6px 7px 6px !important;
-		border-right: 1px solid var(--maxi-secondary-color);
+		border-right: 1px solid $sc;
 		margin-right: 5px !important;
 		counter-increment: list-items-counter 1;
 		font-size: 14px;
@@ -238,18 +239,18 @@ body .maxi-background-control {
 }
 
 .parallax-direction .maxi-tabs-control__button {
-	position: relative;
+	position: $pr;
 	display: flex;
 	flex-direction: column;
 	width: 100%;
 	height: auto;
 	padding: 8px 30px !important;
-	border-bottom: 1px solid var(--maxi-grey-light);
-	border-top: 1px solid var(--maxi-grey-light);
-	border-right: 1px solid var(--maxi-grey-light);
+	border-bottom: $bl;
+	border-top: $bl;
+	border-right: $bl;
 	border-radius: 0;
-	color: var(--maxi-grey-dark);
-	background-color: var(--maxi-white);
+	color: $gd;
+	background-color: $w;
 	text-align: center;
 }
 
@@ -261,31 +262,31 @@ body .maxi-background-control {
 	margin-right: 4px !important;
 }
 .parallax-direction .maxi-tabs-control__button hover {
-	background-color: var(--maxi-grey-light);
-	cursor: pointer;
+	background-color: $gl;
+	cursor: $ptr;
 }
 .parallax-direction .maxi-tabs-control__button focus:not(:disabled) {
 	box-shadow: none;
 	outline: none;
 }
 .parallax-direction .maxi-tabs-control__button active {
-	background-color: var(--maxi-grey-light);
+	background-color: $gl;
 }
 
 body.maxi-blocks--active .components-popover__fallback-container {
 	button.components-button.is-link {
 		height: 30px;
-		border: 1.5px solid var(--maxi-secondary-color);
-		color: var(--maxi-secondary-color) !important;
-		background: var(--maxi-whisper-green);
+		border: 1.5px solid $sc;
+		color: $sc !important;
+		background: $wg;
 		border-radius: 30px;
 		text-decoration: none;
 		padding: 0 10px;
-		transition: all 0.5s ease-in-out;
+		transition: $t;
 
 		&:hover {
-			border-color: var(--maxi-primary-color) !important;
-			background: var(--maxi-mid-green);
+			border-color: $pc !important;
+			background: $mg;
 		}
 	}
 }

--- a/src/components/background-displayer/editor.scss
+++ b/src/components/background-displayer/editor.scss
@@ -1,7 +1,8 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block .maxi-background-displayer {
 	&__parallax {
 		img {
-			position: relative;
+			position: $pr;
 		}
 	}
 }

--- a/src/components/background-displayer/style.scss
+++ b/src/components/background-displayer/style.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block .maxi-background-displayer {
-	position: absolute;
+	position: $pa;
 	top: 0;
 	left: 0;
 	bottom: 0;
@@ -12,7 +13,7 @@
 	z-index: 0;
 
 	&__layer {
-		position: absolute;
+		position: $pa;
 		display: none;
 		width: 100%;
 		height: 100%;
@@ -20,7 +21,7 @@
 	}
 
 	&__parallax {
-		position: absolute;
+		position: $pa;
 		top: 0px;
 		left: 0px;
 		width: 100%;
@@ -47,7 +48,7 @@
 	}
 
 	&__iframe-wrapper {
-		position: absolute;
+		position: $pa;
 		top: 0;
 		left: 0;
 		height: 100%;
@@ -67,7 +68,7 @@
 
 		iframe,
 		video {
-			position: absolute;
+			position: $pa;
 			top: 50%;
 			left: 50%;
 			transform: translate(-50%, -50%);

--- a/src/components/base-control/editor.scss
+++ b/src/components/base-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-base-control {
 	&__disable {
 		opacity: 0.3;
@@ -17,7 +18,7 @@
 		flex: 1;
 		min-height: 18px;
 		margin: 0;
-		color: var(--maxi-grey-dark);
+		color: $gd;
 	}
 
 	&__help {

--- a/src/components/block-indicators/editor.scss
+++ b/src/components/block-indicators/editor.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block-indicators {
-	position: absolute;
+	position: $pa;
 	top: 0;
 	left: 0;
 	width: 100%;
@@ -25,7 +26,7 @@
 	}
 
 	.maxi-block-indicator {
-		position: absolute;
+		position: $pa;
 		display: flex;
 		justify-content: center;
 		align-items: center;

--- a/src/components/block-inserter/editor.scss
+++ b/src/components/block-inserter/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block-inserter {
 	width: 100%;
 	height: 100%;
@@ -26,15 +27,15 @@
 	&__button,
 	&__button.components-button.is-next-40px-default-size {
 		display: block;
-		position: relative;
+		position: $pr;
 		width: 16px;
 		height: 16px;
 		margin: auto;
 		padding: 0 !important;
-		background: var(--maxi-primary-color) !important;
+		background: $pc !important;
 		box-shadow: none;
 		border-radius: 0;
-		transition: all 0.4s ease !important;
+		transition: $t !important;
 
 		&--repeater {
 			background: var(--maxi-tertiary-color) !important;
@@ -44,28 +45,28 @@
 		&:focus {
 			box-shadow: none;
 			outline: none;
-			background: var(--maxi-black) !important;
+			background: $bk !important;
 		}
 
 		svg {
 			display: block;
 			width: 16px;
 			height: 16px;
-			fill: var(--maxi-white);
+			fill: $w;
 		}
 	}
 
 	&__dropdown {
 		&-selector {
-			background: var(--maxi-primary-color);
-			border: 2px solid var(--maxi-black);
+			background: $pc;
+			border: 2px solid $bk;
 		}
 
 		&-content {
 			z-index: 99999;
 			.block-editor-inserter {
 				.components-button {
-					position: relative;
+					position: $pr;
 					display: block;
 					width: 100%;
 					height: 30px !important;
@@ -73,26 +74,26 @@
 					box-shadow: none !important;
 					text-align: left;
 					text-transform: capitalize;
-					transition: all 0.4s ease;
+					transition: $t;
 					&::after,
 					&::before {
 						content: '';
-						position: absolute;
+						position: $pa;
 						bottom: 0;
 						left: 0;
 						right: 0;
 						display: block;
 						height: 1px;
-						background-color: var(--maxi-grey-light);
+						background-color: $gl;
 					}
 					&::after {
 						width: 0;
 						margin: auto;
-						background-color: var(--maxi-secondary-color);
-						transition: all 0.4s ease;
+						background-color: $sc;
+						transition: $t;
 					}
 					&:hover {
-						background-color: var(--maxi-whisper-green);
+						background-color: $wg;
 						&::after {
 							width: 100%;
 						}
@@ -121,15 +122,15 @@
 	// 		width: 25px;
 	// 		height: 25px;
 	// 		margin: auto;
-	// 		background: var(--maxi-black) !important;
-	// 		border: 1px solid var(--maxi-white);
+	// 		background: $bk !important;
+	// 		border: 1px solid $w;
 	// 		svg {
 	// 			width: 24px;
 	// 			height: 24px;
 	// 		}
 	// 		&:hover,
 	// 		&:focus {
-	// 			background: var(--maxi-secondary-color) !important;
+	// 			background: $sc !important;
 	// 		}
 	// 	}
 	// }
@@ -141,14 +142,14 @@
 
 	.components-popover__content {
 		height: auto;
-		background: transparent;
+		background: $tr;
 		border: none;
 		border-radius: 0;
 		box-shadow: none;
 		outline: none;
 
 		.components-dropdown {
-			background-color: var(--maxi-white);
+			background-color: $w;
 		}
 	}
 
@@ -162,14 +163,14 @@
 
 		&:before {
 			content: '';
-			position: absolute;
+			position: $pa;
 			top: 50%;
 			left: 50%;
 			transform: translate(-50%, -50%);
 			width: 0;
 			height: 5px;
-			background-color: var(--maxi-primary-color);
-			transition: all 0.4s ease;
+			background-color: $pc;
+			transition: $t;
 		}
 
 		&:hover:before {
@@ -183,13 +184,13 @@
 
 	.components-popover__content {
 		border: none;
-		background: transparent;
+		background: $tr;
 		border-radius: 0;
 		box-shadow: none;
 		outline: none;
 
 		.components-dropdown {
-			background-color: transparent;
+			background-color: $tr;
 		}
 
 		> div:first-of-type {
@@ -199,12 +200,12 @@
 		.maxi-inter-blocks-inserter__toggle {
 			opacity: 0;
 			height: 10px;
-			cursor: pointer;
-			transition: all 0.4s ease;
+			cursor: $ptr;
+			transition: $t;
 
 			&::before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 50%;
 				transform: translate(-50%, -50%);
@@ -214,7 +215,7 @@
 			&--is-hovered {
 				opacity: 1;
 				height: 10px;
-				fill: var(--maxi-white) !important;
+				fill: $w !important;
 
 				.maxi-inter-blocks-inserter__content-item {
 					width: 20px;
@@ -223,13 +224,13 @@
 				}
 
 				svg {
-					fill: var(--maxi-white);
+					fill: $w;
 				}
 
 				&::before {
 					width: 100%;
 					height: 5px;
-					background-color: var(--maxi-primary-color);
+					background-color: $pc;
 					margin-top: 0;
 				}
 			}
@@ -237,19 +238,19 @@
 	}
 
 	&__content-item {
-		position: absolute;
+		position: $pa;
 		top: 50%;
 		left: 66%;
 		transform: translate(-50%, -50%);
 		width: 20px;
 		height: 20px;
 		padding: 0 !important;
-		background: var(--maxi-primary-color);
+		background: $pc;
 		border-radius: 100%;
-		color: var(--maxi-white);
+		color: $w;
 
 		&:hover {
-			color: var(--maxi-white);
+			color: $w;
 		}
 	}
 }

--- a/src/components/block-resizer/editor.scss
+++ b/src/components/block-resizer/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-block__resizer {
 	.maxi-resizable {
 		&__handle {
@@ -5,19 +6,19 @@ body.maxi-blocks--active .maxi-block__resizer {
 			width: 20px;
 			height: 20px;
 			z-index: 20;
-			position: absolute;
+			position: $pa;
 			&--show {
 				display: block;
 			}
 			&:after {
 				content: '';
 				display: block;
-				position: absolute;
+				position: $pa;
 				width: 20px;
 				height: 20px;
-				border: 2px solid var(--maxi-white);
+				border: 2px solid $w;
 				border-radius: 50%;
-				background: var(--maxi-primary-color);
+				background: $pc;
 				cursor: inherit;
 			}
 			&--repeater:after {
@@ -28,8 +29,8 @@ body.maxi-blocks--active .maxi-block__resizer {
 				content: '';
 				display: block;
 				cursor: inherit;
-				position: absolute;
-				background: var(--maxi-primary-color);
+				position: $pa;
+				background: $pc;
 			}
 
 			&-right {

--- a/src/components/block-styles-control/editor.scss
+++ b/src/components/block-styles-control/editor.scss
@@ -1,6 +1,7 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active {
 	.maxi-block-style-preview {
-		position: relative;
+		position: $pr;
 	}
 	.maxi-block-style-control {
 		.maxi-select-control__input {
@@ -12,13 +13,13 @@ body.maxi-blocks--active {
 		display: flex;
 
 		&__light {
-			background: var(--maxi-pastel-green);
-			color: var(--maxi-grey-dark) !important;
+			background: $pg;
+			color: $gd !important;
 			border-radius: 5px;
 		}
 		&__dark {
-			background: var(--maxi-grey-dark);
-			color: var(--maxi-white) !important;
+			background: $gd;
+			color: $w !important;
 		}
 		span {
 			padding: 5px 8px;

--- a/src/components/border-control/editor.scss
+++ b/src/components/border-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-border-control {
 	.maxi-axis-control__units {
 		.maxi-select-control__input {

--- a/src/components/box-shadow-control/editor.scss
+++ b/src/components/box-shadow-control/editor.scss
@@ -1,16 +1,17 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-shadow-control {
 	&__default {
 		width: 2rem;
 		height: 1rem;
-		background: var(--maxi-white);
+		background: $w;
 		&__total {
-			box-shadow: 0px 0px 10px 0px var(--maxi-grey);
+			box-shadow: 0px 0px 10px 0px $g;
 		}
 		&__bottom {
-			box-shadow: 0px 7px 15px -2px var(--maxi-grey);
+			box-shadow: 0px 7px 15px -2px $g;
 		}
 		&__solid {
-			box-shadow: 2.5px 5px 0px 0px var(--maxi-grey);
+			box-shadow: 2.5px 5px 0px 0px $g;
 		}
 	}
 }

--- a/src/components/breadcrumbs/editor.scss
+++ b/src/components/breadcrumbs/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-breadcrumbs__popover {
 	z-index: 10;
 }
@@ -5,13 +6,13 @@
 .maxi-breadcrumbs {
 	font-family: 'Inter', sans-serif !important;
 	display: flex;
-	position: absolute;
+	position: $pa;
 	bottom: -22px;
 	left: 25px;
 	border-radius: 3px;
 	margin: 0 !important;
 	padding: 0 10px 0 5px !important;
-	background: var(--maxi-primary-color);
+	background: $pc;
 	z-index: 9;
 	transition: 0.3s;
 	transform: scaleX(0);
@@ -44,20 +45,20 @@
 		.maxi-breadcrumbs__item__content {
 			text-decoration: underline;
 			text-underline-offset: 3px;
-			text-decoration-color: rgba(var(--maxi-white), 0.6);
+			text-decoration-color: rgba($w, 0.6);
 			top: -1px;
-			position: relative;
+			position: $pr;
 		}
 
 		&:not(:last-child):after {
 			content: '>';
 			padding: 0 4px;
-			color: var(--maxi-white);
+			color: $w;
 		}
 		&__content {
 			text-decoration: underline;
-			cursor: pointer;
-			color: var(--maxi-white);
+			cursor: $ptr;
+			color: $w;
 			text-decoration: none;
 			transition: all 0.5s;
 

--- a/src/components/checkbox-control/editor.scss
+++ b/src/components/checkbox-control/editor.scss
@@ -1,6 +1,7 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-checkbox-control {
 	&__input {
-		position: relative;
+		position: $pr;
 		width: 23px !important;
 		height: 23px !important;
 		background-color: #c50df3 !important;
@@ -8,7 +9,7 @@
 
 		&:checked:before {
 			content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" x="0" y="0" version="1.1" viewBox="0 0 24 25" xml:space="preserve"><path fill="#FFF" d="M23.6 12.6c0 6.5-5.3 11.8-11.8 11.8C5.3 24.4 0 19.1 0 12.6S5.2.7 11.7.7C18.3.7 23.6 6 23.6 12.6zm-21.4 0c0 5.3 4.3 9.5 9.5 9.5 5.3 0 9.5-4.3 9.5-9.5C21.3 7.3 17 3 11.7 3s-9.5 4.3-9.5 9.6zm16.2-2.5l-8.2 8.2c-.2.2-.6.2-.8 0L5 13.9c-.2-.2-.2-.6 0-.8L6.1 12c.2-.2.6-.2.8 0l2.9 2.9 6.7-6.7c.2-.2.6-.2.8 0l1.1 1.1c.2.2.2.5 0 .8z"/></svg>') !important;
-			position: absolute;
+			position: $pa;
 			top: 50%;
 			left: 50%;
 			transform: translate(-50%, -50%);

--- a/src/components/clip-path-control/editor.scss
+++ b/src/components/clip-path-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 // Remove padding from accordion panel for clip-path control
 .maxi-accordion-control__item__panel:not(.maxi-accordion-control__item__panel--disable-padding):has(.maxi-clip-path-control__wrapper) {
 	padding: 0;
@@ -30,44 +31,44 @@
 		}
 
 		&__items {
-			position: relative;
+			position: $pr;
 			width: 28px;
 			height: 30px;
 			display: flex;
 			justify-content: center;
 			margin: 0;
 			padding: 3px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 4px;
-			cursor: pointer;
-			transition: all 0.4s ease;
+			cursor: $ptr;
+			transition: $t;
 
 			.clip-path-defaults__clip-path {
-				background-color: var(--maxi-grey-light);
-				transition: all 0.4s ease;
+				background-color: $gl;
+				transition: $t;
 			}
 
 			path {
-				fill: var(--maxi-grey-light);
-				transition: all 0.4s ease;
+				fill: $gl;
+				transition: $t;
 			}
 
 			&[aria-pressed='true'],
 			&:hover {
-				background: var(--maxi-pastel-green);
-				border: 1px solid var(--maxi-primary-color) !important;
+				background: $pg;
+				border: 1px solid $pc !important;
 
 				.clip-path-defaults__clip-path {
-					background-color: var(--maxi-secondary-color);
+					background-color: $sc;
 				}
 
 				path {
-					fill: var(--maxi-secondary-color) !important;
+					fill: $sc !important;
 				}
 			}
 		}
 		&__clip-path {
-			background-color: var(--maxi-grey-light);
+			background-color: $gl;
 			width: 18px;
 			height: 18px;
 			transform: translateZ(0);
@@ -78,14 +79,14 @@
 			width: 18px;
 			height: 18px;
 			path {
-				fill: var(--maxi-grey-light);
+				fill: $gl;
 			}
 		}
 	}
 
 	.maxi-clip-path-controller {
 		display: flex;
-		position: relative;
+		position: $pr;
 		&__handle {
 			display: flex;
 			align-items: center;
@@ -106,17 +107,17 @@
 			}
 
 			&.maxi-clip-path-delete-handle {
-				position: absolute;
+				position: $pa;
 				left: 0;
 				bottom: 0;
 
 				span {
-					position: relative;
+					position: $pr;
 					width: 1rem;
 					height: 1rem;
 					background-color: var(--maxi-orange-red);
-					cursor: pointer;
-					transition: all 0.4s ease; // Added transition
+					cursor: $ptr;
+					transition: $t; // Added transition
 
 					&:hover {
 						background-color: var(
@@ -127,14 +128,14 @@
 
 					&:before {
 						content: '';
-						position: absolute;
+						position: $pa;
 						top: 50%;
 						left: 50%;
 						transform: translate(-50%, -50%);
 						width: 50%;
 						height: 0.1rem;
-						background-color: var(--maxi-white);
-						transition: all 0.3s ease; // Added transition
+						background-color: $w;
+						transition: $t; // Added transition
 					}
 				}
 			}
@@ -160,22 +161,22 @@
 	}
 
 	.maxi-clip-path-visual-editor-wrapper {
-		border: 2px solid var(--maxi-secondary-color) !important;
+		border: 2px solid $sc !important;
 		border-radius: 5px;
 	}
 	.maxi-clip-path-visual-editor {
-		background-color: var(--maxi-white) !important;
-		position: relative;
+		background-color: $w !important;
+		position: $pr;
 		width: 100%;
 		margin: 10px 10px 10px 0;
 		min-height: 291px;
 		overflow: visible;
-		border: 1px solid var(--maxi-grey-light);
+		border: $bl;
 		border-radius: 6px;
 
 		&__preview {
-			background-color: var(--maxi-pastel-green) !important;
-			position: absolute;
+			background-color: $pg !important;
+			position: $pa;
 			top: 0px;
 			left: 0px;
 			width: 100%;
@@ -184,8 +185,8 @@
 	}
 
 	.maxi-clip-path-button {
-		background-color: var(--maxi-secondary-color);
-		position: absolute;
+		background-color: $sc;
+		position: $pa;
 		transform: translate(-50%, -50%);
 		width: 0.5rem;
 		height: 0.5rem;
@@ -197,7 +198,7 @@
 			clip-path: circle(50% at 50% 50%);
 
 			&__hidden {
-				position: absolute;
+				position: $pa;
 				transform: translate(-50%, -50%);
 				border-radius: 50%;
 				z-index: 1;
@@ -216,17 +217,17 @@
 }
 
 .maxi-clip-path-add-point-button {
-	background-color: var(--maxi-white) !important;
-	border-color: var(--maxi-grey-light) !important;
-	border: 1.5px solid var(--maxi-grey-light) !important;
-	color: var(--maxi-black) !important;
+	background-color: $w !important;
+	border-color: $gl !important;
+	border: $bg !important;
+	color: $bk !important;
 	font-weight: 700;
 	border-radius: 6px;
 	margin-bottom: 20px !important;
 
 	&:hover {
-		background-color: var(--maxi-whisper-green) !important;
-		border-color: var(--maxi-secondary-color) !important;
+		background-color: $wg !important;
+		border-color: $sc !important;
 	}
 }
 

--- a/src/components/color-control/editor.scss
+++ b/src/components/color-control/editor.scss
@@ -151,9 +151,7 @@
 		}
 
 		&-box {
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 			width: 30px;
 			height: 30px;
 			padding: 0;
@@ -195,9 +193,7 @@
 			width: 24px;
 			height: 24px;
 			border-radius: 50%;
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 		}
 
 		&-custom-item {

--- a/src/components/color-control/editor.scss
+++ b/src/components/color-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-color-control {
 	&__wrap {
 		display: flex;
@@ -48,13 +49,13 @@
 		input {
 			width: 90% !important;
 			height: 27px !important;
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			border: $bg !important;
 			border-radius: 5px !important;
 			font-size: 12px !important;
 			box-shadow: none !important;
 
 			&:focus {
-				border-color: var(--maxi-grey-dark) !important;
+				border-color: $gd !important;
 				box-shadow: none !important;
 				outline: 0;
 			}
@@ -62,24 +63,24 @@
 	}
 
 	&--disabled {
-		position: relative;
+		position: $pr;
 
 		&:before {
 			content: '';
-			position: absolute;
+			position: $pa;
 			z-index: 2;
 			top: 0;
 			left: 0;
 			width: 100%;
 			height: 100%;
 			cursor: not-allowed;
-			background-color: var(--maxi-white);
+			background-color: $w;
 			background: repeating-linear-gradient(
 				-45deg,
-				var(--maxi-grey-dark),
-				var(--maxi-grey-dark) 2px,
-				var(--maxi-white) 2px,
-				var(--maxi-white) 10px
+				$gd,
+				$gd 2px,
+				$w 2px,
+				$w 10px
 			);
 			opacity: 0.1;
 		}
@@ -101,7 +102,7 @@
 		&-custom {
 			width: 100%;
 			margin-top: 15px;
-			border-top: 1px solid var(--maxi-grey-light);
+			border-top: $bl;
 			padding-top: 10px;
 
 			&-header {
@@ -114,7 +115,7 @@
 
 		&-label {
 			.maxi-base-control__field {
-				position: relative;
+				position: $pr;
 				flex-direction: column;
 
 				& > * {
@@ -124,8 +125,8 @@
 					margin-bottom: 10px;
 				}
 				.components-maxi-control__reset-button {
-					position: absolute;
-					background-color: transparent;
+					position: $pa;
+					background-color: $tr;
 					border-width: 0 0 0 2px;
 					width: auto;
 					top: 0;
@@ -133,7 +134,7 @@
 					padding: 1px 1px 1px 8px;
 					&:hover {
 						svg {
-							fill: var(--maxi-primary-color);
+							fill: $pc;
 						}
 					}
 				}
@@ -157,10 +158,10 @@
 			height: 30px;
 			padding: 0;
 			border: none !important;
-			box-shadow: 0 0 0 1px var(--maxi-grey);
+			box-shadow: 0 0 0 1px $g;
 			margin: 0;
-			background-color: var(--maxi-white);
-			cursor: pointer;
+			background-color: $w;
+			cursor: $ptr;
 			transition: all 0.5s;
 			border-radius: 50%;
 
@@ -170,7 +171,7 @@
 
 			&:hover {
 				border: none !important;
-				box-shadow: 0 0 0 2px var(--maxi-secondary-color);
+				box-shadow: 0 0 0 2px $sc;
 			}
 
 			&:nth-child(n + 9) {
@@ -178,14 +179,14 @@
 			}
 
 			&--active {
-				background: var(--maxi-pastel-green);
+				background: $pg;
 				border: none;
-				box-shadow: 0 0 0 2px var(--maxi-secondary-color);
+				box-shadow: 0 0 0 2px $sc;
 				outline: none;
 
 				&:hover {
-					background: var(--maxi-pastel-green) !important;
-					box-shadow: 0 0 0 2px var(--maxi-secondary-color) !important;
+					background: $pg !important;
+					box-shadow: 0 0 0 2px $sc !important;
 				}
 			}
 		}
@@ -234,7 +235,7 @@
 				display: block;
 				width: 18px;
 				height: 18px;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 50%;
 				margin: auto;
 				opacity: 1;
@@ -242,7 +243,7 @@
 			}
 
 			.components-maxi-control__reset-button {
-				border-color: var(--maxi-grey-light);
+				border-color: $gl;
 			}
 		}
 	}

--- a/src/components/content-loader/editor.scss
+++ b/src/components/content-loader/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 @keyframes changeSentence {
 	0% {
 		content: 'Loading assets';

--- a/src/components/css-code-editor/editor.scss
+++ b/src/components/css-code-editor/editor.scss
@@ -1,18 +1,19 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-css-code-editor {
 	.w-tc-editor {
 		margin: 8px 8px 0 0;
 		width: 100%;
-		background-color: var(--maxi-white);
-		border: 1px solid var(--maxi-grey-light);
+		background-color: $w;
+		border: $bl;
 		border-radius: 10px;
 		font-family: monospace !important;
 		flex: 1 0 100%;
 		direction: ltr;
 		border-radius: 10px;
-		transition: all 0.3s ease;
+		transition: $t;
 
 		textarea.w-tc-editor-text {
-			background-color: var(--maxi-white);
+			background-color: $w;
 			font-family: monospace !important;
 			font-size: 13px !important;
 			&:hover:not(#inspector-select-control-0):not([id^='inspector-input-control']):not([id^='url-input-control']) {
@@ -20,7 +21,7 @@ body.maxi-blocks--active .maxi-css-code-editor {
 			}
 		}
 		&:hover {
-			border: 1px solid var(--maxi-primary-color) !important;
+			border: 1px solid $pc !important;
 		}
 	}
 	button.components-button[class*='maxi-advanced-css-control']:hover,
@@ -29,10 +30,10 @@ body.maxi-blocks--active .maxi-css-code-editor {
 	}
 	code {
 		padding: 0;
-		background-color: var(--maxi-white);
+		background-color: $w;
 		font-family: monospace !important;
 		span {
-			background-color: var(--maxi-white);
+			background-color: $w;
 			font-family: monospace !important;
 		}
 	}
@@ -46,7 +47,7 @@ body.maxi-blocks--active .maxi-css-code-editor {
 			border-left: 2px solid var(--maxi-orange-red);
 		}
 		&.valid {
-			border-left: 2px solid var(--maxi-primary-color);
+			border-left: 2px solid $pc;
 		}
 	}
 
@@ -61,14 +62,14 @@ body.maxi-blocks--active .maxi-css-code-editor {
 
 		.components-button {
 			height: 24px;
-			background-color: var(--maxi-pastel-green);
-			border: 1px solid var(--maxi-mid-green);
+			background-color: $pg;
+			border: 1px solid $mg;
 			border-radius: 30px;
 
 			&:hover {
-				background-color: var(--maxi-mid-green) !important;
-				color: var(--maxi-white) !important;
-				border-color: var(--maxi-primary-color) !important;
+				background-color: $mg !important;
+				color: $w !important;
+				border-color: $pc !important;
 			}
 		}
 	}

--- a/src/components/custom-css-control/editor.scss
+++ b/src/components/custom-css-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-custom-css-control {
 	.maxi-custom-css-control__category {
 		.maxi-base-control__field {
@@ -29,14 +30,14 @@
 			margin-left: 10px;
 			float: right;
 			height: 24px;
-			background-color: var(--maxi-whisper-green);
-			border: 1px solid var(--maxi-mid-green);
+			background-color: $wg;
+			border: 1px solid $mg;
 			border-radius: 0;
-			color: var(--maxi-black);
+			color: $bk;
 
 			&:hover {
-				border: 1px solid var(--maxi-secondary-color);
-				background-color: var(--maxi-pastel-green);
+				border: 1px solid $sc;
+				background-color: $pg;
 			}
 		}
 	}
@@ -44,25 +45,25 @@
 	.w-tc-editor {
 		margin: 5px 0 0 0;
 		width: 100%;
-		background-color: var(--maxi-white);
-		border: 1px solid var(--maxi-grey-light);
+		background-color: $w;
+		border: $bl;
 		font-family: monospace !important;
 		flex: 1 0 100%;
 		direction: ltr !important;
 
 		textarea {
-			background-color: var(--maxi-white);
+			background-color: $w;
 			font-family: monospace !important;
 		}
 	}
 
 	code {
 		padding: 0;
-		background-color: var(--maxi-white);
+		background-color: $w;
 		font-family: monospace !important;
 
 		span {
-			background-color: var(--maxi-white);
+			background-color: $w;
 			font-family: monospace !important;
 		}
 	}
@@ -74,11 +75,11 @@
 		font-style: italic;
 
 		&.not-valid {
-			border-left: 2px solid var(--maxi-primary-color);
+			border-left: 2px solid $pc;
 		}
 
 		&.valid {
-			border-left: 2px solid var(--maxi-secondary-color);
+			border-left: 2px solid $sc;
 		}
 	}
 }

--- a/src/components/default-styles-control/editor.scss
+++ b/src/components/default-styles-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-default-styles-control:not(.maxi-button-default-styles) {
 	display: flex;
 	flex-wrap: wrap;
@@ -9,43 +10,43 @@
 		justify-content: center;
 		height: 32px;
 		width: 22.5%;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 		border-radius: 4px;
 		transition: all 0.5s;
 
 		&--active {
-			background-color: var(--maxi-whisper-green);
-			border-color: var(--maxi-secondary-color);
+			background-color: $wg;
+			border-color: $sc;
 
 			path {
-				fill: var(--maxi-secondary-color);
-				//stroke: var(--maxi-secondary-color);
+				fill: $sc;
+				//stroke: $sc;
 			}
 			&:first-child,
 			&:nth-child-4 {
 				svg {
 					path {
-						fill: var(--maxi-secondary-color);
-						//stroke: var(--maxi-secondary-color);
+						fill: $sc;
+						//stroke: $sc;
 					}
 				}
 			}
 			// &:nth-child(3),
 			// &:nth-child(4) {
 			// 	path {
-			// 		stroke: var(--maxi-secondary-color);
+			// 		stroke: $sc;
 			// 	}
 			// }
 		}
 
 		&:hover {
-			background-color: var(--maxi-pastel-green);
-			stroke: var(--maxi-secondary-color);
+			background-color: $pg;
+			stroke: $sc;
 
 			svg {
 				path {
-					//stroke: var(--maxi-secondary-color) !important;
-					fill: var(--maxi-secondary-color) !important;
+					//stroke: $sc !important;
+					fill: $sc !important;
 				}
 			}
 		}

--- a/src/components/dialog-box/editor.scss
+++ b/src/components/dialog-box/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-dialog-box {
 	position: fixed;
 	left: 0;
@@ -16,7 +17,7 @@
 }
 
 .maxi-dialog-box__content {
-	position: relative;
+	position: $pr;
 	z-index: 2;
 	display: flex;
 	box-sizing: border-box;
@@ -26,13 +27,13 @@
 	width: 400px;
 	height: auto;
 	padding: 25px 30px;
-	border: 1px solid var(--maxi-grey-light);
+	border: $bl;
 	border-radius: 3px;
 	margin: auto;
-	background: var(--maxi-white);
+	background: $w;
 	animation: scale 0.2s ease-in-out;
 	.maxi-dialog-close-button {
-		position: absolute;
+		position: $pa;
 		top: -10px;
 		right: -10px;
 		.maxi-components-button {
@@ -42,10 +43,10 @@
 			background-color: rgba(var(--maxi-active-sc-color), 1);
 			border-radius: 50%;
 			&:hover {
-				background-color: var(--maxi-black);
+				background-color: $bk;
 			}
 			path {
-				stroke: var(--maxi-white);
+				stroke: $w;
 			}
 		}
 	}
@@ -70,8 +71,8 @@
 	align-items: center;
 	height: calc(100% - 50px);
 	padding: 10px 0;
-	color: var(--maxi-black);
-	font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+	color: $bk;
+	font-family: $f !important;
 	font-size: 12px;
 	text-align: center;
 }
@@ -82,16 +83,16 @@
 
 	button {
 		height: auto !important;
-		border: 1.5px solid var(--maxi-grey-light) !important;
+		border: $bg !important;
 		border-radius: 5px !important;
-		color: var(--maxi-black);
-		font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+		color: $bk;
+		font-family: $f !important;
 		font-size: 12px;
 		transition: all 0.1s;
 
 		&:hover {
 			background-color: rgba(var(--maxi-active-sc-color), 1);
-			color: var(--maxi-white);
+			color: $w;
 			border: 1px solid rgba(var(--maxi-active-sc-color), 1);
 		}
 	}

--- a/src/components/display-control/editor.scss
+++ b/src/components/display-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block-display-none {
 	filter: blur(1px);
 
@@ -22,30 +23,30 @@
 			column-gap: 5px;
 
 			.maxi-components-button {
-				border: 1px solid var(--maxi-mid-green);
+				border: 1px solid $mg;
 				border-radius: 4px;
 				&[aria-pressed='true'] {
-					background: var(--maxi-whisper-green);
-					border: 1.5px solid var(--maxi-secondary-color) !important;
-					color: var(--maxi-secondary-color) !important;
+					background: $wg;
+					border: 1.5px solid $sc !important;
+					color: $sc !important;
 					font-weight: 700 !important;
 				}
 				&:hover {
-					background: var(--maxi-pastel-green);
-					border: 1.5px solid var(--maxi-primary-color) !important;
+					background: $pg;
+					border: 1.5px solid $pc !important;
 				}
 				&:active {
-					background: var(--maxi-pastel-green) !important;
-					border: 1.5px solid var(--maxi-secondary-color) !important;
+					background: $pg !important;
+					border: 1.5px solid $sc !important;
 				}
 			}
 		}
 	}
 }
 .block-editor-list-view-leaf.is-selected td {
-	background: var(--maxi-mid-green) !important;
+	background: $mg !important;
 }
 .block-editor-list-view-leaf.is-selected .block-editor-list-view-block-contents,
 .block-editor-list-view-leaf.is-selected .components-button.has-icon {
-	color: var(--maxi-primary-color) !important;
+	color: $pc !important;
 }

--- a/src/components/dynamic-content/custom-date-formatting/editor.scss
+++ b/src/components/dynamic-content/custom-date-formatting/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../src/css/backend-variables.scss';
 .maxi-info-helper-popover {
 	.components-popover__content {
 		width: 220px;
@@ -12,7 +13,7 @@
 		flex: 1;
 	}
 	&__help-trigger {
-		position: relative;
+		position: $pr;
 		display: flex;
 		width: 100%;
 	}
@@ -31,12 +32,12 @@
 			min-width: 20px;
 			font-size: 12px !important;
 			border-radius: 50%;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			padding-top: 2px;
 			padding-right: 1px;
 
 			&:hover {
-				border-color: var(--maxi-grey);
+				border-color: $g;
 			}
 		}
 	}
@@ -48,8 +49,8 @@
 			flex: 1;
 			min-height: unset;
 			max-height: unset !important;
-			border: 1px solid var(--maxi-grey-light);
-			color: var(--maxi-grey);
+			border: $bl;
+			color: $g;
 			font-size: 12px;
 			line-height: 14px;
 			width: 100%;

--- a/src/components/dynamic-content/editor.scss
+++ b/src/components/dynamic-content/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-dynamic-content {
 	.maxi-dynamic-content__custom-delimiter .maxi-text-input {
 		padding: 8px;

--- a/src/components/flex-settings-control/editor.scss
+++ b/src/components/flex-settings-control/editor.scss
@@ -1,9 +1,10 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-control__item {
 	&__flexbox {
 		.maxi-tabs-control:first-child {
 			.maxi-tabs-control__button {
 				&[aria-pressed='true'] {
-					color: var(--maxi-black);
+					color: $bk;
 				}
 			}
 		}
@@ -12,7 +13,7 @@
 				.maxi-tabs-control {
 					column-gap: 5px;
 					&__button {
-						border: 1px solid var(--maxi-grey-light);
+						border: $bl;
 						border-radius: 4px;
 						padding: 6px 3px;
 						transition: all 0.5s;
@@ -20,23 +21,23 @@
 						svg {
 							width: 18px;
 							height: 18px;
-							fill: var(--maxi-grey) !important;
+							fill: $g !important;
 						}
 
 						&:hover {
-							background-color: var(--maxi-pastel-green);
+							background-color: $pg;
 							border-color: var(
 								--maxi-secondary-color
 							) !important;
 						}
 
 						&--selected {
-							background-color: var(--maxi-whisper-green);
-							border-color: var(--maxi-primary-color);
+							background-color: $wg;
+							border-color: $pc;
 
 							svg {
 								path {
-									fill: var(--maxi-secondary-color);
+									fill: $sc;
 								}
 							}
 						}
@@ -54,7 +55,7 @@
 		.maxi-tabs-control {
 			column-gap: 5px;
 			&__button {
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 				border-radius: 4px;
 				padding: 6px 3px;
 				transition: all 0.5s;
@@ -63,15 +64,15 @@
 					height: 18px;
 				}
 				&:hover {
-					background-color: var(--maxi-whisper-green);
-					border-color: var(--maxi-secondary-color) !important;
+					background-color: $wg;
+					border-color: $sc !important;
 				}
 				&--selected {
-					background-color: var(--maxi-pastel-green);
-					border-color: var(--maxi-secondary-color);
+					background-color: $pg;
+					border-color: $sc;
 					svg {
 						path {
-							fill: var(--maxi-secondary-color);
+							fill: $sc;
 						}
 					}
 				}

--- a/src/components/font-family-selector/editor.scss
+++ b/src/components/font-family-selector/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	.maxi-font-family-selector {
 		.maxi-font-family-selector__control {
 			&--is-focused,
 			&:focus {
-				border-color: var(--maxi-secondary-color);
-				box-shadow: 0 0 0 1px var(--maxi-secondary-color);
-				outline: 2px solid transparent;
+				border-color: $sc;
+				box-shadow: 0 0 0 1px $sc;
+				outline: 2px solid $tr;
 			}
 		}
 	}
@@ -18,7 +19,7 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	flex: 1 1 auto;
 
 	&__container {
-		position: relative;
+		position: $pr;
 		display: flex;
 		align-items: center;
 		gap: 5px;
@@ -28,7 +29,7 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 	.maxi-font-family-selector__control {
 		&__menu {
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 0;
 			box-shadow: none;
 		}
@@ -38,14 +39,14 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 		&__option {
 			&--is-focused,
 			&--is-selected {
-				background-color: var(--maxi-pastel-green);
-				color: var(--maxi-black) !important;
+				background-color: $pg;
+				color: $bk !important;
 				font-weight: 700 !important;
-				cursor: pointer;
+				cursor: $ptr;
 			}
 		}
 		&__control {
-			border-color: var(--maxi-grey-light);
+			border-color: $gl;
 			padding: 8px 2px 8px 8px;
 			border-radius: 5px;
 			min-height: unset;
@@ -57,17 +58,17 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 			&:focus,
 			&:hover {
-				border-color: var(--maxi-grey);
+				border-color: $g;
 			}
 			&--is-focused {
-				border-color: var(--maxi-grey);
+				border-color: $g;
 				box-shadow: none;
 				outline: none;
 			}
 		}
 		&__single-value {
 			margin: 0;
-			color: var(--maxi-black);
+			color: $bk;
 
 			& + div {
 				margin: 0;
@@ -76,48 +77,48 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 		}
 		&__value-container {
 			padding: 0;
-			cursor: pointer;
+			cursor: $ptr;
 		}
 		&__clear-indicator {
 			width: 16px;
 			height: 16px;
 			padding: 0;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: 0.5s all;
 
 			&:hover {
-				color: var(--maxi-black) !important;
+				color: $bk !important;
 				font-weight: 700 !important;
 				svg {
-					fill: var(--maxi-black);
+					fill: $bk;
 				}
 			}
 			svg {
 				width: 100%;
 				height: 100%;
-				fill: var(--maxi-grey);
+				fill: $g;
 			}
 		}
 		&__dropdown-indicator {
 			width: 20px;
 			height: 20px;
 			padding: 0;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: 0.5s all;
 
 			&:hover {
-				color: var(--maxi-black) !important;
+				color: $bk !important;
 				font-weight: 700 !important;
 			}
 			svg {
-				fill: var(--maxi-grey);
+				fill: $g;
 			}
 		}
 		&__indicator-separator {
 			width: 2px;
 			height: 80%;
 			margin: auto 2px;
-			background-color: var(--maxi-grey-light);
+			background-color: $gl;
 		}
 	}
 
@@ -132,6 +133,6 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 // Position reset button relative to BaseControl field for font family selector
 .maxi-font-family-selector-control {
 	.maxi-base-control__field {
-		position: relative;
+		position: $pr;
 	}
 }

--- a/src/components/font-level-control/editor.scss
+++ b/src/components/font-level-control/editor.scss
@@ -1,9 +1,10 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-font-level-control {
 	display: flex;
 	flex-wrap: nowrap;
 	margin-bottom: 8px;
 	justify-content: space-between;
-	border-top: 1.5px solid var(--maxi-grey-light);
+	border-top: 1.5px solid $gl;
 	padding-top: 8px;
 
 	&__button {
@@ -12,22 +13,22 @@
 		justify-content: center;
 		width: calc(100% / 8.5);
 		height: 26px;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 		border-radius: 5px;
-		color: var(--maxi-grey-dark) !important;
-		background-color: var(--maxi-white);
+		color: $gd !important;
+		background-color: $w;
 		transition: all 0.5s;
 		font-weight: 700;
 		margin-right: 6px;
 
 		&:hover {
-			background-color: var(--maxi-pastel-green);
-			border: 1.5px solid var(--maxi-secondary-color) !important;
+			background-color: $pg;
+			border: 1.5px solid $sc !important;
 		}
 		&[aria-pressed='true'] {
-			background-color: var(--maxi-whisper-green);
-			border: 1.5px solid var(--maxi-secondary-color) !important;
-			color: var(--maxi-secondary-color) !important;
+			background-color: $wg;
+			border: 1.5px solid $sc !important;
+			color: $sc !important;
 			font-weight: 700 !important;
 		}
 		&:first-child {

--- a/src/components/full-size-control/editor.scss
+++ b/src/components/full-size-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-full-size-control {
 	.maxi-tabs-control {
 		margin-left: -12px;

--- a/src/components/gradient-control/editor.scss
+++ b/src/components/gradient-control/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-gradient-control {
-	position: relative;
+	position: $pr;
 
 	.components-custom-gradient-picker__control-point-button {
-		border: 1px solid var(--maxi-grey-dark);
+		border: 1px solid $gd;
 	}
 
 	.components-angle-picker-control {
@@ -14,7 +15,7 @@
 			margin: 0;
 			padding: 0 8px;
 			line-height: 20px;
-			position: relative;
+			position: $pr;
 			top: 2px;
 			left: -1px;
 		}
@@ -25,7 +26,7 @@
 			line-height: 2 !important;
 		}
 		&__backdrop {
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			border: $bg !important;
 			border-radius: 5px !important;
 		}
 	}
@@ -34,7 +35,7 @@
 		flex-direction: column-reverse;
 
 		&__custom-clear-wrapper {
-			position: absolute;
+			position: $pa;
 			top: -2px;
 			right: 31px;
 			margin-top: 0;
@@ -45,11 +46,11 @@
 			padding: 0;
 			height: 31px;
 			width: 31px;
-			transition: all 0.4s ease !important;
+			transition: $t !important;
 
 			&:hover {
-				fill: var(--maxi-primary-color) !important;
-				background-color: var(--maxi-white) !important;
+				fill: $pc !important;
+				background-color: $w !important;
 			}
 			&:focus {
 				box-shadow: none !important;
@@ -75,13 +76,13 @@
 				width: 25px;
 				height: 25px;
 				margin: auto;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				opacity: 1;
 				float: left;
 				border-radius: 50%;
 			}
 			.components-maxi-control__reset-button {
-				border-color: var(--maxi-grey-light);
+				border-color: $gl;
 			}
 		}
 	}
@@ -96,13 +97,13 @@
 				width: 100%;
 				gap: 0;
 				label {
-					position: absolute;
+					position: $pa;
 					top: -5px;
 					left: 8px;
 					font-size: 10px !important;
 					color: var(--maxi-accessibility-grey);
 					font-style: italic;
-					background: var(--maxi-white);
+					background: $w;
 					padding: 0 5px;
 					pointer-events: none;
 					box-sizing: border-box;

--- a/src/components/icon-control/editor.scss
+++ b/src/components/icon-control/editor.scss
@@ -1,23 +1,24 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-icon-styles-control {
 	.maxi-tabs-control__button {
 		&--selected {
 			path {
-				fill: var(--maxi-secondary-color);
-				stroke: transparent;
+				fill: $sc;
+				stroke: $tr;
 			}
 		}
 	}
 	.maxi-tabs-control__button-color {
 		path {
 			&:first-child {
-				fill: var(--maxi-white) !important;
+				fill: $w !important;
 			}
 		}
 	}
 	.maxi-tabs-control__button-border.maxi-tabs-control__button--selected {
 		path {
-			fill: transparent;
-			stroke: var(--maxi-secondary-color);
+			fill: $tr;
+			stroke: $sc;
 		}
 	}
 }

--- a/src/components/image-crop-control/editor.scss
+++ b/src/components/image-crop-control/editor.scss
@@ -1,7 +1,8 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-image-crop-control {
 	margin-bottom: 8px;
 	.ReactCrop__crop-selection {
-		background: transparent;
+		background: $tr;
 	}
 	&__options {
 		display: flex;

--- a/src/components/image-url-upload/editor.scss
+++ b/src/components/image-url-upload/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-image-url-upload {
 	& &__error {
 		color: var(--maxi-orange-red);

--- a/src/components/image-url/editor.scss
+++ b/src/components/image-url/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block--backend {
 	.maxi-editor-url-input__button {
-		position: absolute;
+		position: $pa;
 		top: 43px;
 		right: 0;
 		width: 40px;
 		height: 40px;
-		background: var(--maxi-grey-dark);
+		background: $gd;
 
 		.components-button.has-icon {
 			min-width: 40px;
@@ -18,12 +19,12 @@
 		}
 		form,
 		button {
-			background: var(--maxi-white);
+			background: $w;
 		}
 		button {
 			&:hover {
 				svg {
-					fill: var(--maxi-primary-color);
+					fill: $pc;
 				}
 			}
 		}
@@ -31,13 +32,13 @@
 			.block-editor-url-input,
 			button {
 				box-shadow: none;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 			}
 		}
 		svg {
 			width: 20px;
 			height: 20px;
-			fill: var(--maxi-primary-color);
+			fill: $pc;
 		}
 		.components-base-control__field {
 			margin-bottom: 0;
@@ -54,9 +55,9 @@
 			margin-top: 0px;
 			margin-bottom: 3px;
 			margin-left: -301px;
-			color: var(--maxi-primary-color);
+			color: $pc;
 			padding-left: 8px;
-			background: var(--maxi-white);
+			background: $w;
 		}
 		.maxi-editor-url-input__button-modal-line {
 			display: flex;

--- a/src/components/info-box/editor.scss
+++ b/src/components/info-box/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-warning-box {
-	position: relative;
+	position: $pr;
 	padding: 0.5rem;
 	background: var(--maxi-light-yellow);
-	color: var(--maxi-grey-dark) !important;
+	color: $gd !important;
 	line-height: 1.3em;
 
 	&__links {
@@ -15,8 +16,8 @@
 		a {
 			text-decoration: underline;
 			font-size: 13px !important;
-			cursor: pointer;
-			color: var(--maxi-grey-dark) !important;
+			cursor: $ptr;
+			color: $gd !important;
 			transition: all 0.5s;
 
 			&:last-child {
@@ -29,10 +30,10 @@
 	}
 
 	&__close-button {
-		position: absolute;
+		position: $pa;
 		top: 5px;
 		right: 5px;
-		cursor: pointer;
+		cursor: $ptr;
 	}
 }
 .maxi-accordion-control__item__panel {

--- a/src/components/inspector-tabs/repeater-info-box/editor.scss
+++ b/src/components/inspector-tabs/repeater-info-box/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../../src/css/backend-variables.scss';
 .maxi-repeater-info-box {
 	background: var(--maxi-tertiary-color);
-	color: var(--maxi-white) !important;
+	color: $w !important;
 
 	a {
 		&,
 		&:hover {
-			color: var(--maxi-white) !important;
+			color: $w !important;
 		}
 	}
 }

--- a/src/components/link-control/editor.scss
+++ b/src/components/link-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-link-control {
 	&--dc {
 		.block-editor-link-control__search-item,
@@ -32,7 +33,7 @@
 	}
 
 	.components-form-toggle {
-		position: relative;
+		position: $pr;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
@@ -43,12 +44,12 @@
 				margin-bottom: 0;
 			}
 			&__label {
-				cursor: pointer;
+				cursor: $ptr;
 			}
 		}
 
 		input[type='checkbox'] {
-			position: absolute;
+			position: $pa;
 			z-index: 1;
 			top: 0;
 			left: 0;
@@ -61,8 +62,8 @@
 
 			&:focus + .components-form-toggle__track {
 				border-radius: 12px;
-				box-shadow: 0 0 0 1px var(--maxi-grey);
-				outline: 2px solid transparent;
+				box-shadow: 0 0 0 1px $g;
+				outline: 2px solid $tr;
 			}
 		}
 		&__track {
@@ -72,54 +73,54 @@
 			vertical-align: top;
 			width: 44px;
 			height: 24px;
-			background-color: var(--maxi-white) !important;
+			background-color: $w !important;
 			background-image: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.8 8"><path d="M8.43.22A1 1 0 0 0 7 .37L2.93 5.48 1.72 4.21a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.41l2 2.1h.05a.83.83 0 0 0 .16.09l.1.06A1.15 1.15 0 0 0 3 8a.93.93 0 0 0 .4-.09l.11-.07a.71.71 0 0 0 .18-.12s0 0 0-.06l4.8-6A1 1 0 0 0 8.43.22Z"/></svg>'),
 				url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path d="m5.6 4 2.55-2.55A.85.85 0 1 0 7 .25L4.4 2.8 1.85.25a.85.85 0 0 0-1.2 1.2L3.2 4 .65 6.55a.85.85 0 0 0 0 1.2.83.83 0 0 0 .6.25.82.82 0 0 0 .6-.25L4.4 5.2 7 7.75a.82.82 0 0 0 .6.25.83.83 0 0 0 .6-.25.85.85 0 0 0 0-1.2Z" transform="translate(-.4)"/></svg>');
 			background-repeat: no-repeat, no-repeat;
 			background-position: 8px center, 24px center;
 			background-size: 10px auto, 10px auto;
-			border: 1px solid var(--maxi-grey-light) !important;
+			border: $bl !important;
 			border-radius: 12px;
 			transition: 0.2s background ease;
 		}
 		&__thumb {
-			position: absolute;
+			position: $pa;
 			top: 3px;
 			left: 3px;
 			display: block;
 			box-sizing: border-box;
 			width: 18px;
 			height: 18px;
-			background-color: var(--maxi-white);
-			border: 1px solid var(--maxi-grey-light);
+			background-color: $w;
+			border: $bl;
 			border-radius: 50%;
 			transition: 0.1s transform ease;
 		}
 
 		&.is-checked {
 			.components-form-toggle__thumb {
-				background-color: var(--maxi-primary-color);
-				border-color: var(--maxi-primary-color);
+				background-color: $pc;
+				border-color: $pc;
 				transform: translateX(20px);
 			}
 		}
 		&.is-checked {
 			.components-form-toggle__track {
-				background-color: var(--maxi-grey);
+				background-color: $g;
 			}
 		}
 		.components-form-toggle__track {
 			border: 0;
-			background-color: var(--maxi-white);
+			background-color: $w;
 		}
 	}
 	.block-editor-url-input__input {
-		background-color: transparent;
-		color: var(--maxi-white);
-		border: 2px solid var(--maxi-grey) !important;
+		background-color: $tr;
+		color: $w;
+		border: 2px solid $g !important;
 
 		&::placeholder {
-			color: var(--maxi-grey);
+			color: $g;
 		}
 	}
 	.block-editor-link-control {
@@ -137,14 +138,14 @@
 			input {
 				margin: 0 !important;
 				width: 100% !important;
-				border-color: var(--maxi-grey-light) !important;
+				border-color: $gl !important;
 				border-radius: 10px !important;
 				min-height: 0;
 				height: 28px;
 				font-weight: 400;
 				padding: 8px !important;
 				box-shadow: none !important;
-				color: var(--maxi-black) !important;
+				color: $bk !important;
 				border-width: 2px !important;
 			}
 		}
@@ -152,14 +153,14 @@
 			align-items: center;
 
 			.components-button.is-tertiary {
-				color: var(--maxi-primary-color);
-				border: 1px solid var(--maxi-grey-light) !important;
+				color: $pc;
+				border: $bl !important;
 				border-radius: 60px !important;
 			}
 
 			// WP 6.2.2 and lower support
 			&:has(.block-editor-link-control__search-submit.has-icon) {
-				position: absolute;
+				position: $pa;
 				top: 2px;
 				right: 2px;
 			}
@@ -183,36 +184,36 @@
 			}
 		}
 		&__search-item {
-			background-color: var(--maxi-whisper-green) !important;
-			border: 1px solid var(--maxi-grey-light);
+			background-color: $wg !important;
+			border: $bl;
 			border-radius: 10px;
 			padding: 8px;
 			transition: background-color 0.4s ease;
 
 			&:hover {
-				background-color: var(--maxi-pastel-green) !important;
+				background-color: $pg !important;
 			}
 
 			&-action {
-				background-color: var(--maxi-primary-color);
+				background-color: $pc;
 				box-shadow: none !important;
 				padding: 4px 17px;
 				height: 24px;
 				border-radius: 0;
-				transition: all 0.4s ease;
+				transition: $t;
 				&:hover {
-					background-color: var(--maxi-pastel-green) !important;
-					color: var(--maxi-primary-color);
+					background-color: $pg !important;
+					color: $pc;
 				}
 			}
 
 			&-error-notice {
-				color: var(--maxi-primary-color);
+				color: $pc;
 			}
 
 			.components-menu-item__info-wrapper {
 				.components-menu-item__item {
-					color: var(--maxi-black);
+					color: $bk;
 				}
 			}
 		}
@@ -223,11 +224,11 @@
 			overflow-x: hidden;
 			max-width: 100%;
 			.block-editor-link-control__search-item-type {
-				transition: all 0.4s ease;
+				transition: $t;
 			}
 			&:hover {
 				.block-editor-link-control__search-item-type {
-					background-color: var(--maxi-black);
+					background-color: $bk;
 				}
 			}
 			.components-menu-item__button {
@@ -241,14 +242,14 @@
 			margin-bottom: 0;
 		}
 		&__search-item-type {
-			background-color: var(--maxi-primary-color);
+			background-color: $pc;
 			padding: 5px 17px;
 			height: 24px;
 			border-radius: 0;
 		}
 		&__search-item-icon {
-			fill: var(--maxi-primary-color);
-			background-color: transparent !important;
+			fill: $pc;
+			background-color: $tr !important;
 		}
 		&__tools {
 			border: none;
@@ -267,15 +268,15 @@
 	&__link-destroyer,
 	.block-editor-link-control__search-actions
 		.components-button.block-editor-link-control__search-submit.is-primary {
-		background-color: var(--maxi-primary-color) !important;
+		background-color: $pc !important;
 		border-radius: 60px !important;
 		text-align: center;
-		color: var(--maxi-white);
+		color: $w;
 		display: block;
-		transition: all 0.4s ease !important;
+		transition: $t !important;
 		&:hover {
-			color: var(--maxi-white) !important;
-			background-color: var(--maxi-secondary-color) !important;
+			color: $w !important;
+			background-color: $sc !important;
 		}
 	}
 
@@ -300,5 +301,5 @@
 
 .maxi-toolbar__popover
 	.components-button.maxi-link-control__link-destroyer:hover {
-	color: var(--maxi-white) !important;
+	color: $w !important;
 }

--- a/src/components/link-control/editor.scss
+++ b/src/components/link-control/editor.scss
@@ -200,7 +200,7 @@
 				padding: 4px 17px;
 				height: 24px;
 				border-radius: 0;
-				transition: $t;
+				@include transit;
 				&:hover {
 					background-color: $pg !important;
 					color: $pc;
@@ -224,7 +224,7 @@
 			overflow-x: hidden;
 			max-width: 100%;
 			.block-editor-link-control__search-item-type {
-				transition: $t;
+				@include transit;
 			}
 			&:hover {
 				.block-editor-link-control__search-item-type {
@@ -273,7 +273,7 @@
 		text-align: center;
 		color: $w;
 		display: block;
-		transition: $t !important;
+		@include transit(true);
 		&:hover {
 			color: $w !important;
 			background-color: $sc !important;

--- a/src/components/list-control/editor.scss
+++ b/src/components/list-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-list-control {
 	.maxi-settingstab-control .maxi-tabs-content {
 		padding-right: 0 !important;
@@ -17,23 +18,23 @@
 		margin: 0 0 8px;
 		display: flex;
 		align-items: center;
-		border: 1px solid var(--maxi-secondary-color);
+		border: 1px solid $sc;
 		z-index: 0;
 		border-radius: 5px !important;
-		transition: all 0.4s ease; // Added transition
+		transition: $t; // Added transition
 
 		&:hover {
-			background-color: var(--maxi-whisper-green) !important;
-			border-color: var(--maxi-primary-color);
+			background-color: $wg !important;
+			border-color: $pc;
 
 			.maxi-list-item-control__arrow {
-				background-color: var(--maxi-whisper-green);
+				background-color: $wg;
 			}
 		}
 	}
 
 	&__content {
-		border: 1px solid var(--maxi-secondary-color);
+		border: 1px solid $sc;
 		border-radius: 5px;
 		padding: 22px 8px 0;
 		margin: -23px -8px 8px;
@@ -49,7 +50,7 @@
 		.components-custom-gradient-picker__gradient-bar {
 			margin-top: 0;
 			margin-bottom: 8px;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 		}
 
 		.components-custom-gradient-picker__ui-line {
@@ -60,16 +61,16 @@
 	&__arrow {
 		width: 27px;
 		transition: 0.4s ease all;
-		cursor: pointer;
+		cursor: $ptr;
 		transform-origin: center;
 		padding: 7px 9px !important;
-		border-right: 1px solid var(--maxi-secondary-color);
-		background-color: var(--maxi-white);
+		border-right: 1px solid $sc;
+		background-color: $w;
 		text-align: center;
 		border-radius: 5px 0px 0px 5px !important;
 
 		&:hover {
-			background-color: var(--maxi-whisper-green);
+			background-color: $wg;
 		}
 
 		&::before {
@@ -86,7 +87,7 @@
 			display: none !important;
 			transition: 0.3s ease all;
 			path {
-				fill: var(--maxi-grey-dark);
+				fill: $gd;
 			}
 		}
 	}
@@ -100,19 +101,19 @@
 	}
 
 	&__title {
-		position: relative;
+		position: $pr;
 		display: flex;
 		align-items: center;
 		width: 100%;
 		margin: 0;
 		border-radius: 5px;
-		transition: all 0.4s ease;
-		cursor: pointer;
+		transition: $t;
+		cursor: $ptr;
 		padding-right: 5px;
-		background-color: var(--maxi-white);
+		background-color: $w;
 
 		&:hover {
-			background-color: var(--maxi-whisper-green) !important;
+			background-color: $wg !important;
 		}
 
 		&__wrapper {
@@ -127,10 +128,10 @@
 		&__id {
 			&:before {
 				content: counter(list-items-counter);
-				background: var(--maxi-pastel-green);
+				background: $pg;
 				display: block;
 				padding: 7px 10px 7px 8px;
-				border-right: 1px solid var(--maxi-secondary-color);
+				border-right: 1px solid $sc;
 				margin-right: 7px;
 				counter-increment: list-items-counter 1;
 				font-size: 14px;
@@ -139,14 +140,14 @@
 		}
 
 		&__remover {
-			position: absolute;
+			position: $pa;
 			display: block;
 			width: 16px;
 			height: 16px;
 			margin: 0;
 			background-color: var(--maxi-golden-orange);
 			border-radius: 50%;
-			cursor: pointer;
+			cursor: $ptr;
 			right: -5px;
 			top: -5px;
 			transition: background-color 0.2s ease;
@@ -158,13 +159,13 @@
 			&:after,
 			&:before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 50%;
 				transform: translate(-50%, -50%) rotate(45deg);
 				width: 12px;
 				height: 2px;
-				background-color: var(--maxi-white);
+				background-color: $w;
 			}
 
 			&:after {
@@ -188,7 +189,7 @@ html[dir='rtl'] {
 		}
 	}
 	.maxi-list-item-control__arrow {
-		border-left: 1px solid var(--maxi-secondary-color);
+		border-left: 1px solid $sc;
 		border-right: 0;
 		border-radius: 0px 5px 5px 0px !important;
 	}
@@ -200,7 +201,7 @@ html[dir='rtl'] {
 		content: counter(list-items-counter);
 		padding: 7px 8px 7px 10px;
 		border-right: 0;
-		border-left: 1px solid var(--maxi-secondary-color);
+		border-left: 1px solid $sc;
 		margin-left: 7px;
 		margin-right: unset;
 	}

--- a/src/components/maxi-block/editor.scss
+++ b/src/components/maxi-block/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-block {
 	&.maxi-block--backend {
 		&.maxi-block--is-drag-over:before {
 			content: '';
-			position: absolute;
+			position: $pa;
 			width: 100%;
 			height: 100%;
 			box-shadow: 0px 0px 5px 5px rgba(241, 239, 238, 0.75);

--- a/src/components/maxi-popover-button/editor.scss
+++ b/src/components/maxi-popover-button/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .components-popover.maxi-popover-button {
 	.components-popover__content {
 		margin: auto;

--- a/src/components/media-uploader-control/editor.scss
+++ b/src/components/media-uploader-control/editor.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-mediauploader-control {
-	position: relative;
+	position: $pr;
 	margin-bottom: 8px;
 	&__image,
 	&__video {
@@ -17,24 +18,24 @@
 		display: block;
 		text-align: center;
 		box-shadow: none !important;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 		border-radius: 5px;
-		color: var(--maxi-grey-dark);
+		color: $gd;
 		transition: all 0.5s;
 		&:hover {
-			border: 1.5px solid var(--maxi-primary-color);
-			color: var(--maxi-black);
-			background-color: var(--maxi-pastel-green);
+			border: 1.5px solid $pc;
+			color: $bk;
+			background-color: $pg;
 		}
 	}
 	&__toggle {
 		display: block;
 		width: 100%;
 		min-height: 90px;
-		background: var(--maxi-whisper-green);
-		border: 1.5px dashed var(--maxi-grey-light);
+		background: $wg;
+		border: 1.5px dashed $gl;
 		border-radius: 10px;
-		color: var(--maxi-grey-dark) !important;
+		color: $gd !important;
 		line-height: 20px;
 		padding: 8px 0;
 		text-align: center;

--- a/src/components/motion-preview/editor.scss
+++ b/src/components/motion-preview/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-motion-preview {
 	z-index: 1;
 }

--- a/src/components/opacity-control/editor.scss
+++ b/src/components/opacity-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-accordion-control__item[data-name='opacity'] {
 	.maxi-accordion-control__item__panel {
 		padding: 0;

--- a/src/components/overflow-control/editor.scss
+++ b/src/components/overflow-control/editor.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-overflow-control {
-	position: relative;
+	position: $pr;
 	display: flex;
 	justify-content: space-between;
 	margin-bottom: 10px;
@@ -14,15 +15,15 @@
 	}
 
 	.sync-wrapper {
-		position: absolute;
+		position: $pa;
 		left: 50%;
 		top: 50%;
 		transform: translate(-50%, -50%);
 		margin-top: 2px;
 
 		button {
-			background: var(--maxi-white);
-			border: 1.5px solid var(--maxi-grey-light);
+			background: $w;
+			border: $bg;
 			border-radius: 4px;
 			width: 24px;
 			height: 24px;
@@ -41,27 +42,27 @@
 			transition: all 0.2s;
 
 			&:focus {
-				border-color: transparent;
+				border-color: $tr;
 			}
 
 			&[aria-pressed='true'] {
-				background: var(--maxi-whisper-green) !important;
-				border: 1.5px solid var(--maxi-secondary-color);
+				background: $wg !important;
+				border: 1.5px solid $sc;
 
 				&:hover {
-					background: var(--maxi-pastel-green) !important;
-					border: 1px solid var(--maxi-primary-color);
+					background: $pg !important;
+					border: 1px solid $pc;
 
 					svg {
 						path {
-							fill: var(--maxi-primary-color);
+							fill: $pc;
 						}
 					}
 				}
 
 				svg {
 					path {
-						fill: var(--maxi-secondary-color);
+						fill: $sc;
 					}
 				}
 			}
@@ -70,7 +71,7 @@
 				width: 14px;
 				height: 14px;
 				path {
-					fill: var(--maxi-grey);
+					fill: $g;
 				}
 			}
 		}

--- a/src/components/placeholder/editor.scss
+++ b/src/components/placeholder/editor.scss
@@ -1,12 +1,13 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-placeholder.maxi-placeholder {
 	// This needs specificity to override individual block styles.
 	box-sizing: border-box;
-	position: relative;
+	position: $pr;
 	padding: 1em;
 	width: 100%;
 	text-align: left;
 	margin: 0;
-	color: var(--maxi-grey-dark);
+	color: $gd;
 
 	// Some editor styles unset this.
 	-moz-font-smoothing: subpixel-antialiased;
@@ -22,7 +23,7 @@
 
 	// Block UI appearance.
 	border-radius: 2px;
-	background-color: var(--maxi-white);
+	background-color: $w;
 
 	.components-base-control__label {
 		font-size: 18pt;
@@ -129,13 +130,13 @@
 		}
 
 		.maxi-placeholder__instructions {
-			position: absolute;
+			position: $pa;
 			bottom: 40px;
 			left: 0;
 			width: 100%;
 			text-align: center;
 			font-size: 18px;
-			color: var(--maxi-grey);
+			color: $g;
 		}
 	}
 

--- a/src/components/popover/editor.scss
+++ b/src/components/popover/editor.scss
@@ -1,10 +1,11 @@
+@import '../../../src/css/backend-variables.scss';
 $arrow-triangle-base-size: 14px;
 $border-width: 1px;
-$white: var(--maxi-white);
-$gray-400: var(--maxi-grey-light);
-$gray-900: var(--maxi-grey-dark);
-$shadow-popover: 0 0 0 1px rgba(var(--maxi-black), 0.2),
-	0 4px 11px rgba(var(--maxi-black), 0.1);
+$white: $w;
+$gray-400: $gl;
+$gray-900: $gd;
+$shadow-popover: 0 0 0 1px rgba($bk, 0.2),
+	0 4px 11px rgba($bk, 0.1);
 $radius-block-ui: 3px;
 $panel-header-height: 32px;
 $grid-unit-20: 20px;
@@ -36,11 +37,11 @@ $grid-unit-20: 20px;
 	border-radius: $radius-block-ui;
 	box-sizing: border-box;
 	width: min-content;
-	position: relative !important;
-	transition: all 0.4s ease;
+	position: $pr !important;
+	transition: $t;
 
 	&:hover {
-		background-color: var(--maxi-pastel-green);
+		background-color: $pg;
 	}
 
 	// Alternate treatment for popovers that put them at elevation zero with high contrast.
@@ -81,7 +82,7 @@ $grid-unit-20: 20px;
 }
 
 .maxi-components-popover__arrow {
-	position: absolute;
+	position: $pa;
 	width: $arrow-triangle-base-size;
 	height: $arrow-triangle-base-size;
 	pointer-events: none;
@@ -92,7 +93,7 @@ $grid-unit-20: 20px;
 	// arrow
 	&::before {
 		content: '';
-		position: absolute;
+		position: $pa;
 		top: -1px;
 		left: 1px;
 		height: 2px;
@@ -135,7 +136,7 @@ $grid-unit-20: 20px;
 
 .maxi-components-popover__triangle-border {
 	// Stroke colors are the same as the .components-popover__content's outline
-	fill: transparent;
+	fill: $tr;
 	stroke-width: $border-width;
 	stroke: $gray-400;
 

--- a/src/components/prompt-control/components/result-card/editor.scss
+++ b/src/components/prompt-control/components/result-card/editor.scss
@@ -1,13 +1,14 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-results-card {
 	padding: 20px;
-	border: 1.5px solid var(--maxi-grey-light);
+	border: $bg;
 	border-radius: 10px;
 	background: var(--maxi-off-white);
-	cursor: pointer;
+	cursor: $ptr;
 	transition: background-color 0.2s ease-in-out, border 0.2s ease-in-out;
 
 	& > * {
-		color: var(--maxi-black) !important;
+		color: $bk !important;
 	}
 	& &__variant {
 		font-weight: bold;
@@ -18,17 +19,17 @@
 		height: auto;
 		padding: 4px 8px;
 		width: auto;
-		border: 1.5px solid var(--maxi-secondary-color);
-		color: var(--maxi-secondary-color) !important;
-		background: var(--maxi-whisper-green);
+		border: 1.5px solid $sc;
+		color: $sc !important;
+		background: $wg;
 		font-size: 12px !important;
 		font-weight: 600 !important;
 		border-radius: 30px;
 		text-align: center;
-		cursor: pointer;
+		cursor: $ptr;
 
 		&:hover {
-			background-color: var(--maxi-secondary-color);
+			background-color: $sc;
 		}
 
 		&:focus {
@@ -47,12 +48,12 @@
 		&__select-row {
 			display: flex;
 			justify-content: space-between;
-			cursor: pointer;
+			cursor: $ptr;
 
 			& &__select-text_output,
 			& &__from-previous-session,
 			& &__id_output {
-				color: var(--maxi-secondary-color) !important;
+				color: $sc !important;
 			}
 
 			& &__select-text,
@@ -62,14 +63,14 @@
 			}
 
 			& &__from-previous-session {
-				color: var(--maxi-grey-light);
+				color: $gl;
 			}
 		}
 	}
 
 	&__modificator {
 		&:has(&__id) {
-			cursor: pointer;
+			cursor: $ptr;
 		}
 
 		& &__id {
@@ -78,10 +79,10 @@
 	}
 
 	&__scroll-to {
-		position: relative;
+		position: $pr;
 
 		&__inner {
-			position: absolute;
+			position: $pa;
 			top: -80px;
 		}
 	}
@@ -93,15 +94,15 @@
 	}
 
 	& &__content-length {
-		color: var(--maxi-grey-dark);
+		color: $gd;
 		text-align: end;
 	}
 
 	&__end-of-content {
-		position: relative;
+		position: $pr;
 
 		&__inner {
-			position: absolute;
+			position: $pa;
 			bottom: -120px;
 		}
 	}
@@ -116,20 +117,20 @@
 			padding: 0;
 
 			&:hover {
-				color: var(--maxi-primary-color);
+				color: $pc;
 			}
 		}
 	}
 
 	&--selected {
 		background: var(--maxi-off-white);
-		border-color: var(--maxi-secondary-color);
+		border-color: $sc;
 		cursor: default;
 
 		.maxi-prompt-control-results-card__top-bar {
 			&__select-row {
 				cursor: default;
-				border-top: 1px solid var(--maxi-mid-green);
+				border-top: 1px solid $mg;
 				padding-top: 10px;
 			}
 		}

--- a/src/components/prompt-control/components/result-cards/editor.scss
+++ b/src/components/prompt-control/components/result-cards/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-results {
 	display: flex;
 	flex-direction: column;

--- a/src/components/prompt-control/components/result-modify-bar/editor.scss
+++ b/src/components/prompt-control/components/result-modify-bar/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-result-modify-bar {
 	&__modification-options {
 		display: flex;
@@ -9,21 +10,21 @@
 		}
 
 		& > div > div > div {
-			border-color: var(--maxi-grey-light);
+			border-color: $gl;
 		}
 	}
 
 	&__button {
-		background: var(--maxi-mid-green);
+		background: $mg;
 		border-radius: 10px;
-		color: var(--maxi-black) !important;
+		color: $bk !important;
 		font-size: 12px;
 		height: 30px;
 		margin: 0;
 		padding: 2px 13px;
 		&:hover {
-			background: var(--maxi-white);
-			color: var(--maxi-primary-color) !important;
+			background: $w;
+			color: $pc !important;
 		}
 	}
 }
@@ -33,5 +34,5 @@
 }
 
 .maxi-prompt-control-results-card__clean-history-button:hover {
-	color: var(--maxi-primary-color) !important;
+	color: $pc !important;
 }

--- a/src/components/prompt-control/editor.scss
+++ b/src/components/prompt-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-prompt-control {
 	&__buttons {
 		display: flex;
@@ -16,7 +17,7 @@
 			.maxi-components-button {
 				height: auto;
 				padding: 0;
-				color: var(--maxi-black);
+				color: $bk;
 			}
 		}
 	}
@@ -31,30 +32,30 @@
 			}
 			& > div > div {
 				z-index: 10000;
-				border-color: var(--maxi-grey-light);
+				border-color: $gl;
 			}
 		}
 		.maxi-prompt-control__buttons {
 			.maxi-components-button {
 				justify-content: center;
 				width: 100%;
-				border: 1.5px solid var(--maxi-secondary-color);
-				color: var(--maxi-secondary-color) !important;
-				background: var(--maxi-whisper-green);
+				border: 1.5px solid $sc;
+				color: $sc !important;
+				background: $wg;
 				font-size: 16px !important;
 				font-weight: 700 !important;
 				border-radius: 30px;
 				text-align: center;
 				&:hover {
-					border-color: var(--maxi-primary-color) !important;
-					background: var(--maxi-mid-green);
+					border-color: $pc !important;
+					background: $mg;
 				}
 				&:disabled {
 					opacity: 0.6;
 					cursor: not-allowed;
-					border-color: var(--maxi-grey) !important;
-					color: var(--maxi-grey-dark) !important;
-					background: var(--maxi-grey-light);
+					border-color: $g !important;
+					color: $gd !important;
+					background: $gl;
 				}
 			}
 		}
@@ -65,23 +66,23 @@
 			height: auto;
 			padding: 4px 8px !important;
 			width: auto;
-			border: 1.5px solid var(--maxi-secondary-color);
-			color: var(--maxi-secondary-color) !important;
-			background: var(--maxi-whisper-green);
+			border: 1.5px solid $sc;
+			color: $sc !important;
+			background: $wg;
 			font-size: 12px !important;
 			font-weight: 600 !important;
 			border-radius: 30px;
 			text-align: center;
-			cursor: pointer;
+			cursor: $ptr;
 
 			&:hover {
-				background: var(--maxi-pastel-green);
-				border-color: var(--maxi-secondary-color);
+				background: $pg;
+				border-color: $sc;
 			}
 
 			&:focus {
 				outline: none;
-				box-shadow: 0 0 0 2px var(--maxi-cloud-primary-light);
+				box-shadow: 0 0 0 2px $cpl;
 			}
 		}
 	}

--- a/src/components/prompt-control/tabs/generate-tab/editor.scss
+++ b/src/components/prompt-control/tabs/generate-tab/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-generate-tab {
 	&__textarea {
 		.maxi-base-control__field {
@@ -16,22 +17,22 @@
 		justify-content: space-between;
 		margin-bottom: 12px;
 		margin-top: -15px;
-		border-bottom: 1px solid var(--maxi-grey-light) !important;
+		border-bottom: $bl !important;
 
 		span {
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 	}
 
 	&__ai-model {
 		p {
 			font-size: small;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 
 		p strong {
 			font-weight: 600;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 	}
 }

--- a/src/components/prompt-control/tabs/modify-tab/editor.scss
+++ b/src/components/prompt-control/tabs/modify-tab/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-modify-tab {
 	display: flex;
 	flex-direction: column;

--- a/src/components/prompt-control/tabs/results-tab/editor.scss
+++ b/src/components/prompt-control/tabs/results-tab/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-prompt-control-history-tab {
 	.maxi-prompt-control__buttons {
 		margin: 8px 0;
@@ -7,8 +8,8 @@
 		position: sticky;
 		bottom: 0;
 		padding: 8px 0;
-		border-top: 2px solid var(--maxi-grey);
-		background: var(--maxi-white);
+		border-top: 2px solid $g;
+		background: $w;
 		justify-content: center;
 		width: 100%;
 	}

--- a/src/components/radio-control/editor.scss
+++ b/src/components/radio-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-sidebar .maxi-radio-control {
 	display: inline-flex;
 	justify-content: space-between;
@@ -23,27 +24,27 @@
 			flex: 1;
 			min-width: 35px;
 			height: 32px;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			margin-bottom: 0;
-			color: var(--maxi-grey);
-			background-color: var(--maxi-white);
+			color: $g;
+			background-color: $w;
 			opacity: 1 !important;
 			transition: all 0.5s;
 
 			&:hover {
-				background-color: var(--maxi-grey);
+				background-color: $g;
 			}
 			&:focus {
-				background-color: var(--maxi-grey);
+				background-color: $g;
 			}
 			input {
 				display: none;
 
 				&:checked ~ label {
-					position: relative;
+					position: $pr;
 					z-index: 1;
-					border-bottom: 2px solid var(--maxi-secondary-color);
-					background-color: var(--maxi-white);
+					border-bottom: 2px solid $sc;
+					background-color: $w;
 				}
 			}
 			label {
@@ -57,7 +58,7 @@
 				width: 20px;
 				height: 100%;
 				margin: 0;
-				fill: var(--maxi-black);
+				fill: $bk;
 			}
 		}
 	}

--- a/src/components/relation-control/editor.scss
+++ b/src/components/relation-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-relation-control {
 		margin-top: 10px;
 	&__button {
@@ -41,10 +42,10 @@
 	width: fit-content;
 	margin: 10px auto; // Changed from margin-top to center horizontally
 	padding: 8px 12px;
-	background-color: var(--maxi-pastel-green);
-	border: 1px solid var(--maxi-mid-green);
+	background-color: $pg;
+	border: 1px solid $mg;
 	border-radius: 30px;
-	color: var(--maxi-grey-dark);
+	color: $gd;
 	text-align: center;
 	text-decoration: none;
 	transition: background-color 0.3s ease, color 0.3s ease,
@@ -57,6 +58,6 @@
 	background-color: var(
 		--maxi-primary-color
 	) !important; // Changed to primary color
-	color: var(--maxi-white) !important;
-	border-color: var(--maxi-primary-color) !important;
+	color: $w !important;
+	border-color: $pc !important;
 }

--- a/src/components/reset-control/editor.scss
+++ b/src/components/reset-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-reset-button {
 	display: flex;
 	overflow: hidden;
@@ -7,26 +8,26 @@
 	padding: 8px 5px !important;
 	border-radius: 50%;
 	margin-left: 4px;
-	background: var(--maxi-white);
+	background: $w;
 	text-decoration: none;
 	transition: all 0.3s;
 	-webkit-appearance: none;
 	box-shadow: none;
-	cursor: pointer;
+	cursor: $ptr;
 	opacity: 1;
 	margin-right: 0 !important;
 
 	&:focus {
-		border-color: var(--maxi-grey);
+		border-color: $g;
 	}
 	svg {
 		width: 14px;
 		height: 14px;
 		margin: auto;
-		fill: var(--maxi-grey);
+		fill: $g;
 	}
 	&:hover svg {
-		fill: var(--maxi-black);
+		fill: $bk;
 		transition: all 0.3s;
 	}
 	@at-root .rtl #{&} {
@@ -35,8 +36,8 @@
 }
 .maxi-color-control__palette-label {
 	.maxi-reset-button {
-		position: absolute;
-		background-color: transparent;
+		position: $pa;
+		background-color: $tr;
 		border-width: 0 0 0 2px;
 		max-width: 32px;
 		top: 0;
@@ -45,7 +46,7 @@
 		margin-top: -6px !important;
 		&:hover svg {
 			transition: all 0.3s;
-			fill: var(--maxi-black);
+			fill: $bk;
 		}
 	}
 }
@@ -61,10 +62,10 @@
 		border-radius: 0;
 
 		&:hover {
-			background: var(--maxi-white);
+			background: $w;
 		}
 		&:focus {
-			border-color: var(--maxi-grey);
+			border-color: $g;
 		}
 	}
 }

--- a/src/components/responsive-tabs-control/editor.scss
+++ b/src/components/responsive-tabs-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-responsive-tabs-control {
 	.maxi-tabs-content:not(.maxi-tabs-content--disable-padding) {
 		padding: 8px 0 0;
@@ -15,10 +16,10 @@
 			font-weight: 500;
 
 			&[aria-pressed='true'] {
-				color: var(--maxi-secondary-color) !important;
-				background-color: var(--maxi-whisper-green) !important;
+				color: $sc !important;
+				background-color: $wg !important;
 				font-weight: 700 !important;
-				fill: var(--maxi-secondary-color) !important;
+				fill: $sc !important;
 			}
 		}
 	}
@@ -40,8 +41,8 @@
 			font-weight: 500;
 
 			&[aria-pressed='true'] {
-				color: var(--maxi-primary-color);
-				background-color: var(--maxi-whisper-green);
+				color: $pc;
+				background-color: $wg;
 			}
 		}
 	}

--- a/src/components/scroll-effects-control/editor.scss
+++ b/src/components/scroll-effects-control/editor.scss
@@ -1,35 +1,36 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-scroll-effects-control {
 	.maxi-base-control {
 		flex: 1;
 		&__help {
-			color: var(--maxi-grey);
+			color: $g;
 			font-size: 14px !important;
 		}
 		.maxi-tabs-control__button {
 			&:not(.maxi-tabs-control__button-rotate) {
 				svg {
 					path {
-						stroke: var(--maxi-grey);
-						fill: var(--maxi-grey);
+						stroke: $g;
+						fill: $g;
 					}
 				}
 			}
 			&-rotate {
 				svg {
 					path {
-						fill: var(--maxi-grey);
+						fill: $g;
 					}
 				}
 			}
 			&-blur {
 				svg {
-					stroke: var(--maxi-grey);
+					stroke: $g;
 				}
 			}
 			&--selected:not(.maxi-tabs-control__button-rotate) {
 				svg {
 					path {
-						stroke: var(--maxi-secondary-color);
+						stroke: $sc;
 					}
 				}
 			}
@@ -37,7 +38,7 @@
 				&.maxi-tabs-control__button--selected {
 					svg {
 						path {
-							fill: var(--maxi-secondary-color);
+							fill: $sc;
 						}
 					}
 				}
@@ -45,7 +46,7 @@
 			&-blur {
 				&.maxi-tabs-control__button--selected {
 					svg {
-						stroke: var(--maxi-secondary-color);
+						stroke: $sc;
 					}
 				}
 			}
@@ -53,7 +54,7 @@
 		.maxi-tabs-control__button {
 			padding: 8.5px;
 			margin-right: 5px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 4px;
 			&:last-child {
 				margin-right: 0;
@@ -63,7 +64,7 @@
 			> .maxi-tabs-control__button {
 			padding: 5px;
 			margin-right: 12px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 4px;
 			width: 34px;
 			height: 34px;
@@ -73,26 +74,26 @@
 		}
 
 		.maxi-tabs-control__button[aria-pressed='true'] {
-			background-color: var(--maxi-whisper-green) !important;
-			border-color: var(--maxi-primary-green) !important;
+			background-color: $wg !important;
+			border-color: $pgr !important;
 		}
 		.maxi-tabs-control__button svg:not(.maxi-tabs-control__notification) {
 			height: 100%;
 			margin: 0;
-			fill: var(--maxi-secondary-color) !important;
+			fill: $sc !important;
 		}
 	}
 	.maxi-scroll-unique-control {
 		margin: 20px 0 5px;
 
 		&__slider-wrapper {
-			position: relative;
+			position: $pr;
 		}
 
 		.maxi-scroll-unique-control-slider {
 			width: 2px;
 			height: 400px;
-			background-color: var(--maxi-grey-light) !important;
+			background-color: $gl !important;
 			border-radius: 5px;
 			padding: 20px 0;
 			margin: 0 20px;
@@ -101,35 +102,35 @@
 				width: 30px;
 				height: 30px;
 				line-height: 30px;
-				background-color: var(--maxi-mid-green);
-				border: 1.5px solid var(--maxi-secondary-color);
+				background-color: $mg;
+				border: 1.5px solid $sc;
 				border-radius: 50%;
-				color: var(--maxi-white);
+				color: $w;
 				display: flex;
 				align-items: center;
 				justify-content: center;
 				cursor: grab;
 				outline: none;
-				box-shadow: 0 2px 6px var(--maxi-whisper-green) !important;
+				box-shadow: 0 2px 6px $wg !important;
 				transition: transform 0.1s ease;
 				transform: translateX(-50%);
 				padding: 20px !important;
 
 				&--selected {
 					background-color: var(--maxi-light-blue-alt);
-					color: var(--maxi-white) !important;
+					color: $w !important;
 					font-weight: bold !important;
 				}
 
 				&-label-wrapper {
-					position: absolute;
+					position: $pa;
 					display: flex;
 					align-items: center;
 					justify-content: space-between;
 					gap: 8px;
 					left: 50px;
 					white-space: nowrap;
-					background-color: var(--maxi-pastel-green);
+					background-color: $pg;
 					padding: 4px 20px;
 					border-radius: 20px;
 					width: 200px;
@@ -137,38 +138,38 @@
 
 				&-label-delete {
 					display: flex;
-					cursor: pointer;
+					cursor: $ptr;
 					align-items: center;
 					svg {
 						width: 17px;
 						height: 17px;
 						path {
-							fill: var(--maxi-grey);
+							fill: $g;
 							transition: fill 0.3s ease;
 						}
 					}
 
 					&:hover svg path {
-						fill: var(--maxi-secondary-color) !important;
+						fill: $sc !important;
 					}
 				}
 			}
 
 			&__divider {
-				position: absolute;
+				position: $pa;
 				width: 100%;
 				height: 2px;
-				background-color: var(--maxi-pastel-green);
+				background-color: $pg;
 				top: 50%;
 				transform: translateY(-50%);
 			}
 
 			&__add-button {
-				position: absolute;
+				position: $pa;
 				left: 10px;
 				transform: translateY(-50%);
 				background-color: var(--maxi-deep-golden);
-				color: var(--maxi-white);
+				color: $w;
 				width: 25px;
 				height: 25px;
 				line-height: 20px;
@@ -177,9 +178,9 @@
 				font-size: 16px;
 				font-weight: bolder !important;
 				user-select: none;
-				cursor: pointer;
-				transition: all 0.3s ease;
-				border: 1px solid transparent;
+				cursor: $ptr;
+				transition: $t;
+				border: 1px solid $tr;
 				padding-bottom: 5px !important;
 
 				&:hover {
@@ -196,14 +197,14 @@
 				.maxi-tabs-control__button {
 					padding: 8px;
 					margin-right: 5px;
-					border: 1.5px solid var(--maxi-grey-light) !important;
+					border: $bg !important;
 					border-radius: 4px;
 					font-weight: 400;
 				}
 
 				.maxi-tabs-control__button[aria-pressed='true'] {
-					background-color: var(--maxi-pastel-green) !important;
-					border-color: var(--maxi-primary-green) !important;
+					background-color: $pg !important;
+					border-color: $pgr !important;
 					font-weight: 700;
 				}
 			}
@@ -225,8 +226,8 @@
 		transition: all 0.5s;
 
 		&:hover:enabled {
-			// background-color: var(--maxi-pastel-green);
-			// border-color: var(--maxi-mid-green);
+			// background-color: $pg;
+			// border-color: $mg;
 		}
 	}
 	.maxi-tab-content {

--- a/src/components/select-control/editor.scss
+++ b/src/components/select-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active {
 	select.maxi-select-control__input {
 		flex: 1;
@@ -7,9 +8,9 @@ body.maxi-blocks--active {
 		min-height: unset;
 		max-height: unset !important;
 		padding: 8px;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 		margin: 0;
-		color: var(--maxi-grey);
+		color: $g;
 		background-size: 9px 9px;
 		font-size: 12px;
 		line-height: 14px;
@@ -17,12 +18,12 @@ body.maxi-blocks--active {
 		-webkit-appearance: none;
 		appearance: none;
 		-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
-		cursor: pointer;
+		cursor: $ptr;
 		opacity: 1;
 		outline: 0;
 		background-image: linear-gradient(
-				var(--maxi-grey-light),
-				var(--maxi-grey-light)
+				$gl,
+				$gl
 			),
 			url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(180, 180, 180, 0.9)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
 		background-repeat: no-repeat, no-repeat !important;
@@ -32,18 +33,18 @@ body.maxi-blocks--active {
 		&:focus,
 		&:active {
 			background-image: linear-gradient(
-					var(--maxi-grey-light),
-					var(--maxi-grey-light)
+					$gl,
+					$gl
 				),
 				url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(99, 186, 121, 1)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
 		}
 		svg {
-			fill: var(--maxi-grey);
+			fill: $g;
 		}
 	}
 	.maxi-select-control__input {
 		padding-left: 12px !important;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 	// Consolidate hover rule to avoid empty ruleset warning
 	.maxi-select-control__input:hover,
@@ -70,21 +71,21 @@ body.maxi-blocks--active {
 				}
 			}
 			.maxi-base-control__field {
-				position: relative;
+				position: $pr;
 				margin-top: 12px;
-				background-color: var(--maxi-white);
-				border: 1px solid var(--maxi-grey-light) !important;
+				background-color: $w;
+				border: $bl !important;
 				border-radius: 5px;
 				margin-right: -3px;
 			}
 			.maxi-base-control__label {
-				position: absolute;
+				position: $pa;
 				top: -8px;
 				left: 8px;
 				font-size: 10px !important;
-				color: var(--maxi-grey-dark);
+				color: $gd;
 				font-style: normal;
-				background: var(--maxi-white);
+				background: $w;
 				padding: 0 5px;
 				pointer-events: none;
 				box-sizing: border-box;
@@ -94,10 +95,10 @@ body.maxi-blocks--active {
 				padding: 10px 11px;
 				border: none !important;
 				/* Short right divider + chevron */
-				background-color: var(--maxi-white) !important;
+				background-color: $w !important;
 				background-image: linear-gradient(
-						var(--maxi-grey-light),
-						var(--maxi-grey-light)
+						$gl,
+						$gl
 					),
 					url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(180, 180, 180, 0.9)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
 				background-repeat: no-repeat, no-repeat !important;
@@ -107,8 +108,8 @@ body.maxi-blocks--active {
 				&:focus,
 				&:active {
 					background-image: linear-gradient(
-							var(--maxi-grey-light),
-							var(--maxi-grey-light)
+							$gl,
+							$gl
 						),
 						url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(99, 186, 121, 1)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
 				}

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -1,19 +1,19 @@
 @import '../../../src/css/backend-variables.scss';
 .maxi-settingstab-control {
 	width: 100%;
-	transition: $t;
+	@include transit;
 
 	&.maxi-axis-control__sync {
 		.maxi-tabs-control__button {
 			margin-left: 7px;
 			border: $bg;
 			border-radius: 4px;
-			transition: $t;
+			@include transit;
 			padding: 4px 6px;
 
 			svg {
 				fill: $sc;
-				transition: $t;
+				@include transit;
 			}
 
 			&[aria-pressed='true'],
@@ -35,10 +35,10 @@
 				background: var(--maxi-admin-black);
 				color: var(--maxi-admin-white);
 				border: none;
-				transition: $t;
+				@include transit;
 			}
 			.maxi-tabs-control__button:not(.maxi-tabs-control__button--nested) {
-				transition: $t;
+				@include transit;
 
 				&[aria-pressed='true'] {
 					border-bottom: 1.5px solid $bk !important;
@@ -56,7 +56,7 @@
 			margin-bottom: -18px;
 
 			.maxi-tabs-control__button {
-				transition: $t;
+				@include transit;
 				&:hover {
 					background-color: $pg;
 				}
@@ -68,7 +68,7 @@
 
 		&__sidebar-settings-tabs {
 			.maxi-tabs-control__button[aria-pressed='true'] {
-				transition: $t;
+				@include transit;
 				color: $bk;
 			}
 		}
@@ -93,11 +93,11 @@
 			background-color: $w;
 			text-align: center;
 			white-space: nowrap;
-			transition: $t;
+			@include transit;
 
 			&:last-child {
 				border-right: none;
-				transition: $t;
+				@include transit;
 			}
 			&:hover {
 				background-color: $wg;
@@ -107,17 +107,17 @@
 			&:focus:not(:disabled) {
 				box-shadow: none;
 				outline: none;
-				transition: $t;
+				@include transit;
 			}
 			&:active {
 				background-color: $wg !important;
-				transition: $t;
+				@include transit;
 			}
 			&[aria-pressed='true'] {
 				color: $pc !important;
 				font-weight: 700 !important;
 				background-color: $wg !important;
-				transition: $t;
+				@include transit;
 			}
 			&--active:before {
 				content: '';
@@ -131,16 +131,16 @@
 				background-color: var(--maxi-light-blue-alt);
 				margin-left: 5px;
 				transform: translateY(-50%);
-				transition: $t;
+				@include transit;
 			}
 
 			&.maxi-accordion-control__item__button {
 				padding-left: 25px;
-				transition: $t;
+				@include transit;
 			}
 
 			&.maxi-clip-path-control__handles-button {
-				transition: $t;
+				@include transit;
 				&[aria-pressed='true'] {
 					background-color: $pg;
 					border-color: $mg;
@@ -156,7 +156,7 @@
 			&.maxi-tabs-control__button-visual,
 			&.maxi-tabs-control__button-edit.points {
 				border: $bg !important;
-				transition: $t;
+				@include transit;
 				&[aria-pressed='true'] {
 					background-color: $pg !important;
 					border-color: $pgr !important;
@@ -170,11 +170,11 @@
 				&:last-child {
 					border: $bg !important;
 					border-radius: 6px !important;
-					transition: $t;
+					@include transit;
 				}
 				&:first-child {
 					border-radius: 6px !important;
-					transition: $t;
+					@include transit;
 				}
 			}
 
@@ -189,7 +189,7 @@
 		}
 
 		&__notification {
-			transition: $t;
+			@include transit;
 			position: $pa;
 			z-index: 8;
 			top: 0;
@@ -299,26 +299,26 @@
 
 	.maxi-text-control__input {
 		padding-left: 10px !important;
-		transition: $t;
+		@include transit;
 	}
 
 	.maxi-custom-label {
 		width: 100%;
 		position: $pr;
-		transition: $t;
+		@include transit;
 	}
 	.maxi-base-control.maxi-block-style-control {
 		position: $pr;
 		min-width: 75px;
 		margin: 0 5px;
-		transition: $t;
+		@include transit;
 	}
 	.maxi-block-style-preview {
 		position: $pr;
 		min-width: 100px;
 		margin-left: 10px;
 		height: 32px;
-		transition: $t;
+		@include transit;
 	}
 	.block-style-label-2,
 	.maxi-base-control__label {
@@ -333,7 +333,7 @@
 		pointer-events: none;
 		box-sizing: border-box;
 		-webkit-box-sizing: border-box;
-		transition: $t;
+		@include transit;
 	}
 }
 .block-info-icon {
@@ -346,20 +346,18 @@
 	text-align: center;
 	top: 9px;
 	cursor: $ptr;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	transition: $t;
+	@include flex-center;
+	@include transit;
 
 	&:hover {
 		border-color: $pc;
 		color: $gd;
-		transition: $t;
+		@include transit;
 	}
 
 	span {
 		font-size: 10px;
-		transition: $t;
+		@include transit;
 	}
 }
 /*******************************

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -1,28 +1,29 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-settingstab-control {
 	width: 100%;
-	transition: all 0.5s ease;
+	transition: $t;
 
 	&.maxi-axis-control__sync {
 		.maxi-tabs-control__button {
 			margin-left: 7px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 4px;
-			transition: all 0.5s ease;
+			transition: $t;
 			padding: 4px 6px;
 
 			svg {
-				fill: var(--maxi-secondary-color);
-				transition: all 0.5s ease;
+				fill: $sc;
+				transition: $t;
 			}
 
 			&[aria-pressed='true'],
 			&:hover {
-				background-color: var(--maxi-pastel-green);
-				border: 1.5px solid var(--maxi-secondary-color);
+				background-color: $pg;
+				border: 1.5px solid $sc;
 				font-weight: 700;
 
 				svg {
-					fill: var(--maxi-primary-color) !important;
+					fill: $pc !important;
 				}
 			}
 		}
@@ -34,14 +35,14 @@
 				background: var(--maxi-admin-black);
 				color: var(--maxi-admin-white);
 				border: none;
-				transition: all 0.5s ease;
+				transition: $t;
 			}
 			.maxi-tabs-control__button:not(.maxi-tabs-control__button--nested) {
-				transition: all 0.5s ease;
+				transition: $t;
 
 				&[aria-pressed='true'] {
-					border-bottom: 1.5px solid var(--maxi-black) !important;
-					background-color: var(--maxi-whisper-green);
+					border-bottom: 1.5px solid $bk !important;
+					background-color: $wg;
 				}
 			}
 		}
@@ -55,20 +56,20 @@
 			margin-bottom: -18px;
 
 			.maxi-tabs-control__button {
-				transition: all 0.5s ease;
+				transition: $t;
 				&:hover {
-					background-color: var(--maxi-pastel-green);
+					background-color: $pg;
 				}
 				&:focus:not(:disabled) {
-					background-color: var(--maxi-white);
+					background-color: $w;
 				}
 			}
 		}
 
 		&__sidebar-settings-tabs {
 			.maxi-tabs-control__button[aria-pressed='true'] {
-				transition: all 0.5s ease;
-				color: var(--maxi-black);
+				transition: $t;
+				color: $bk;
 			}
 		}
 		&:not(.maxi-tabs-control--disable-padding) {
@@ -78,49 +79,49 @@
 			margin-bottom: 8px !important;
 		}
 		&__button {
-			position: relative;
+			position: $pr;
 			display: flex;
 			flex-direction: column;
 			width: 100%;
 			height: auto;
 			padding: 12px 8px;
-			border-bottom: 1.5px solid var(--maxi-grey-light);
-			border-top: 1.5px solid var(--maxi-grey-light);
-			border-right: 1.5px solid var(--maxi-grey-light);
+			border-bottom: 1.5px solid $gl;
+			border-top: 1.5px solid $gl;
+			border-right: 1.5px solid $gl;
 			border-radius: 0;
-			color: var(--maxi-grey-dark);
-			background-color: var(--maxi-white);
+			color: $gd;
+			background-color: $w;
 			text-align: center;
 			white-space: nowrap;
-			transition: all 0.5s ease;
+			transition: $t;
 
 			&:last-child {
 				border-right: none;
-				transition: all 0.5s ease;
+				transition: $t;
 			}
 			&:hover {
-				background-color: var(--maxi-whisper-green);
-				cursor: pointer;
-				color: var(--maxi-black);
+				background-color: $wg;
+				cursor: $ptr;
+				color: $bk;
 			}
 			&:focus:not(:disabled) {
 				box-shadow: none;
 				outline: none;
-				transition: all 0.5s ease;
+				transition: $t;
 			}
 			&:active {
-				background-color: var(--maxi-whisper-green) !important;
-				transition: all 0.5s ease;
+				background-color: $wg !important;
+				transition: $t;
 			}
 			&[aria-pressed='true'] {
-				color: var(--maxi-primary-color) !important;
+				color: $pc !important;
 				font-weight: 700 !important;
-				background-color: var(--maxi-whisper-green) !important;
-				transition: all 0.5s ease;
+				background-color: $wg !important;
+				transition: $t;
 			}
 			&--active:before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 5px !important;
 				left: -2px !important;
 				z-index: 1;
@@ -130,66 +131,66 @@
 				background-color: var(--maxi-light-blue-alt);
 				margin-left: 5px;
 				transform: translateY(-50%);
-				transition: all 0.5s ease;
+				transition: $t;
 			}
 
 			&.maxi-accordion-control__item__button {
 				padding-left: 25px;
-				transition: all 0.5s ease;
+				transition: $t;
 			}
 
 			&.maxi-clip-path-control__handles-button {
-				transition: all 0.5s ease;
+				transition: $t;
 				&[aria-pressed='true'] {
-					background-color: var(--maxi-pastel-green);
-					border-color: var(--maxi-mid-green);
-					color: var(--maxi-black);
+					background-color: $pg;
+					border-color: $mg;
+					color: $bk;
 					border-radius: 6px !important;
 				}
 				&:hover {
-					background-color: var(--maxi-whisper-green);
+					background-color: $wg;
 					border-radius: 6px !important;
 				}
 			}
 
 			&.maxi-tabs-control__button-visual,
 			&.maxi-tabs-control__button-edit.points {
-				border: 1.5px solid var(--maxi-grey-light) !important;
-				transition: all 0.5s ease;
+				border: $bg !important;
+				transition: $t;
 				&[aria-pressed='true'] {
-					background-color: var(--maxi-pastel-green) !important;
-					border-color: var(--maxi-primary-green) !important;
-					color: var(--maxi-black) !important;
+					background-color: $pg !important;
+					border-color: $pgr !important;
+					color: $bk !important;
 					font-weight: 700;
 					border-radius: 6px !important;
 				}
 				&:hover {
-					background-color: var(--maxi-whisper-green) !important;
+					background-color: $wg !important;
 				}
 				&:last-child {
-					border: 1.5px solid var(--maxi-grey-light) !important;
+					border: $bg !important;
 					border-radius: 6px !important;
-					transition: all 0.5s ease;
+					transition: $t;
 				}
 				&:first-child {
 					border-radius: 6px !important;
-					transition: all 0.5s ease;
+					transition: $t;
 				}
 			}
 
 			&.maxi-tabs-control__button-edit.points[aria-pressed='true'],
 			&.maxi-tabs-control__button-visual[aria-pressed='true'] {
-				background-color: var(--maxi-whisper-green) !important;
-				border-color: var(--maxi-primary-color) !important;
-				color: var(--maxi-primary-color) !important;
+				background-color: $wg !important;
+				border-color: $pc !important;
+				color: $pc !important;
 				font-weight: 700;
 				border-radius: 6px !important;
 			}
 		}
 
 		&__notification {
-			transition: all 0.5s ease;
-			position: absolute;
+			transition: $t;
+			position: $pa;
 			z-index: 8;
 			top: 0;
 			right: 0;
@@ -197,8 +198,8 @@
 			height: 0;
 			border-style: solid;
 			border-width: 0 8px 8px 0;
-			border-color: transparent var(--maxi-primary-color) transparent
-				transparent;
+			border-color: $tr $pc $tr
+				$tr;
 		}
 
 		.maxi-base-control {
@@ -230,12 +231,12 @@
 	.maxi-tabs-content {
 		&:not(.maxi-tabs-content--disable-padding) {
 			padding: 0px 8px 0px;
-			background-color: var(--maxi-white);
+			background-color: $w;
 		}
 
 		&--nested {
-			background: var(--maxi-white);
-			border: 1.5px solid var(--maxi-secondary-color);
+			background: $w;
+			border: 1.5px solid $sc;
 			padding: 25px 0 0;
 			margin-bottom: 8px;
 			border-radius: 5px;
@@ -244,23 +245,23 @@
 
 		.maxi-tab-content {
 			display: none;
-			background: var(--maxi-white);
+			background: $w;
 
 			&__box {
-				position: relative;
+				position: $pr;
 				padding: 8px;
-				border-top: 1.5px solid var(--maxi-grey-light);
-				border-bottom: 1.5px solid var(--maxi-grey-light);
-				background-color: var(--maxi-white);
+				border-top: 1.5px solid $gl;
+				border-bottom: 1.5px solid $gl;
+				background-color: $w;
 
 				&:after {
 					content: '';
-					position: absolute;
+					position: $pa;
 					bottom: 0;
 					left: 0;
 					width: 100%;
 					height: 1px;
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 				& > *:last-child {
 					.maxi-base-control__field {
@@ -281,10 +282,10 @@
 	&_has-border-left-right {
 		.maxi-tabs-control__button {
 			&:last-child {
-				border-right: 1.5px solid var(--maxi-grey-light);
+				border-right: 1.5px solid $gl;
 			}
 			&:first-child {
-				border-left: 1.5px solid var(--maxi-grey-light);
+				border-left: 1.5px solid $gl;
 			}
 		}
 	}
@@ -293,72 +294,72 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	background-color: var(--maxi-white);
+	background-color: $w;
 	padding-left: 5px;
 
 	.maxi-text-control__input {
 		padding-left: 10px !important;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 
 	.maxi-custom-label {
 		width: 100%;
-		position: relative;
-		transition: all 0.5s ease;
+		position: $pr;
+		transition: $t;
 	}
 	.maxi-base-control.maxi-block-style-control {
-		position: relative;
+		position: $pr;
 		min-width: 75px;
 		margin: 0 5px;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 	.maxi-block-style-preview {
-		position: relative;
+		position: $pr;
 		min-width: 100px;
 		margin-left: 10px;
 		height: 32px;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 	.block-style-label-2,
 	.maxi-base-control__label {
-		position: absolute;
+		position: $pa;
 		top: -8px;
 		left: 8px;
 		font-size: 8px;
-		color: var(--maxi-grey-dark);
+		color: $gd;
 		font-style: italic;
-		background: var(--maxi-white);
+		background: $w;
 		padding: 0 5px;
 		pointer-events: none;
 		box-sizing: border-box;
 		-webkit-box-sizing: border-box;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 }
 .block-info-icon {
-	position: absolute;
+	position: $pa;
 	right: 5px;
-	border: 2px solid var(--maxi-grey-light);
+	border: 2px solid $gl;
 	border-radius: 50%;
 	height: 16px;
 	width: 16px;
 	text-align: center;
 	top: 9px;
-	cursor: pointer;
+	cursor: $ptr;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	transition: all 0.5s ease;
+	transition: $t;
 
 	&:hover {
-		border-color: var(--maxi-primary-color);
-		color: var(--maxi-grey-dark);
-		transition: all 0.5s ease;
+		border-color: $pc;
+		color: $gd;
+		transition: $t;
 	}
 
 	span {
 		font-size: 10px;
-		transition: all 0.5s ease;
+		transition: $t;
 	}
 }
 /*******************************
@@ -370,8 +371,8 @@ html[dir='rtl'] {
 		left: 5px;
 	}
 	.maxi-settingstab-control .maxi-tabs-control__button:last-child {
-		border-left: 1.5px solid var(--maxi-grey-light);
-		border-right: 1.5px solid var(--maxi-grey-light);
+		border-left: 1.5px solid $gl;
+		border-right: 1.5px solid $gl;
 	}
 	.maxi-block-style-preview {
 		margin-left: unset;

--- a/src/components/shape-divider/style.scss
+++ b/src/components/shape-divider/style.scss
@@ -1,5 +1,6 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-shape-divider {
-	position: relative;
+	position: $pr;
 	z-index: 1;
 	transition: all 1s;
 	overflow: hidden;

--- a/src/components/spinner/editor.scss
+++ b/src/components/spinner/editor.scss
@@ -1,17 +1,18 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-spinner {
 	display: inline-block;
-	background-color: var(--maxi-grey-light);
+	background-color: $gl;
 	width: 20px;
 	height: 20px;
 	opacity: 0.7;
 	margin: 5px 11px 0;
 	border-radius: 100%;
-	position: relative;
+	position: $pr;
 
 	&::before {
 		content: '';
-		position: absolute;
-		background-color: var(--maxi-white);
+		position: $pa;
+		background-color: $w;
 		top: 3px;
 		left: 3px;
 		width: 4px;

--- a/src/components/text-control/editor.scss
+++ b/src/components/text-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active .maxi-text-control {
 	.maxi-base-control__field {
 		flex-wrap: wrap;
@@ -9,14 +10,14 @@ body.maxi-blocks--active .maxi-text-control {
 		padding: 2px 8px;
 		border-radius: 5px;
 		background-color: rgba(33, 141, 250, 0);
-		border: 1px solid var(--maxi-grey-light);
+		border: $bl;
 		font-size: 13px;
-		color: var(--maxi-grey-dark);
+		color: $gd;
 		font-weight: 500;
 		flex: 1;
 
 		&:focus {
-			border-color: var(--maxi-grey);
+			border-color: $g;
 		}
 	}
 
@@ -39,17 +40,17 @@ body.maxi-blocks--active .maxi-text-control {
 	}
 	&__second-style {
 		.maxi-base-control__field {
-			position: relative;
+			position: $pr;
 			margin-top: 12px;
 		}
 		.maxi-base-control__label {
-			position: absolute;
+			position: $pa;
 			top: -8px;
 			left: 8px;
 			font-size: 10px !important;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 			font-style: normal;
-			background: var(--maxi-white);
+			background: $w;
 			padding: 0 5px;
 			pointer-events: none;
 			box-sizing: border-box;

--- a/src/components/text-input/editor.scss
+++ b/src/components/text-input/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active {
 	.maxi-text-input {
 		border: none;
@@ -6,7 +7,7 @@ body.maxi-blocks--active {
 		padding: 0;
 		margin: 0;
 		width: 100%;
-		background-color: transparent;
+		background-color: $tr;
 
 		&:focus {
 			border: none;
@@ -15,7 +16,7 @@ body.maxi-blocks--active {
 		}
 
 		&::placeholder {
-			color: var(--maxi-grey);
+			color: $g;
 		}
 	}
 }

--- a/src/components/text-shadow-control/editor.scss
+++ b/src/components/text-shadow-control/editor.scss
@@ -1,13 +1,14 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-textshadow-control {
 	&__default {
 		&__total {
-			text-shadow: 0px 0px 5px var(--maxi-grey);
+			text-shadow: 0px 0px 5px $g;
 		}
 		&__bottom {
-			text-shadow: 5px 0px 3px var(--maxi-grey);
+			text-shadow: 5px 0px 3px $g;
 		}
 		&__solid {
-			text-shadow: 2px 4px 0px var(--maxi-grey);
+			text-shadow: 2px 4px 0px $g;
 		}
 	}
 }

--- a/src/components/textarea-control/editor.scss
+++ b/src/components/textarea-control/editor.scss
@@ -1,11 +1,12 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-textarea-control__input {
 	width: 100%;
 	padding: 6px 8px;
 
-	box-shadow: 0 0 0 transparent;
+	box-shadow: 0 0 0 $tr;
 	transition: box-shadow 0.1s linear;
 	border-radius: 2px;
-	border: 1px solid var(--maxi-grey-light);
+	border: $bl;
 	transition-duration: 0ms;
 
 	/* Fonts smaller than 16px causes mobile safari to zoom. */
@@ -20,18 +21,18 @@
 	}
 
 	&:focus {
-		border-color: var(--maxi-grey-light);
+		border-color: $gl;
 	}
 	// Use opacity to work in various editor styles.
 	&::-webkit-input-placeholder {
-		color: rgba(var(--maxi-grey-dark), 0.62);
+		color: rgba($gd, 0.62);
 	}
 	&::-moz-placeholder {
 		opacity: 1; // Necessary because Firefox reduces this from 1.
-		color: rgba(var(--maxi-grey-dark), 0.62);
+		color: rgba($gd, 0.62);
 	}
 	&:-ms-input-placeholder {
-		color: rgba(var(--maxi-grey-dark), 0.62);
+		color: rgba($gd, 0.62);
 	}
 
 	&--disable-resize {

--- a/src/components/toggle-switch/editor.scss
+++ b/src/components/toggle-switch/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	.maxi-toggle-switch__toggle {
 		&__track {
@@ -5,14 +6,14 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 		}
 		input[type='checkbox'] {
 			&:focus + .maxi-toggle-switch__toggle__track {
-				box-shadow: 0 0 0 1px var(--maxi-secondary-color);
+				box-shadow: 0 0 0 1px $sc;
 			}
 		}
 	}
 }
 
 .maxi-toggle-switch {
-	position: relative;
+	position: $pr;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -21,8 +22,8 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 	&--is-checked {
 		.maxi-toggle-switch__toggle__thumb {
-			background-color: var(--maxi-primary-color);
-			border-color: var(--maxi-primary-color);
+			background-color: $pc;
+			border-color: $pc;
 			transform: translateX(20px);
 		}
 	}
@@ -35,15 +36,15 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			margin-bottom: 0;
 		}
 		&__label {
-			cursor: pointer;
+			cursor: $ptr;
 		}
 	}
 	&__toggle {
-		position: relative;
-		cursor: pointer;
+		position: $pr;
+		cursor: $ptr;
 
 		input[type='checkbox'] {
-			position: absolute;
+			position: $pa;
 			z-index: 1;
 			top: 0;
 			left: 0;
@@ -55,7 +56,7 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 			&:focus + .maxi-toggle-switch__toggle__track {
 				border-radius: 12px;
-				outline: 1px solid transparent;
+				outline: 1px solid $tr;
 			}
 		}
 		&__track {
@@ -65,27 +66,27 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 			vertical-align: top;
 			width: 44px;
 			height: 24px;
-			background-color: var(--maxi-white);
+			background-color: $w;
 			background-image: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.8 8"><path fill="rgb(147, 147, 147)" d="M8.43.22A1 1 0 0 0 7 .37L2.93 5.48 1.72 4.21a1 1 0 0 0-1.41 0 1 1 0 0 0 0 1.41l2 2.1h.05a.83.83 0 0 0 .16.09l.1.06A1.15 1.15 0 0 0 3 8a.93.93 0 0 0 .4-.09l.11-.07a.71.71 0 0 0 .18-.12s0 0 0-.06l4.8-6A1 1 0 0 0 8.43.22Z"/></svg>'),
 				url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><path fill="rgb(147, 147, 147)" d="m5.6 4 2.55-2.55A.85.85 0 1 0 7 .25L4.4 2.8 1.85.25a.85.85 0 0 0-1.2 1.2L3.2 4 .65 6.55a.85.85 0 0 0 0 1.2.83.83 0 0 0 .6.25.82.82 0 0 0 .6-.25L4.4 5.2 7 7.75a.82.82 0 0 0 .6.25.83.83 0 0 0 .6-.25.85.85 0 0 0 0-1.2Z" transform="translate(-.4)"/></svg>');
 			background-repeat: no-repeat, no-repeat;
 			background-position: 8px center, 24px center;
 			background-size: 10px auto, 10px auto;
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			border: $bg !important;
 			border-radius: 12px;
 			outline: 0;
 			transition: 0.2s background ease, 0.2s border-color ease;
 		}
 		&__thumb {
-			position: absolute;
+			position: $pa;
 			top: 3px;
 			left: 3px;
 			display: block;
 			box-sizing: border-box;
 			width: 18px;
 			height: 18px;
-			background-color: var(--maxi-white);
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			background-color: $w;
+			border: $bg !important;
 			border-radius: 50%;
 			transition: 0.1s transform ease;
 		}
@@ -94,10 +95,10 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 
 .maxi-toggle-switch__toggle:hover {
 	.maxi-toggle-switch__toggle__track {
-		border-color: var(--maxi-grey) !important;
+		border-color: $g !important;
 	}
 	.maxi-toggle-switch__toggle__thumb {
-		border-color: var(--maxi-grey) !important;
+		border-color: $g !important;
 	}
 }
 

--- a/src/components/toolbar/components/alignment/editor.scss
+++ b/src/components/toolbar/components/alignment/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-dropdown__alignment-content {
 	z-index: 99999999;
 	margin: -33px 0 0 98px !important;
@@ -15,10 +16,10 @@
 					display: block;
 					align-items: flex-start;
 					&:hover {
-						background-color: var(--maxi-grey-light);
+						background-color: $gl;
 					}
 					&:focus:not(:disabled) {
-						background-color: var(--maxi-white);
+						background-color: $w;
 					}
 				}
 			}

--- a/src/components/toolbar/components/background-color/editor.scss
+++ b/src/components/toolbar/components/background-color/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__background {
 	&__popover {
 		min-width: 279px;

--- a/src/components/toolbar/components/border/editor.scss
+++ b/src/components/toolbar/components/border/editor.scss
@@ -1,9 +1,10 @@
+@import '../../../../../src/css/backend-variables.scss';
 // Border toolbar item styles
 .toolbar-item__border {
 	width: 33px !important;
 	height: 33px !important;
-	background-color: var(--maxi-white);
-	border-right: 1px solid var(--maxi-grey-light);
+	background-color: $w;
+	border-right: $bl;
 
 	// Icon alignment specific to border
 	.toolbar-item__icon {
@@ -18,7 +19,7 @@
 	// Hover states for border icon
 	&:hover,
 	&[aria-expanded='true'] {
-		background-color: var(--maxi-pastel-green);
+		background-color: $pg;
 
 		svg,
 		.toolbar-item__icon {
@@ -28,18 +29,18 @@
 			rect,
 			polyline,
 			path {
-				stroke: var(--maxi-secondary-color);
-				fill: var(--maxi-secondary-color);
+				stroke: $sc;
+				fill: $sc;
 			}
 		}
 	}
 
 	// Keyboard accessibility focus treatment
 	&:focus-visible {
-		outline: 2px solid var(--maxi-primary-color);
+		outline: 2px solid $pc;
 		outline-offset: 2px;
-		box-shadow: 0 0 0 1px var(--maxi-white),
-			0 0 0 3px var(--maxi-primary-color);
+		box-shadow: 0 0 0 1px $w,
+			0 0 0 3px $pc;
 		border-radius: 3px;
 	}
 }

--- a/src/components/toolbar/components/box-shadow/editor.scss
+++ b/src/components/toolbar/components/box-shadow/editor.scss
@@ -1,10 +1,11 @@
+@import '../../../../../src/css/backend-variables.scss';
 // Box shadow toolbar item styles
 .toolbar-item__box-shadow {
 	// Ensure proper toolbar button dimensions
 	width: var(--mx-toolbar-size) !important;
 	height: var(--mx-toolbar-size) !important;
-	background-color: var(--maxi-white);
-	border-right: var(--maxi-border-1px) solid var(--maxi-grey-light);
+	background-color: $w;
+	border-right: var(--maxi-border-1px) solid $gl;
 
 	// Icon alignment specific to box shadow
 	.toolbar-item__icon {
@@ -18,7 +19,7 @@
 	// Hover states for box shadow icon
 	&:hover,
 	&[aria-expanded='true'] {
-		background-color: var(--maxi-pastel-green);
+		background-color: $pg;
 
 		svg,
 		.toolbar-item__icon {
@@ -28,8 +29,8 @@
 			rect,
 			polyline,
 			path {
-				stroke: var(--maxi-secondary-color);
-				fill: var(--maxi-secondary-color);
+				stroke: $sc;
+				fill: $sc;
 			}
 		}
 	}

--- a/src/components/toolbar/components/column-mover/editor.scss
+++ b/src/components/toolbar/components/column-mover/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item-move__horizontally {
 	display: flex;
 	align-items: center;
@@ -20,7 +21,7 @@
 		}
 		&:hover {
 			path {
-				fill: var(--maxi-secondary-color) !important;
+				fill: $sc !important;
 			}
 		}
 	}

--- a/src/components/toolbar/components/column-pattern/editor.scss
+++ b/src/components/toolbar/components/column-pattern/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__column-pattern__popover {
 	min-width: 392px;
 
@@ -25,13 +26,13 @@
 			&--toolbar {
 				&:hover {
 					svg path {
-						fill: var(--maxi-white);
+						fill: $w;
 					}
 				}
 
 				&[aria-pressed='true'] {
 					svg path {
-						fill: var(--maxi-white);
+						fill: $w;
 					}
 				}
 
@@ -47,7 +48,7 @@
 	.toolbar-item__icon {
 		path {
 			&:nth-child(2) {
-				fill: transparent !important;
+				fill: $tr !important;
 			}
 		}
 	}

--- a/src/components/toolbar/components/column-size/editor.scss
+++ b/src/components/toolbar/components/column-size/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__column-size__popover {
 	min-width: 300px;
 }

--- a/src/components/toolbar/components/columns-handlers/editor.scss
+++ b/src/components/toolbar/components/columns-handlers/editor.scss
@@ -1,9 +1,10 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__columns-handler {
 	&[aria-pressed='true'] {
 		svg {
 			ellipse,
 			path {
-				fill: var(--maxi-primary-color) !important;
+				fill: $pc !important;
 			}
 		}
 	}

--- a/src/components/toolbar/components/context-loop/editor.scss
+++ b/src/components/toolbar/components/context-loop/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover {
 	.toolbar-item__context-loop__popover {
 		min-width: 280px;
@@ -23,32 +24,32 @@
 		input[type='text'],
 		input[type='number'],
 		select {
-			border: 2px solid var(--maxi-grey-light);
-			color: var(--maxi-grey-light);
+			border: 2px solid $gl;
+			color: $gl;
 		}
 	}
 	.maxi-axis-control {
-		color: var(--maxi-white);
+		color: $w;
 		&__content {
 			&__item {
 				&__checkbox {
 					input {
-						border: 2px solid var(--maxi-grey-light);
-						background-color: var(--maxi-grey-dark);
+						border: 2px solid $gl;
+						background-color: $gd;
 						&:focus {
-							border-color: var(--maxi-grey-light);
+							border-color: $gl;
 						}
 					}
 				}
 				&__sync {
 					margin-top: 35px;
-					border-color: var(--maxi-grey-light);
+					border-color: $gl;
 					button {
 						&[aria-pressed='true'] {
-							background: var(--maxi-grey-dark) !important;
+							background: $gd !important;
 						}
 						svg {
-							fill: var(--maxi-white);
+							fill: $w;
 						}
 					}
 				}

--- a/src/components/toolbar/components/copy-paste/editor.scss
+++ b/src/components/toolbar/components/copy-paste/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__copy-paste {
 	&__popover {
 		form {
@@ -10,32 +11,32 @@
 
 			/* Track */
 			&::-webkit-scrollbar-track {
-				background: var(--maxi-white);
+				background: $w;
 			}
 
 			/* Handle */
 			&::-webkit-scrollbar-thumb {
-				background: var(--maxi-grey-light);
+				background: $gl;
 				border-radius: 0;
-				cursor: pointer;
+				cursor: $ptr;
 			}
 
 			/* Handle on hover */
 			&::-webkit-scrollbar-thumb:hover {
-				background: var(--maxi-primary-color);
+				background: $pc;
 			}
 		}
 
 		&__item {
-			border-top: 1px solid var(--maxi-grey-light);
-			position: relative;
-			cursor: pointer;
+			border-top: $bl;
+			position: $pr;
+			cursor: $ptr;
 			margin: 0;
 			padding: 5px 20px 5px 7px;
 			display: flex;
 			align-items: center;
 			&:hover {
-				background-color: var(--maxi-grey-light);
+				background-color: $gl;
 			}
 			&[data-copy_paste_group] {
 				padding: 3px 7px 3px 15px;
@@ -56,31 +57,31 @@
 			}
 
 			&:last-child {
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 			}
 
 			.maxi-axis-control__content__item__checkbox {
 				display: flex;
 				align-items: center;
-				color: var(--maxi-black);
+				color: $bk;
 				margin-top: 0;
 				width: 100%;
 			}
 
 			input[type='checkbox'] {
-				border-color: var(--maxi-grey-light);
+				border-color: $gl;
 				border-radius: 0;
 				margin: 0;
 				box-shadow: none;
 				&:hover {
-					border-color: var(--maxi-black);
+					border-color: $bk;
 				}
 				&:focus {
 					box-shadow: none;
 				}
 
 				&:checked {
-					border-color: var(--maxi-black);
+					border-color: $bk;
 					&::before {
 						content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M14.83 4.89l1.34.94-5.81 8.38H9.02L5.78 9.67l1.34-1.25 2.57 2.4z' fill='%2380828a'/%3E%3C/svg%3E");
 						margin: -3px 0 0 -5px;
@@ -88,7 +89,7 @@
 				}
 				& + span {
 					padding-left: 5px;
-					color: var(--maxi-black);
+					color: $bk;
 				}
 			}
 			&__group {
@@ -101,7 +102,7 @@
 		&__button {
 			display: flex;
 			width: 100%;
-			color: var(--maxi-black);
+			color: $bk;
 			text-align: left;
 			border-radius: 0;
 			box-shadow: none;
@@ -110,14 +111,14 @@
 				&::before {
 					content: '';
 					display: block;
-					position: absolute;
+					position: $pa;
 					top: 0;
 					left: 0;
 					bottom: 0;
 					width: 100%;
 					height: 1px;
 					margin: 0;
-					background-color: var(--maxi-grey-light);
+					background-color: $gl;
 				}
 			}
 
@@ -128,9 +129,9 @@
 			&--special {
 				display: block;
 				height: 30px;
-				background: var(--maxi-primary-color) !important;
+				background: $pc !important;
 				border-radius: 0;
-				color: var(--maxi-white);
+				color: $w;
 				font-size: 12px;
 				text-align: center !important;
 				padding-top: 4px !important;
@@ -146,7 +147,7 @@
 			}
 
 			&:hover {
-				color: var(--maxi-secondary-color);
+				color: $sc;
 			}
 		}
 	}
@@ -155,7 +156,7 @@
 .copy-paste__group-icon {
 	&:after {
 		content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5.783 9.578"><path d="M5.783 4.758a.963.963 0 01-.283.684L1.651 9.295A.967.967 0 01.283 7.927l3.179-3.169L.293 1.59A.963.963 0 011.651.232L5.5 4.084a.963.963 0 01.283.674z" /></svg>');
-		position: absolute;
+		position: $pa;
 		top: 50%;
 		right: 7px;
 		width: 6px;
@@ -169,8 +170,8 @@
 		}
 	}
 	&[aria-expanded='true'] {
-		border-bottom: 1px solid var(--maxi-grey-light);
-		background: var(--maxi-white);
+		border-bottom: $bl;
+		background: $w;
 
 		&:after {
 			transform: translateY(-50%) rotate(90deg);
@@ -189,34 +190,34 @@
 
 		/* Track */
 		&::-webkit-scrollbar-track {
-			background: var(--maxi-white);
+			background: $w;
 		}
 
 		/* Handle */
 		&::-webkit-scrollbar-thumb {
-			background: var(--maxi-grey-light);
+			background: $gl;
 			border-radius: 0;
-			cursor: pointer;
+			cursor: $ptr;
 		}
 
 		/* Handle on hover */
 		&::-webkit-scrollbar-thumb:hover {
-			background: var(--maxi-primary-color);
+			background: $pc;
 		}
 		.maxi-settingstab-control {
 			.maxi-tabs-control {
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				.components-button {
-					border-right: 1px solid var(--maxi-grey-light);
+					border-right: $bl;
 					text-align: center;
 					display: flex;
 					padding-left: 0;
 					padding-right: 0;
 					transition: background-color 0.3s;
-					border-bottom: 2px solid transparent;
+					border-bottom: 2px solid $tr;
 					font-weight: 400 !important;
 					&:last-child {
-						background-color: var(--maxi-white);
+						background-color: $w;
 						border-right: none !important;
 					}
 					&::before {

--- a/src/components/toolbar/components/divider-alignment/editor.scss
+++ b/src/components/toolbar/components/divider-alignment/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover {
 	.toolbar-item__divider-alignment__popover {
 		min-width: 270px;
@@ -5,18 +6,18 @@
 
 	.maxi-alignment-control {
 		.maxi-tabs-control__button {
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			padding: 5px 30px;
 
 			&:hover {
-				background-color: var(--maxi-whisper-green);
-				border-color: var(--maxi-primary-color) !important;
+				background-color: $wg;
+				border-color: $pc !important;
 			}
 
 			&[aria-pressed='true'] {
-				background-color: var(--maxi-whisper-green) !important;
-				border-color: var(--maxi-primary-color) !important;
-				color: var(--maxi-black) !important;
+				background-color: $wg !important;
+				border-color: $pc !important;
+				color: $bk !important;
 			}
 		}
 		.maxi-tabs-control {

--- a/src/components/toolbar/components/divider-color/editor.scss
+++ b/src/components/toolbar/components/divider-color/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__divider-color__popover {
 	min-width: 300px;
 	.maxi-opacity-control {

--- a/src/components/toolbar/components/divider-line/editor.scss
+++ b/src/components/toolbar/components/divider-line/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__divider-line__popover {
 	min-width: 302px;
 

--- a/src/components/toolbar/components/dynamic-content/editor.scss
+++ b/src/components/toolbar/components/dynamic-content/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover {
 	.toolbar-item__dynamic-content__popover {
 		min-width: 280px;
@@ -28,8 +29,8 @@
 		input[type='text'],
 		input[type='number'],
 		select {
-			border: 2px solid var(--maxi-grey-light);
-			color: var(--maxi-grey-light);
+			border: 2px solid $gl;
+			color: $gl;
 		}
 	}
 	.maxi-axis-control {

--- a/src/components/toolbar/components/help/editor.scss
+++ b/src/components/toolbar/components/help/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item {
 	&__help {
 		width: auto !important;

--- a/src/components/toolbar/components/icon-background/editor.scss
+++ b/src/components/toolbar/components/icon-background/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__icon-background__popover {
 	min-width: 300px;
 
@@ -6,7 +7,7 @@
 		font-style: italic;
 		margin-bottom: 8px;
 		margin-top: 0;
-		border-left: 2px solid var(--maxi-primary-color);
+		border-left: 2px solid $pc;
 		padding: 4px 0 4px 9px;
 		border-radius: 0;
 		color: #151617;

--- a/src/components/toolbar/components/icon-color/editor.scss
+++ b/src/components/toolbar/components/icon-color/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__icon-color__popover {
 	min-width: 300px;
 
@@ -6,7 +7,7 @@
 		font-style: italic;
 		margin-bottom: 8px;
 		margin-top: 0;
-		border-left: 2px solid var(--maxi-primary-color);
+		border-left: 2px solid $pc;
 		padding: 4px 0 4px 9px;
 		border-radius: 0;
 		color: #151617;

--- a/src/components/toolbar/components/icon-position/editor.scss
+++ b/src/components/toolbar/components/icon-position/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__icon-position__popover {
 	min-width: 176px;
 	.maxi-base-control__label {

--- a/src/components/toolbar/components/icon-size/editor.scss
+++ b/src/components/toolbar/components/icon-size/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__icon-size__popover {
 	min-width: 216px;
 	.maxi-advanced-number-control__value {

--- a/src/components/toolbar/components/link/editor.scss
+++ b/src/components/toolbar/components/link/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__link {
 	& > div {
 		display: block;

--- a/src/components/toolbar/components/media-upload/editor.scss
+++ b/src/components/toolbar/components/media-upload/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__replace-image {
 	.maxi-dropdown__url-upload-content {
 		& .maxi-components-popover__content.components-popover__content {

--- a/src/components/toolbar/components/more-settings/editor.scss
+++ b/src/components/toolbar/components/more-settings/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item {
 	&__more-settings {
 		width: auto !important;
@@ -21,7 +22,7 @@
 		margin-left: 0 !important;
 		margin-top: 15px;
 		transform: translate(3px, -13px);
-		background-color: var(--maxi-white);
+		background-color: $w;
 		font-family: 'Inter', sans-serif !important;
 		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 
@@ -35,8 +36,8 @@
 					height: 1px;
 					left: 12px;
 					right: 12px;
-					background-color: var(--maxi-grey-light);
-					position: absolute;
+					background-color: $gl;
+					position: $pa;
 					bottom: 0;
 				}
 			}
@@ -56,7 +57,7 @@
 			display: block;
 			width: 100%;
 			text-align: left;
-			position: relative;
+			position: $pr;
 			transition: 0.3s;
 			height: 30px !important;
 			padding: 6px 12px !important;
@@ -64,8 +65,8 @@
 				float: right;
 			}
 			&:hover {
-				background-color: var(--maxi-whisper-green);
-				color: var(--maxi-primary-color) !important;
+				background-color: $wg;
+				color: $pc !important;
 			}
 			&::after {
 				content: '';
@@ -74,8 +75,8 @@
 				left: 0;
 				right: 0;
 				width: 0;
-				background-color: var(--maxi-secondary-color);
-				position: absolute;
+				background-color: $sc;
+				position: $pa;
 				bottom: 0;
 				margin: auto;
 				transition: 0.3s;

--- a/src/components/toolbar/components/mover/editor.scss
+++ b/src/components/toolbar/components/mover/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item-move__vertically {
 	display: flex;
 	align-items: center;
@@ -19,16 +20,16 @@
 
 		&:hover {
 			background-color: #eaf2f6 !important;
-			border-color: var(--maxi-secondary-color) !important;
+			border-color: $sc !important;
 
 			path {
-				fill: var(--maxi-secondary-color) !important;
+				fill: $sc !important;
 			}
 		}
 	}
 
 	.components-button:nth-child(1) {
-		border-top: 2px solid transparent;
+		border-top: 2px solid $tr;
 
 		svg {
 			margin-top: auto !important;
@@ -40,7 +41,7 @@
 	}
 
 	.components-button:nth-child(2) {
-		border-bottom: 2px solid transparent;
+		border-bottom: 2px solid $tr;
 
 		svg {
 			margin-bottom: auto !important;
@@ -57,20 +58,20 @@
 	}
 
 	.components-button:nth-child(1) {
-		border-left: 2px solid transparent;
+		border-left: 2px solid $tr;
 
 		&:hover {
 			background-color: #eaf2f6 !important;
-			border-color: var(--maxi-secondary-color);
+			border-color: $sc;
 		}
 	}
 	.components-button:nth-child(2) {
-		border-right: 2px solid transparent;
+		border-right: 2px solid $tr;
 		z-index: 1;
 
 		&:hover {
 			background-color: #eaf2f6 !important;
-			border-color: var(--maxi-secondary-color);
+			border-color: $sc;
 		}
 	}
 }

--- a/src/components/toolbar/components/reusable-blocks/editor.scss
+++ b/src/components/toolbar/components/reusable-blocks/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__reusable-blocks {
 	&__popover {
 		min-width: 350px;

--- a/src/components/toolbar/components/size/editor.scss
+++ b/src/components/toolbar/components/size/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__size__popover {
 	min-width: 230px;
 }

--- a/src/components/toolbar/components/slider-settings/editor.scss
+++ b/src/components/toolbar/components/slider-settings/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__size__popover {
 	min-width: 230px;
 

--- a/src/components/toolbar/components/slider-slides-settings/editor.scss
+++ b/src/components/toolbar/components/slider-slides-settings/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__slide__popover {
 	display: flex;
 	padding-bottom: 10px;
@@ -5,7 +6,7 @@
 	padding-left: 0;
 	margin-left: -9px;
 	.maxi-slider-toolbar__slide {
-		position: relative;
+		position: $pr;
 		margin: 0 7px;
 		span {
 			display: block;
@@ -19,12 +20,12 @@
 		&:hover,
 		&--active {
 			span {
-				border-color: var(--maxi-primary-color);
-				color: var(--maxi-primary-color);
+				border-color: $pc;
+				color: $pc;
 			}
 		}
 		.maxi-slider-toolbar__slide-remove {
-			position: absolute;
+			position: $pa;
 			right: -9px;
 			top: -9px;
 			padding: 0;
@@ -39,8 +40,8 @@
 			}
 			&:hover {
 				svg {
-					background-color: var(--maxi-primary-color);
-					border-color: var(--maxi-primary-color);
+					background-color: $pc;
+					border-color: $pc;
 					path {
 						fill: white;
 					}

--- a/src/components/toolbar/components/svg-color/editor.scss
+++ b/src/components/toolbar/components/svg-color/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__svg-color__popover {
 	min-width: 300px;
 }

--- a/src/components/toolbar/components/svg-width/editor.scss
+++ b/src/components/toolbar/components/svg-width/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__svg-size__popover {
 	min-width: 300px;
 }

--- a/src/components/toolbar/components/text-bold/editor.scss
+++ b/src/components/toolbar/components/text-bold/editor.scss
@@ -1,7 +1,8 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__bold {
 	&[aria-pressed='true'] {
 		svg path {
-			fill: var(--maxi-primary-color);
+			fill: $pc;
 		}
 	}
 }

--- a/src/components/toolbar/components/text-color/editor.scss
+++ b/src/components/toolbar/components/text-color/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__text-color__popover {
 	min-width: 300px;
 }

--- a/src/components/toolbar/components/text-generator/editor.scss
+++ b/src/components/toolbar/components/text-generator/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .maxi-dropdown__text-generator-child-content {
 	.components-popover__content {
 		width: 230px !important;
@@ -13,8 +14,8 @@
 		clear: both;
 	}
 	.components-button {
-		border: 1px solid var(--maxi-grey-light) !important;
-		color: var(--maxi-black) !important;
+		border: $bl !important;
+		color: $bk !important;
 		border-radius: 0;
 		height: 30px;
 		width: 72px !important;
@@ -30,11 +31,11 @@
 		}
 
 		&:hover {
-			background-color: var(--maxi-grey-dark);
+			background-color: $gd;
 		}
 
 		&:active {
-			background-color: var(--maxi-grey-dark);
+			background-color: $gd;
 		}
 	}
 	.maxi-base-control__label {

--- a/src/components/toolbar/components/text-italic/editor.scss
+++ b/src/components/toolbar/components/text-italic/editor.scss
@@ -1,7 +1,8 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__italic {
 	&[aria-pressed='true'] {
 		svg path {
-			fill: var(--maxi-primary-color);
+			fill: $pc;
 		}
 	}
 }

--- a/src/components/toolbar/components/text-level/editor.scss
+++ b/src/components/toolbar/components/text-level/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover .maxi-font-level-control {
 	&__button {
 		&:hover,
 		&[aria-pressed='true'] {
-			color: var(--maxi-secondary-color);
+			color: $sc;
 		}
 	}
 }

--- a/src/components/toolbar/components/text-link/editor.scss
+++ b/src/components/toolbar/components/text-link/editor.scss
@@ -1,13 +1,14 @@
+@import '../../../../../src/css/backend-variables.scss';
 body .toolbar-item__popover {
 	.components-form-toggle {
 		&.is-checked {
 			.components-form-toggle__track {
-				background-color: var(--maxi-grey-dark);
+				background-color: $gd;
 			}
 		}
 		.components-form-toggle__track {
 			border: 0;
-			background-color: var(--maxi-white);
+			background-color: $w;
 		}
 	}
 	.block-editor-url-input {
@@ -19,27 +20,27 @@ body .toolbar-item__popover {
 		}
 	}
 	.block-editor-url-input__input {
-		background-color: transparent;
-		color: var(--maxi-white);
-		border: 1.5px solid var(--maxi-grey) !important;
+		background-color: $tr;
+		color: $w;
+		border: 1.5px solid $g !important;
 
 		&::placeholder {
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 	}
 	.block-editor-link-control__search-item-title {
-		color: var(--maxi-grey);
+		color: $g;
 	}
 	.block-editor-link-control__search-submit {
 		&.has-icon {
 			padding: 0 !important;
 		}
 		svg {
-			fill: var(--maxi-grey-dark) !important;
+			fill: $gd !important;
 			transition: fill 0.4s ease;
 
 			&:hover {
-				fill: var(--maxi-primary-color) !important;
+				fill: $pc !important;
 			}
 		}
 	}
@@ -48,7 +49,7 @@ body .toolbar-item__popover {
 		padding: 0 18px 15px;
 	}
 	.toolbar-popover-link-destroyer {
-		background: var(--maxi-white);
+		background: $w;
 	}
 	input[type='text'].components-input-control__input:hover {
 		border: none !important;

--- a/src/components/toolbar/components/text-list-options/editor.scss
+++ b/src/components/toolbar/components/text-list-options/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover__list-options {
 	display: flex;
 	margin: -13px -11px 0;
@@ -5,13 +6,13 @@
 	&__button {
 		font-weight: 700;
 		font-size: 15px;
-		border-right: 1px solid var(--maxi-grey-light);
-		transition: all 0.4s ease !important;
+		border-right: $bl;
+		transition: $t !important;
 
 		&:hover {
-			color: var(--maxi-primary-color) !important;
+			color: $pc !important;
 			svg path {
-				stroke: var(--maxi-primary-color) !important;
+				stroke: $pc !important;
 			}
 		}
 
@@ -20,17 +21,17 @@
 		}
 
 		svg path {
-			fill: transparent;
+			fill: $tr;
 			stroke: #000;
 			stroke-width: 1;
 		}
 
 		&[aria-pressed='true'] {
-			color: var(--maxi-secondary-color);
-			border-bottom: 2px solid var(--maxi-secondary-color);
+			color: $sc;
+			border-bottom: 2px solid $sc;
 
 			svg path {
-				stroke: var(--maxi-secondary-color);
+				stroke: $sc;
 			}
 		}
 	}
@@ -42,7 +43,7 @@
 	.toolbar-item {
 	&__list-options {
 		svg path {
-			fill: transparent;
+			fill: $tr;
 			stroke: #000;
 		}
 	}

--- a/src/components/toolbar/components/text-margin/editor.scss
+++ b/src/components/toolbar/components/text-margin/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item {
 	&__text-margin {
 		// Fix button sizing issues - prevent 100% width problems
@@ -18,8 +19,8 @@
 
 			line,
 			path {
-				fill: transparent !important;
-				stroke: var(--maxi-black) !important;
+				fill: $tr !important;
+				stroke: $bk !important;
 			}
 		}
 	}

--- a/src/components/toolbar/components/text-options/editor.scss
+++ b/src/components/toolbar/components/text-options/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 // Main container for the toolbar popup
 .toolbar-item__popover {
 	// Container for font-related options
@@ -8,7 +9,7 @@
 		&__wrap {
 			display: flex; // Makes children align horizontally
 			align-items: center; // Vertically centers items in container
-			border-top: 1px solid var(--maxi-grey-light); // Adds separator line
+			border-top: $bl; // Adds separator line
 
 			// Styles for base control elements
 			.maxi-base-control {
@@ -19,7 +20,7 @@
 
 			// Default SVG icon styling
 			svg {
-				fill: none; // Makes SVG icons transparent by default
+				fill: none; // Makes SVG icons $tr by default
 				&:hover {
 					fill: none !important; // Maintains transparency on hover
 				}
@@ -43,11 +44,11 @@
 
 					// Active button state
 					&[aria-pressed='true'] {
-						color: var(--maxi-primary-color);
+						color: $pc;
 						// Changes text color when active
-						background-color: var(--maxi-white) !important;
+						background-color: $w !important;
 						fill: none !important;
-						border-bottom: 3px solid var(--maxi-primary-color) !important; // Adds highlight bar
+						border-bottom: 3px solid $pc !important; // Adds highlight bar
 					}
 				}
 
@@ -57,14 +58,14 @@
 					fill: none !important;
 
 					path {
-						stroke: var(--maxi-black); // Default icon color
+						stroke: $bk; // Default icon color
 					}
 				}
 				&:hover {
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 					svg {
 						path {
-							stroke: var(--maxi-secondary-color) !important;
+							stroke: $sc !important;
 						}
 					}
 				}
@@ -78,7 +79,7 @@
 				margin: 0;
 
 				&__button {
-					border-color: var(--maxi-grey-light);
+					border-color: $gl;
 					border-style: solid;
 					border-width: 0 1px 0 0;
 
@@ -110,7 +111,7 @@
 						svg {
 							width: 14px;
 							path {
-								stroke: var(--maxi-black);
+								stroke: $bk;
 								transition: stroke 0.2s ease;
 							}
 						}
@@ -124,7 +125,7 @@
 			}
 
 			.maxi-font-family-selector__control__control {
-				// border-color: var(--maxi-grey-light);
+				// border-color: $gl;
 				border-style: solid;
 				border-width: 0 1px 0 0;
 				height: 36px;
@@ -173,8 +174,8 @@
 				}
 
 				&__button {
-					color: var(--maxi-white);
-					border-color: var(--maxi-grey);
+					color: $w;
+					border-color: $g;
 				}
 			}
 
@@ -196,8 +197,8 @@
 					margin-bottom: 0;
 
 					.maxi-font-family-selector__control__control:hover {
-						background-color: var(--maxi-white);
-						cursor: pointer;
+						background-color: $w;
+						cursor: $ptr;
 					}
 				}
 			}
@@ -222,7 +223,7 @@
 					margin-right: 3px;
 
 					path {
-						// stroke: var(--maxi-black);
+						// stroke: $bk;
 					}
 				}
 			}

--- a/src/components/toolbar/components/toolbar-popover/editor.scss
+++ b/src/components/toolbar/components/toolbar-popover/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__popover {
 	.maxi-button-group-control {
 		.maxi-base-control__field {
@@ -14,7 +15,7 @@
 			background-color: rgba(33, 141, 250, 0);
 			font-size: 13px;
 			line-height: 13px;
-			color: var(--maxi-white);
+			color: $w;
 			font-weight: 500;
 			flex: 1;
 			border-bottom: none;
@@ -50,11 +51,11 @@
 			input {
 				display: none;
 				&:checked ~ label {
-					background-color: var(--maxi-grey);
-					position: relative;
+					background-color: $g;
+					position: $pr;
 					z-index: 1;
-					border: 2px solid var(--maxi-grey-light);
-					border-bottom: 2px solid var(--maxi-primary-color);
+					border: 2px solid $gl;
+					border-bottom: 2px solid $pc;
 				}
 			}
 			label {
@@ -62,7 +63,7 @@
 				height: 100%;
 				text-align: center;
 				line-height: 26px;
-				border: 2px solid var(--maxi-grey);
+				border: 2px solid $g;
 			}
 		}
 	}
@@ -73,18 +74,18 @@
 				margin-bottom: 10px;
 			}
 			&-box {
-				background-color: var(--maxi-white);
+				background-color: $w;
 				width: 32px;
 				height: 32px;
 
 				&__active,
 				&:hover {
-					border-color: var(--maxi-mid-green);
-					background-color: var(--maxi-pastel-green);
+					border-color: $mg;
+					background-color: $pg;
 				}
 			}
 			&-item {
-				border: 1.5px solid var(--maxi-grey-light) !important;
+				border: $bg !important;
 			}
 		}
 	}
@@ -92,12 +93,12 @@
 		border: 0;
 
 		svg {
-			fill: var(--maxi-white);
+			fill: $w;
 		}
 	}
 	.maxi-color-control__color {
 		.chrome-picker {
-			background-color: transparent !important;
+			background-color: $tr !important;
 			& > div:last-of-type {
 				padding-bottom: 0 !important;
 			}

--- a/src/components/toolbar/components/vertical-align/editor.scss
+++ b/src/components/toolbar/components/vertical-align/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../../../src/css/backend-variables.scss';
 .toolbar-item__vertical-align__popover {
 	min-width: 250px;
 }

--- a/src/components/toolbar/editor.scss
+++ b/src/components/toolbar/editor.scss
@@ -17,7 +17,7 @@
 	*,
 	*:before,
 	*:after {
-		transition: $t;
+		@include transit;
 	}
 
 	&-caption,
@@ -168,9 +168,7 @@
 				}
 			}
 			.toolbar-item {
-				display: flex;
-				align-items: center;
-				justify-content: center;
+				@include flex-center;
 
 				&__dynamic-content {
 					&:hover,
@@ -218,9 +216,7 @@
 				&__text-options,
 				&__border {
 					.toolbar-item__icon {
-						display: flex;
-						justify-content: center;
-						align-items: center;
+						@include flex-center;
 					}
 				}
 				&__more-settings .components-button,
@@ -236,7 +232,7 @@
 					width: 100%;
 					height: 100%;
 					padding: 0;
-					transition: $t;
+					@include transit;
 					border-radius: 0;
 					background-color: $tr;
 					fill: $bk !important;
@@ -250,7 +246,7 @@
 						bottom: -1px;
 						left: -1px;
 						right: -1px;
-						transition: $t;
+						@include transit;
 					}
 
 					&:hover,
@@ -282,7 +278,7 @@
 					width: 100%;
 					height: 100%;
 					padding: 0;
-					transition: $t;
+					@include transit;
 					border-radius: 0;
 
 					&::after {
@@ -294,7 +290,7 @@
 						bottom: -1px;
 						left: -1px;
 						right: -1px;
-						transition: $t;
+						@include transit;
 					}
 
 					&:hover,
@@ -346,7 +342,7 @@
 					rect,
 					polyline,
 					path {
-						transition: $t;
+						@include transit;
 						// fill: $bk;
 						// stroke: $tr;
 					}
@@ -837,7 +833,7 @@ html[dir='rtl'] {
 	width: 100%;
 	height: 100%;
 	padding: 0;
-	transition: $t;
+	@include transit;
 	border-radius: 0;
 	background-color: $tr;
 	fill: $bk !important;

--- a/src/components/toolbar/editor.scss
+++ b/src/components/toolbar/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 // Maxi Toolbar Styles - Optimized & Refactored
 // =============================================
 
@@ -16,7 +17,7 @@
 	*,
 	*:before,
 	*:after {
-		transition: all 0.4s ease;
+		transition: $t;
 	}
 
 	&-caption,
@@ -30,9 +31,9 @@
 
 	.toolbar-more-indicator {
 		margin-left: 10px;
-		position: absolute;
+		position: $pa;
 		right: -16px;
-		background: var(--maxi-primary-color);
+		background: $pc;
 		border-radius: 0 3px 3px 0px;
 		height: 20px;
 		top: 0;
@@ -47,7 +48,7 @@
 	}
 	.components-popover__content {
 		overflow: visible !important;
-		background-color: transparent;
+		background-color: $tr;
 		border: none;
 		box-shadow: none;
 		outline: none;
@@ -55,15 +56,15 @@
 
 		.toolbar-wrapper {
 			display: flex;
-			background-color: var(--maxi-white);
+			background-color: $w;
 			width: min-content;
-			position: relative;
+			position: $pr;
 			top: -23px;
 			left: 50%;
 			transform: translateX(-50%);
 			box-shadow: 0px 6px 8px 0 rgba(0, 0, 0, 0.08);
 			border-radius: 0;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 
 			&.pinned--true .maxi-breadcrumbs {
 				transform: scaleX(1);
@@ -75,13 +76,13 @@
 			}
 
 			.breadcrumbs-pin-tooltip {
-				position: absolute;
+				position: $pa;
 				top: -24px;
 				left: 0;
 				background-color: rgba(0, 0, 0, 0.85);
 				padding: 7px 8px;
 				text-align: center;
-				color: var(--maxi-white);
+				color: $w;
 				visibility: none;
 				z-index: 5;
 				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
@@ -107,13 +108,13 @@
 			.toolbar-block-custom-label {
 				display: inline-block;
 				width: auto;
-				position: absolute;
+				position: $pa;
 				bottom: -22px;
 				left: 0;
 				padding: 4px 10px;
-				background: var(--maxi-primary-color);
+				background: $pc;
 				border-radius: 3px 0 0 3px;
-				color: var(--maxi-white);
+				color: $w;
 				font-size: 10px !important;
 				font-weight: 400;
 				font-family: 'Inter', sans-serif !important;
@@ -133,7 +134,7 @@
 				.breadcrumbs-pin {
 					display: inline-block;
 					padding-right: 10px;
-					cursor: pointer;
+					cursor: $ptr;
 				}
 			}
 
@@ -146,15 +147,15 @@
 			> button {
 				display: flex;
 				justify-content: center;
-				position: relative;
+				position: $pr;
 				width: 2rem;
 				height: 2rem;
 				padding: 0;
 				padding-right: 0;
-				background-color: var(--maxi-white);
+				background-color: $w;
 				border-radius: 0;
-				border-right: 1px solid var(--maxi-grey-light);
-				cursor: pointer;
+				border-right: $bl;
+				cursor: $ptr;
 
 				&.toolbar-item__more-settings {
 					border-right: none;
@@ -181,7 +182,7 @@
 							rect,
 							polyline,
 							path {
-								stroke: var(--maxi-secondary-color) !important;
+								stroke: $sc !important;
 							}
 						}
 					}
@@ -198,7 +199,7 @@
 							rect,
 							polyline,
 							path {
-								stroke: var(--maxi-secondary-color) !important;
+								stroke: $sc !important;
 							}
 						}
 					}
@@ -208,7 +209,7 @@
 					&--active {
 						.toolbar-item__icon {
 							path {
-								fill: var(--maxi-primary-color);
+								fill: $pc;
 							}
 						}
 					}
@@ -235,26 +236,26 @@
 					width: 100%;
 					height: 100%;
 					padding: 0;
-					transition: all 0.5s ease;
+					transition: $t;
 					border-radius: 0;
-					background-color: transparent;
-					fill: var(--maxi-black) !important;
+					background-color: $tr;
+					fill: $bk !important;
 
 					&::after {
 						content: '';
 						display: block;
-						background-color: var(--maxi-secondary-color);
+						background-color: $sc;
 						height: 0;
-						position: absolute;
+						position: $pa;
 						bottom: -1px;
 						left: -1px;
 						right: -1px;
-						transition: all 0.5s ease;
+						transition: $t;
 					}
 
 					&:hover,
 					&[aria-expanded='true'] {
-						background-color: var(--maxi-pastel-green) !important;
+						background-color: $pg !important;
 						.toolbar-item__icon {
 							ellipse,
 							circle,
@@ -262,7 +263,7 @@
 							rect,
 							polyline,
 							path {
-								fill: var(--maxi-secondary-color);
+								fill: $sc;
 							}
 						}
 					}
@@ -281,24 +282,24 @@
 					width: 100%;
 					height: 100%;
 					padding: 0;
-					transition: all 0.5s ease;
+					transition: $t;
 					border-radius: 0;
 
 					&::after {
 						content: '';
 						display: block;
-						background-color: var(--maxi-secondary-color);
+						background-color: $sc;
 						height: 0;
-						position: absolute;
+						position: $pa;
 						bottom: -1px;
 						left: -1px;
 						right: -1px;
-						transition: all 0.5s ease;
+						transition: $t;
 					}
 
 					&:hover,
 					&[aria-expanded='true'] {
-						background-color: var(--maxi-pastel-green);
+						background-color: $pg;
 						.toolbar-item__icon {
 							ellipse,
 							circle,
@@ -306,7 +307,7 @@
 							rect,
 							polyline,
 							path {
-								stroke: var(--maxi-secondary-color);
+								stroke: $sc;
 							}
 						}
 					}
@@ -321,7 +322,7 @@
 				&__bold,
 				&__italic {
 					&:hover path {
-						stroke: var(--maxi-secondary-color);
+						stroke: $sc;
 					}
 				}
 
@@ -345,9 +346,9 @@
 					rect,
 					polyline,
 					path {
-						transition: all 0.5s ease;
-						// fill: var(--maxi-black);
-						// stroke: transparent;
+						transition: $t;
+						// fill: $bk;
+						// stroke: $tr;
 					}
 				}
 
@@ -357,8 +358,8 @@
 
 				&__bold path,
 				&__italic path {
-					fill: var(--maxi-white);
-					stroke: var(--maxi-black);
+					fill: $w;
+					stroke: $bk;
 				}
 			}
 		}
@@ -368,8 +369,8 @@
 		font-family: 'Inter', sans-serif !important;
 
 		&:hover {
-			color: var(--maxi-primary-color) !important;
-			transition: all 0.4s ease !important;
+			color: $pc !important;
+			transition: $t !important;
 		}
 	}
 	.maxi-responsive-tabs-control {
@@ -383,7 +384,7 @@
 				}
 
 				&:last-child {
-					border-right: 1px solid var(--maxi-grey-light);
+					border-right: $bl;
 					border-radius: 0 10px 10px 0;
 				}
 			}
@@ -392,7 +393,7 @@
 
 	.maxi-color-control__palette-box {
 		&--active {
-			background-color: var(--maxi-pastel-green) !important;
+			background-color: $pg !important;
 		}
 	}
 }
@@ -421,10 +422,10 @@ body .toolbar-item__popover {
 			opacity: 1 !important;
 			min-width: 40px;
 			height: 30px;
-			background-color: var(--maxi-black);
+			background-color: $bk;
 			font-size: 13px;
 			line-height: 13px;
-			color: var(--maxi-white);
+			color: $w;
 			font-weight: 500;
 			flex: 1;
 			border-bottom: none;
@@ -463,11 +464,11 @@ body .toolbar-item__popover {
 			input {
 				display: none;
 				&:checked ~ label {
-					background-color: var(--maxi-pastel-green);
-					position: relative;
+					background-color: $pg;
+					position: $pr;
 					z-index: 1;
-					border: 2px solid var(--maxi-grey-light);
-					border-bottom: 2px solid var(--maxi-primary-color);
+					border: 2px solid $gl;
+					border-bottom: 2px solid $pc;
 				}
 			}
 
@@ -476,16 +477,16 @@ body .toolbar-item__popover {
 				height: 100%;
 				text-align: center;
 				line-height: 26px;
-				border: 2px solid var(--maxi-grey);
+				border: 2px solid $g;
 			}
 		}
 	}
 
 	&:before,
 	&:after {
-		border-color: var(--maxi-grey-dark) !important;
-		// border-left-color: transparent !important;
-		// border-right-color: transparent !important;
+		border-color: $gd !important;
+		// border-left-color: $tr !important;
+		// border-right-color: $tr !important;
 		z-index: -1;
 		display: none;
 	}
@@ -497,55 +498,55 @@ body .toolbar-item__popover {
 		}
 
 		&__field {
-			color: var(--maxi-black);
+			color: $bk;
 
 			.components-range-control__track {
 				& + span {
 					span {
-						background-color: var(--maxi-white) !important;
+						background-color: $w !important;
 						&:before {
-							border-color: var(--maxi-grey-dark) !important;
+							border-color: $gd !important;
 						}
 					}
 				}
 			}
 
 			.components-range-control__number {
-				background-color: transparent;
-				color: var(--maxi-black);
-				border-color: var(--maxi-grey) !important;
+				background-color: $tr;
+				color: $bk;
+				border-color: $g !important;
 			}
 
 			.maxi-select-control__input {
 				option {
-					color: var(--maxi-black) !important;
+					color: $bk !important;
 				}
 			}
 
 			.components-button {
 				&.is-secondary {
-					background-color: transparent;
-					border-color: var(--maxi-grey) !important;
+					background-color: $tr;
+					border-color: $g !important;
 
 					&:hover {
-						background-color: transparent !important;
+						background-color: $tr !important;
 					}
 
 					svg {
-						fill: var(--maxi-black) !important;
+						fill: $bk !important;
 					}
 				}
 			}
 		}
 
 		&__label {
-			color: var(--maxi-black);
+			color: $bk;
 		}
 	}
 
 	.components-popover__content {
-		background-color: var(--maxi-white) !important;
-		border: 1px solid var(--maxi-grey-light);
+		background-color: $w !important;
+		border: $bl;
 		border-radius: 0;
 		min-width: auto;
 		padding: 12px 11px 0 14px;
@@ -560,7 +561,7 @@ body .toolbar-item__popover {
 
 		.maxi-color-control {
 			margin-bottom: 10px;
-			color: var(--maxi-white);
+			color: $w;
 
 			button.maxi-components-button.maxi-reset-button {
 				margin-top: -4px !important;
@@ -574,7 +575,7 @@ body .toolbar-item__popover {
 				.components-angle-picker-control {
 					&__angle-circle-indicator,
 					&__angle-circle {
-						border-color: var(--maxi-grey);
+						border-color: $g;
 					}
 				}
 
@@ -582,12 +583,12 @@ body .toolbar-item__popover {
 					background: none;
 
 					button.components-toolbar__control {
-						border-color: var(--maxi-grey);
+						border-color: $g;
 
 						&.is-pressed,
 						&:hover {
-							background-color: var(--maxi-grey) !important;
-							border-color: var(--maxi-grey) !important;
+							background-color: $g !important;
+							border-color: $g !important;
 							& > svg {
 								background: none;
 							}
@@ -596,28 +597,28 @@ body .toolbar-item__popover {
 				}
 			}
 			&__items {
-				color: var(--maxi-white);
+				color: $w;
 
 				.maxi-tabs-control__button {
-					border-color: var(--maxi-grey);
-					background-color: var(--maxi-grey);
+					border-color: $g;
+					background-color: $g;
 				}
 
 				input {
 					&:checked ~ label {
-						background-color: var(--maxi-grey);
+						background-color: $g;
 					}
 				}
 
 				svg {
-					fill: var(--maxi-white) !important;
+					fill: $w !important;
 					path {
-						stroke: var(--maxi-white);
+						stroke: $w;
 					}
 				}
 			}
 			&__display {
-				color: var(--maxi-white);
+				color: $w;
 			}
 		}
 
@@ -634,60 +635,60 @@ body .toolbar-item__popover {
 	}
 
 	input[type='number'] {
-		border: 1px solid var(--maxi-grey-light) !important;
-		color: var(--maxi-grey) !important;
+		border: $bl !important;
+		color: $g !important;
 		flex: 2;
 
 		&::placeholder {
-			color: var(--maxi-grey);
+			color: $g;
 			opacity: 0.8;
 		}
 	}
 
 	.maxi-dimensions-control {
-		color: var(--maxi-white);
+		color: $w;
 
 		&_sync {
-			border-color: var(--maxi-grey) !important;
-			background-color: transparent !important;
+			border-color: $g !important;
+			background-color: $tr !important;
 			width: 36px !important;
 
 			&:hover {
-				background-color: transparent !important;
+				background-color: $tr !important;
 			}
 
 			&[aria-pressed='true'] {
-				border-color: var(--maxi-white);
+				border-color: $w;
 
 				svg {
-					fill: var(--maxi-white);
+					fill: $w;
 				}
 			}
 		}
 
 		&__mobile-controls-item {
 			height: 36px;
-			border-color: var(--maxi-grey) !important;
+			border-color: $g !important;
 
 			svg {
 				fill: currentColor;
-				color: var(--maxi-white);
+				color: $w;
 			}
 		}
 
 		&__number {
-			background-color: transparent;
-			border-color: var(--maxi-grey) !important;
-			color: var(--maxi-white);
+			background-color: $tr;
+			border-color: $g !important;
+			color: $w;
 		}
 	}
 
 	&__advanced-button {
-		position: absolute;
+		position: $pa;
 		top: -10px !important;
 		right: -10px !important;
 		transform: translate(0, 0);
-		background-color: var(--maxi-primary-color);
+		background-color: $pc;
 		border-radius: 50%;
 		min-width: 22px !important;
 		padding: 0 !important;
@@ -695,11 +696,11 @@ body .toolbar-item__popover {
 		left: auto !important;
 
 		&:hover {
-			background-color: var(--maxi-secondary-color);
+			background-color: $sc;
 		}
 
 		svg {
-			fill: var(--maxi-white);
+			fill: $w;
 			width: 16px;
 		}
 	}
@@ -708,7 +709,7 @@ body .toolbar-item__popover {
 		display: flex;
 		&__button {
 			display: block;
-			background: var(--maxi-white);
+			background: $w;
 			width: 100%;
 			margin: 0 4px;
 
@@ -728,17 +729,17 @@ body .toolbar-item__popover {
 
 	.maxi-tabs-control {
 		&__button {
-			background: transparent;
-			color: var(--maxi-grey-dark);
-			border: 1px solid var(--maxi-grey-light);
+			background: $tr;
+			color: $gd;
+			border: $bl;
 			border-right: none;
 			padding-top: 8px;
 			padding-bottom: 8px;
 			font-weight: 400;
 
 			&[aria-pressed='true'] {
-				color: var(--maxi-primary-color);
-				background-color: var(--maxi-whisper-green) !important;
+				color: $pc;
+				background-color: $wg !important;
 				font-weight: 700;
 			}
 		}
@@ -813,7 +814,7 @@ body.rtl .toolbar-item__popover {
 html[dir='rtl'] {
 	.toolbar-item__more-settings {
 		border-left: unset !important;
-		border-right: 1px solid var(--maxi-grey-light) !important;
+		border-right: $bl !important;
 	}
 	.toolbar-block-custom-label {
 		left: unset !important;
@@ -836,13 +837,13 @@ html[dir='rtl'] {
 	width: 100%;
 	height: 100%;
 	padding: 0;
-	transition: all 0.5s ease;
+	transition: $t;
 	border-radius: 0;
-	background-color: transparent;
-	fill: var(--maxi-black) !important;
+	background-color: $tr;
+	fill: $bk !important;
 }
 
 // Target the SVG fill when hovering over the button
 .components-button:hover .st0 {
-	fill: var(--maxi-primary-color) !important;
+	fill: $pc !important;
 }

--- a/src/components/transform-control/editor.scss
+++ b/src/components/transform-control/editor.scss
@@ -1,10 +1,11 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-transform-control {
 	input[type='range'] {
 		-webkit-appearance: none;
 		width: 100%;
 		height: 2px;
 		border-radius: 0;
-		background: var(--maxi-grey-light);
+		background: $gl;
 		outline: none;
 		-webkit-transition: 0.2s;
 		transition: opacity 0.2s;
@@ -15,87 +16,87 @@
 			width: 16px;
 			height: 16px;
 			border-radius: 50%;
-			background: var(--maxi-black);
-			cursor: pointer;
-			box-shadow: inset 0 0 0 2px var(--maxi-black),
-				inset 0 0 0 4px var(--maxi-white);
+			background: $bk;
+			cursor: $ptr;
+			box-shadow: inset 0 0 0 2px $bk,
+				inset 0 0 0 4px $w;
 		}
 
 		&::-moz-range-thumb {
 			width: 16px;
 			height: 16px;
 			border-radius: 50%;
-			background: var(--maxi-black);
-			cursor: pointer;
-			box-shadow: inset 0 0 0 2px var(--maxi-black),
-				inset 0 0 0 4px var(--maxi-white);
+			background: $bk;
+			cursor: $ptr;
+			box-shadow: inset 0 0 0 2px $bk,
+				inset 0 0 0 4px $w;
 		}
 	}
 
 	&__square-control {
 		display: flex;
 		flex-wrap: wrap;
-		position: relative;
+		position: $pr;
 
 		&__canvas {
-			position: relative;
+			position: $pr;
 			display: flex;
 			justify-content: center;
 			align-items: center;
 			width: 170px;
 			height: 170px;
-			border: 1px solid var(--maxi-grey-light);
+			border: $bl;
 			border-radius: 5px;
 			overflow: hidden;
 
 			&:before {
 				content: '';
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 0%;
 				transform: translateY(-50%);
 				width: 100%;
 				height: 1px;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 			}
 
 			&:after {
 				content: '';
 				display: block;
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 50%;
 				transform: translate(-50%, -50%);
 				width: 10px;
 				height: 10px;
-				border: 2px solid var(--maxi-white);
+				border: 2px solid $w;
 				border-radius: 50%;
-				background: var(--maxi-primary-color);
+				background: $pc;
 				cursor: inherit;
 			}
 
 			&__placeholder,
 			&__origin {
-				position: absolute;
+				position: $pa;
 				top: 50%;
 				left: 50%;
 				transform: translate(-50%, -50%);
 				width: 40px;
 				height: 40px;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 				border-radius: 5px;
 				transition: none !important;
 				&__button {
 					&[aria-pressed='active'] {
-						background: var(--maxi-grey-dark) !important;
-						border-color: var(--maxi-grey-dark) !important;
+						background: $gd !important;
+						border-color: $gd !important;
 					}
 				}
 			}
 
 			&__resizer {
 				z-index: 1;
-				border: 1px solid var(--maxi-grey-light);
+				border: $bl;
 				transition: none !important;
 			}
 
@@ -104,9 +105,9 @@
 				cursor: move;
 				width: 40px;
 				height: 40px;
-				border: 2px solid var(--maxi-grey);
+				border: 2px solid $g;
 				border-radius: 5px;
-				background-color: rgba(var(--maxi-black), 0.3);
+				background-color: rgba($bk, 0.3);
 				transition: none !important;
 			}
 
@@ -115,12 +116,12 @@
 				transition: none !important;
 
 				&__button {
-					position: absolute;
+					position: $pa;
 					transform: translate(-50%, -50%);
 					width: 8px;
 					height: 8px;
 					padding: 0;
-					background-color: var(--maxi-grey-light);
+					background-color: $gl;
 					border-radius: 100%;
 				}
 
@@ -145,7 +146,7 @@
 			}
 		}
 		&__y-control {
-			position: absolute;
+			position: $pa;
 			top: 55px;
 			right: -20px;
 			width: 168px;
@@ -156,7 +157,7 @@
 			}
 
 			input[type='range'] {
-				position: relative;
+				position: $pr;
 				right: 18px;
 				top: 18px;
 				margin-left: 4px;
@@ -172,7 +173,7 @@
 			}
 
 			&__value {
-				position: relative;
+				position: $pr;
 				top: -6px;
 				right: -85px;
 
@@ -226,7 +227,7 @@
 			}
 		}
 		&__sync {
-			position: absolute;
+			position: $pa;
 			top: 185px;
 			right: 0;
 			display: flex;
@@ -241,12 +242,12 @@
 				width: 14px;
 				height: 14px;
 				path {
-					fill: var(--maxi-grey);
+					fill: $g;
 				}
 			}
 
 			button[type='button'] {
-				background: var(--maxi-white);
+				background: $w;
 				border-radius: 4px;
 				width: 32px;
 				height: 32px;
@@ -257,14 +258,14 @@
 				transition: all 0.2s;
 
 				&:focus {
-					border-color: transparent;
+					border-color: $tr;
 				}
 
 				&[aria-pressed='true'] {
-					background: var(--maxi-pastel-green) !important;
+					background: $pg !important;
 					svg {
 						path {
-							fill: var(--maxi-secondary-color);
+							fill: $sc;
 						}
 					}
 				}
@@ -349,13 +350,13 @@
 		flex: 1;
 
 		.maxi-tabs-control__button--selected svg path {
-			fill: var(--maxi-secondary-color);
+			fill: $sc;
 		}
 
 		.maxi-tabs-control__button {
 			padding: 8px 8px;
 			margin-right: 5px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 4px;
 			transition: all 0.5s;
 			&:last-child {
@@ -364,14 +365,14 @@
 		}
 
 		.maxi-tabs-control__button[aria-pressed='true'] {
-			background-color: var(--maxi-whisper-green) !important;
-			border-color: var(--maxi-secondary-color) !important;
+			background-color: $wg !important;
+			border-color: $sc !important;
 		}
 
 		.maxi-tabs-control__button {
 			&--selected {
 				font-weight: 700;
-				color: var(--maxi-secondary-color) !important;
+				color: $sc !important;
 			}
 		}
 	}

--- a/src/components/transition-control/editor.scss
+++ b/src/components/transition-control/editor.scss
@@ -1,28 +1,29 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-settingstab-control.maxi-transition-control__split-tabs {
 	/* Scope unique styling only to TransitionControl split tabs */
 	.maxi-tabs-control {
 		&__button {
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			border: $bg !important;
 			border-radius: 6px !important;
-			background-color: var(--maxi-white);
-			color: var(--maxi-black) !important;
+			background-color: $w;
+			color: $bk !important;
 			margin-right: 6px !important;
 			padding: 8px 12px !important;
-			transition: all 0.4s ease !important;
+			transition: $t !important;
 
 			&:last-child {
 				margin-right: 0 !important;
 			}
 
 			&:hover {
-				border-color: var(--maxi-primary-color) !important;
-				background-color: var(--maxi-pastel-green);
+				border-color: $pc !important;
+				background-color: $pg;
 			}
 
 			&[aria-pressed='true'] {
-				background-color: var(--maxi-whisper-green);
-				border-color: var(--maxi-secondary-color) !important;
-				color: var(--maxi-secondary-color) !important;
+				background-color: $wg;
+				border-color: $sc !important;
+				color: $sc !important;
 			}
 		}
 	}

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 /*===============================================
  TYPOGRAPHY CONTROL COMPONENT
 ===============================================*/
@@ -8,7 +9,7 @@
 	-------------------------------------------*/
 	--typography-spacing-standard: 15px;
 	--typography-button-transition: all 200ms ease;
-	--typography-interactive-border: 1px solid var(--maxi-grey-light);
+	--typography-interactive-border: $bl;
 	--typography-button-radius: 4px;
 
 	/*-------------------------------------------
@@ -17,13 +18,13 @@
 
 	// Floating label pattern
 	%floating-label {
-		position: absolute !important;
+		position: $pa !important;
 		top: -8px !important;
 		left: 8px !important;
 		font-size: 10px !important;
-		color: var(--maxi-grey-dark) !important;
+		color: $gd !important;
 		font-style: normal !important;
-		background: var(--maxi-white) !important;
+		background: $w !important;
 		padding: 0 5px !important;
 		pointer-events: none !important;
 		box-sizing: border-box !important;
@@ -40,31 +41,31 @@
 	// Shared button base styling
 	%button-base-pattern {
 		@extend %flex-center-pattern;
-		border: 1px solid var(--maxi-grey-light) !important;
+		border: $bl !important;
 		border-radius: 4px !important;
-		background: var(--maxi-white) !important;
-		color: var(--maxi-grey-dark) !important;
-		cursor: pointer !important;
+		background: $w !important;
+		color: $gd !important;
+		cursor: $ptr !important;
 		transition: all 200ms ease !important;
 		box-sizing: border-box !important;
 
 		&:hover {
-			border-color: var(--maxi-primary-color) !important;
-			background: var(--maxi-mid-green) !important;
+			border-color: $pc !important;
+			background: $mg !important;
 		}
 	}
 
 	// Shared interactive states for tabs
 	%tabs-interactive-states {
 		&:hover {
-			background-color: var(--maxi-mid-green);
-			border-color: var(--maxi-primary-color) !important;
+			background-color: $mg;
+			border-color: $pc !important;
 		}
 
 		&[aria-pressed='true'] {
-			background-color: var(--maxi-whisper-green) !important;
-			border-color: var(--maxi-secondary-color) !important;
-			color: var(--maxi-secondary-color) !important;
+			background-color: $wg !important;
+			border-color: $sc !important;
+			color: $sc !important;
 		}
 	}
 
@@ -75,18 +76,18 @@
 		flex: 1;
 
 		&__help {
-			color: var(--maxi-grey-light);
+			color: $gl;
 			font-size: 12px;
 		}
 
 		.maxi-tabs-control__button--selected svg path {
-			fill: var(--maxi-primary-color);
+			fill: $pc;
 		}
 
 		.maxi-tabs-control__button {
 			margin-right: 11px;
 			border-radius: 4px;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			transition: all 400ms ease !important;
 			@extend %tabs-interactive-states;
 		}
@@ -98,7 +99,7 @@
 	.maxi-typography-control__link-options {
 		.maxi-tabs-control__button--selected {
 			font-weight: bold;
-			color: var(--maxi-secondary-color) !important;
+			color: $sc !important;
 		}
 	}
 
@@ -125,7 +126,7 @@
 
 		> div {
 			flex: 1 1 auto; /* Allow items to grow and shrink */
-			position: relative;
+			position: $pr;
 			width: auto !important; /* Remove fixed width */
 		}
 
@@ -157,10 +158,10 @@
 
 	.maxi-typography-control__weight,
 	.maxi-typography-control__size {
-		position: relative !important;
+		position: $pr !important;
 
 		.maxi-base-control {
-			position: relative;
+			position: $pr;
 
 			&__label {
 				@extend %floating-label;
@@ -190,7 +191,7 @@
 			display: inline-block !important;
 			width: calc(50% - 5px) !important;
 			vertical-align: top !important;
-			position: relative !important;
+			position: $pr !important;
 		}
 
 		.maxi-typography-control__line-height {
@@ -232,9 +233,9 @@
 			margin-top: -15px !important;
 
 			&[aria-pressed='true'] {
-				background: var(--maxi-whisper-green) !important;
-				color: var(--maxi-secondary-color) !important;
-				border-color: var(--maxi-secondary-color) !important;
+				background: $wg !important;
+				color: $sc !important;
+				border-color: $sc !important;
 			}
 
 			&--bold {
@@ -267,10 +268,10 @@
 	-------------------------------------------*/
 	.maxi-typography-control__separator {
 		border: none !important;
-		border-top: 1px solid var(--maxi-grey-light) !important;
+		border-top: $bl !important;
 		margin: 14px 0 !important;
 		height: 0 !important;
-		background: transparent !important;
+		background: $tr !important;
 	}
 
 	.maxi-typography-control__advanced-toggle {
@@ -302,9 +303,9 @@
 		width: 100%;
 		text-align: left;
 		margin-top: 10px;
-		color: var(--maxi-grey-dark) !important;
+		color: $gd !important;
 		.maxi-typography-control__toggle-arrow--expanded {
-			color: var(--maxi-grey-dark) !important;
+			color: $gd !important;
 		}
 	}
 

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -33,9 +33,7 @@
 
 	// Shared flexbox center pattern
 	%flex-center-pattern {
-		display: flex;
-		align-items: center;
-		justify-content: center;
+		@include flex-center;
 	}
 
 	// Shared button base styling
@@ -88,7 +86,7 @@
 			margin-right: 11px;
 			border-radius: 4px;
 			border: $bg;
-			transition: all 400ms ease !important;
+			@include transit(true);
 			@extend %tabs-interactive-states;
 		}
 	}

--- a/src/css/backend-variables.scss
+++ b/src/css/backend-variables.scss
@@ -1,3 +1,30 @@
+// Global short variables for size reduction
+$bl: 1px solid var(--maxi-grey-light); // border-light
+
+$t: all 0.3s ease; // standard transition
+$f: 'Inter', Helvetica, Arial, Lucida, sans-serif; // font
+
+// Short color aliases
+$w: var(--maxi-white);
+$gd: var(--maxi-grey-dark);
+$bk: var(--maxi-black);
+$cp: var(--maxi-cloud-primary);
+$gl: var(--maxi-grey-light);
+$cpl: var(--maxi-cloud-primary-light);
+$cpw: var(--maxi-cloud-primary-whisper);
+$pc: var(--maxi-primary-color);
+$sc: var(--maxi-secondary-color);
+$pg: var(--maxi-pastel-green);
+$wg: var(--maxi-whisper-green);
+$pgr: var(--maxi-primary-green);
+$mg: var(--maxi-mid-green);
+$g: var(--maxi-grey);
+$tr: transparent;
+$pa: absolute;
+$pr: relative;
+$ptr: pointer;
+$bg: 1.5px solid $gl; // border-grey
+
 :root {
 	/* Core Builder */
 	--maxi-primary-color: #2c8a46; /* Fresh lime green */

--- a/src/css/backend-variables.scss
+++ b/src/css/backend-variables.scss
@@ -25,6 +25,40 @@ $pr: relative;
 $ptr: pointer;
 $bg: 1.5px solid $gl; // border-grey
 
+@mixin transit {
+	transition: $t;
+}
+
+@mixin flex-center($important: false) {
+	@if $important {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+	} @else {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+@mixin scrollbar($width: 5px, $track: $w, $thumb: $gl) {
+	&::-webkit-scrollbar {
+		width: $width;
+	}
+
+	&::-webkit-scrollbar-track {
+		background: $track;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background: $thumb;
+	}
+
+	&::-webkit-scrollbar-thumb:hover {
+		background: $thumb;
+	}
+}
+
 :root {
 	/* Core Builder */
 	--maxi-primary-color: #2c8a46; /* Fresh lime green */

--- a/src/css/backend-variables.scss
+++ b/src/css/backend-variables.scss
@@ -25,8 +25,12 @@ $pr: relative;
 $ptr: pointer;
 $bg: 1.5px solid $gl; // border-grey
 
-@mixin transit {
-	transition: $t;
+@mixin transit($important: false) {
+	@if $important {
+		transition: $t !important;
+	} @else {
+		transition: $t;
+	}
 }
 
 @mixin flex-center($important: false) {

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -1,3 +1,4 @@
+@import '../../src/css/backend-variables.scss';
 /**
  * #.# Common SCSS
  *
@@ -17,7 +18,7 @@
 	&__sidebar {
 		overflow-x: hidden;
 		.interface-complementary-area__fill {
-			position: relative !important;
+			position: $pr !important;
 			width: auto !important;
 			.editor-sidebar {
 				min-width: 295px;
@@ -52,9 +53,9 @@ h2.gx_error {
 		*):not([class*='maxi-transform-control']):not([class*='maxi-transform-control']
 		*):not(.w-tc-editor-text):not(.maxi-css-code-editor__code-editor *),
 .maxi-popover *:not(i) {
-	transition: all 0.5s ease;
-	color: var(--maxi-grey-dark);
-	font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+	transition: $t;
+	color: $gd;
+	font-family: $f !important;
 	font-weight: normal;
 	.block-editor-block-card__name {
 		padding: 0 !important;
@@ -62,8 +63,8 @@ h2.gx_error {
 }
 
 .maxi-sidebar .block-editor-block-card *:not(i) {
-	color: var(--maxi-grey-dark);
-	font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+	color: $gd;
+	font-family: $f !important;
 	font-weight: normal;
 	.block-editor-block-card__name {
 		padding: 0 !important;
@@ -75,15 +76,15 @@ h2.gx_error {
 }
 
 .block-editor-inserter {
-	transition: all 0.5s ease;
-	color: var(--maxi-white) !important;
+	transition: $t;
+	color: $w !important;
 	height: 100%;
 
 	&__toggle {
-		transition: all 0.5s ease;
+		transition: $t;
 		svg {
-			transition: all 0.5s ease;
-			fill: var(--maxi-white) !important;
+			transition: $t;
+			fill: $w !important;
 		}
 	}
 }
@@ -125,16 +126,16 @@ body {
 	}
 }
 .maxi-block {
-	transition: all 0.5s ease;
+	transition: $t;
 
 	.block-editor-block-list__layout {
-		transition: all 0.5s ease;
+		transition: $t;
 		&:focus:after {
 			box-shadow: none !important;
 		}
 	}
 	&:hover {
-		transition: all 0.5s ease;
+		transition: $t;
 		& > .block-editor-block-list__layout {
 			& > .block-list-appender {
 				.block-editor-button-block-appender {
@@ -146,7 +147,7 @@ body {
 		}
 	}
 	.block-list-appender.wp-block {
-		position: relative;
+		position: $pr;
 		width: 100%;
 		max-width: none;
 		pointer-events: auto !important;
@@ -172,18 +173,18 @@ body {
 			height: 30px;
 			box-shadow: -3px 3px 6px 0px rgb(0 0 0 / 16%) !important;
 			border-radius: 0;
-			background: var(--maxi-white);
+			background: $w;
 			visibility: visible;
 			transition: 0.3s;
 
 			svg {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 				width: 15px;
 				height: 15px;
 			}
 			&:hover {
 				svg {
-					fill: var(--maxi-primary-color);
+					fill: $pc;
 				}
 			}
 		}
@@ -220,21 +221,21 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 		border-color: var(--maxi-accessibility-grey);
 
 		&:focus {
-			border-color: var(--maxi-secondary-color);
-			box-shadow: 0 0 0 1px var(--maxi-secondary-color);
-			outline: 2px solid transparent;
+			border-color: $sc;
+			box-shadow: 0 0 0 1px $sc;
+			outline: 2px solid $tr;
 		}
 
 		&:hover {
-			border-color: var(--maxi-secondary-color);
-			box-shadow: 0 0 0 1px var(--maxi-secondary-color);
-			outline: 2px solid transparent;
+			border-color: $sc;
+			box-shadow: 0 0 0 1px $sc;
+			outline: 2px solid $tr;
 		}
 	}
 	button.maxi-color-control__palette-box,
 	button.maxi-tabs-control__button,
 	.maxi-components-button {
-		border-color: var(--maxi-grey-light);
+		border-color: $gl;
 	}
 	button.maxi-color-control__palette-box--active,
 	button.maxi-color-control__palette-box:focus,
@@ -242,12 +243,12 @@ body.maxi-blocks--active.maxi-blocks--accessibility .maxi-sidebar {
 	button.maxi-tabs-control__button:focus,
 	.maxi-components-button:focus:not(:disabled) {
 		z-index: 2;
-		border-color: var(--maxi-secondary-color);
-		box-shadow: 0 0 0 1px var(--maxi-secondary-color);
-		outline: 2px solid transparent;
+		border-color: $sc;
+		box-shadow: 0 0 0 1px $sc;
+		outline: 2px solid $tr;
 	}
 	.maxi-base-control .components-maxi-control__reset-button {
-		border-color: var(--maxi-grey-light);
+		border-color: $gl;
 	}
 }
 
@@ -258,14 +259,14 @@ body .toolbar-item__popover {
 	input[type='number'],
 	textarea:not(.w-tc-editor-text),
 	select {
-		transition: all 0.5s ease;
+		transition: $t;
 		flex: 1;
 		max-height: unset !important;
 		min-height: unset;
 		padding: 10px;
 		border-radius: 5px !important;
-		color: var(--maxi-grey-dark);
-		background-color: var(--maxi-white);
+		color: $gd;
+		background-color: $w;
 		font-size: 13px;
 		line-height: normal;
 
@@ -274,12 +275,12 @@ body .toolbar-item__popover {
 			outline: none;
 		}
 		// &:hover:not(#inspector-select-control-0):not([id^='inspector-input-control']):not([id^='url-input-control']):not(.w-tc-editor-text):not(.maxi-css-code-editor__code-editor) {
-		// 	color: var(--maxi-grey-dark) !important;
-		// 	border: 1.5px solid var(--maxi-primary-color) !important;
-		// 	transition: all 0.4s ease;
+		// 	color: $gd !important;
+		// 	border: 1.5px solid $pc !important;
+		// 	transition: $t;
 		// }
 		&:active {
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 	}
 	input[type='number'] {
@@ -307,21 +308,21 @@ body .toolbar-item__popover {
 			width: 14px;
 			height: 14px;
 			margin: auto;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 		&:hover {
-			transition: all 0.5s ease;
+			transition: $t;
 			&:before {
 				content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.34 11.5" role="img" aria-hidden="true" focusable="false"><path fill="rgba(99,186,121, 0.8)" d="M11.32.75a.74.74 0 0 0-.75-.75.76.76 0 0 0-.75.75v1.49A5.6 5.6 0 1 0 5.6 11.5a5.44 5.44 0 0 0 1.48-.2.74.74 0 0 0 .52-.92.76.76 0 0 0-.92-.53A4.1 4.1 0 1 1 9.22 4H6.57a.75.75 0 0 0 0 1.5h4a.75.75 0 0 0 .53-.22.77.77 0 0 0 .22-.54Z"></path></svg>') !important;
 			}
 		}
 	}
 	.components-panel {
-		background: transparent;
+		background: $tr;
 		border: none;
 	}
 	.components-simple-tooltip {
-		color: var(--maxi-white);
+		color: $w;
 	}
 }
 
@@ -342,7 +343,7 @@ body .toolbar-item__popover {
 	input[type='number'],
 	textarea,
 	select {
-		border-color: var(--maxi-grey);
+		border-color: $g;
 	}
 	input[type='number'] {
 		padding-right: 0;
@@ -350,11 +351,11 @@ body .toolbar-item__popover {
 	.components-range-control__number {
 		.components-input-control {
 			&__container {
-				background-color: transparent;
+				background-color: $tr;
 			}
 			&__input {
-				color: var(--maxi-grey-dark);
-				border-color: var(--maxi-grey-light);
+				color: $gd;
+				border-color: $gl;
 			}
 		}
 	}
@@ -365,13 +366,13 @@ body .toolbar-item__popover {
 		.components-select-control {
 			&__input {
 				&:disabled {
-					background-color: var(--maxi-pastel-green) !important;
-					color: var(--maxi-black) !important;
+					background-color: $pg !important;
+					color: $bk !important;
 					font-weight: 700 !important;
 
 					&:hover {
-						background-color: var(--maxi-mid-green) !important;
-						color: var(--maxi-white) !important;
+						background-color: $mg !important;
+						color: $w !important;
 					}
 				}
 			}
@@ -411,14 +412,14 @@ body.maxi-blocks--active {
 		max-width: 60px !important;
 		min-width: 55px !important;
 		padding: 8px 6px !important;
-		background-color: var(--maxi-white) !important;
+		background-color: $w !important;
 		/* Draw shorter vertical lines using layered backgrounds */
 		/* Short dividers on LEFT and RIGHT plus chevron */
 		// background-image: linear-gradient(
-		// 		var(--maxi-grey-light),
-		// 		var(--maxi-grey-light)
+		// 		$gl,
+		// 		$gl
 		// 	),
-		// 	linear-gradient(var(--maxi-grey-light), var(--maxi-grey-light)),
+		// 	linear-gradient($gl, $gl),
 		// 	url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(180, 180, 180, 0.9)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>');
 		// background-repeat: no-repeat, no-repeat, no-repeat !important;
 		// /* Set the short line heights here */
@@ -445,13 +446,13 @@ svg path#styleCardBoat_a {
 svg path#styleCardMenu_b,
 svg path#styleCardBoat_b,
 #styleCardBoat_b {
-	stroke: var(--maxi-grey-dark);
+	stroke: $gd;
 }
 .maxi-responsive-close {
 	background-color: rgba(var(--maxi-active-sc-color), 1);
 }
 .maxi-responsive-close:hover svg g {
-	stroke: var(--maxi-white);
+	stroke: $w;
 }
 
 /*******************************
@@ -460,9 +461,9 @@ svg path#styleCardBoat_b,
 
 .maxi-block {
 	&::after {
-		transition: all 0.5s ease;
+		transition: $t;
 		content: '';
-		position: absolute;
+		position: $pa;
 		pointer-events: none;
 		top: -1px !important;
 		right: -3px !important;
@@ -484,10 +485,10 @@ svg path#styleCardBoat_b,
 
 	&:not(.is-selected) {
 		&:hover {
-			transition: all 0.5s ease;
+			transition: $t;
 			&::after {
 				content: '';
-				position: absolute;
+				position: $pa;
 				pointer-events: none;
 				opacity: 1;
 			}
@@ -499,7 +500,7 @@ svg path#styleCardBoat_b,
 			opacity: 1;
 
 			&:not(.maxi-block--is-repeater) {
-				border-color: var(--maxi-primary-color);
+				border-color: $pc;
 			}
 		}
 		&:focus {
@@ -515,11 +516,11 @@ svg path#styleCardBoat_b,
 			left: 0px !important;
 		}
 		.maxi-block-indicators__padding--left {
-			position: absolute;
+			position: $pa;
 			left: 4px;
 		}
 		.maxi-block-indicators__padding--right {
-			position: absolute;
+			position: $pa;
 			right: 4px;
 		}
 	}
@@ -626,22 +627,22 @@ html[dir='rtl'] {
 		height: 30px;
 		box-shadow: -3px 3px 6px 0px rgb(0 0 0 / 16%) !important;
 		border-radius: 0;
-		background: var(--maxi-white);
+		background: $w;
 		visibility: visible;
-		transition: all 0.4s ease !important; // Updated transition to include all properties
+		transition: $t !important; // Updated transition to include all properties
 
 		svg {
-			fill: var(--maxi-primary-color);
+			fill: $pc;
 			width: 15px;
 			height: 15px;
 			transition: fill 0.3s ease; // Added transition for svg fill
 		}
 		&:hover {
-			background-color: var(--maxi-pastel-green) !important;
-			transition: all 0.4s ease !important;
-			border-color: var(--maxi-primary-color);
+			background-color: $pg !important;
+			transition: $t !important;
+			border-color: $pc;
 			svg {
-				fill: var(--maxi-primary-color);
+				fill: $pc;
 			}
 		}
 	}
@@ -726,41 +727,41 @@ body.maxi-blocks--active
 	&-none {
 		svg path {
 			transition: fill 0.5s ease;
-			fill: var(--maxi-grey-dark);
+			fill: $gd;
 		}
 		&.maxi-tabs-control__button--selected {
 			svg path {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 			}
 		}
 	}
 
 	&-color {
 		svg path {
-			fill: var(--maxi-grey-dark);
+			fill: $gd;
 		}
 		&.maxi-tabs-control__button--selected {
 			svg path {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 			}
 		}
 	}
 
 	&-gradient {
 		svg path {
-			stroke: var(--maxi-grey-dark);
+			stroke: $gd;
 			fill: none;
 		}
 		&.maxi-tabs-control__button--selected {
 			svg path {
-				stroke: var(--maxi-secondary-color);
+				stroke: $sc;
 			}
 			svg linearGradient stop {
 				&:first-child {
-					stop-color: var(--maxi-white);
+					stop-color: $w;
 				}
 				&:last-child {
-					stop-color: var(--maxi-secondary-color);
+					stop-color: $sc;
 				}
 			}
 		}
@@ -768,22 +769,22 @@ body.maxi-blocks--active
 
 	&-image {
 		svg path {
-			fill: var(--maxi-grey-dark);
+			fill: $gd;
 		}
 		&.maxi-tabs-control__button--selected {
 			svg path {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 			}
 		}
 	}
 
 	&-video {
 		svg path {
-			fill: var(--maxi-grey-dark);
+			fill: $gd;
 		}
 		&.maxi-tabs-control__button--selected {
 			svg path {
-				fill: var(--maxi-secondary-color);
+				fill: $sc;
 			}
 		}
 	}
@@ -792,19 +793,19 @@ body.maxi-blocks--active
 // Number input field
 // input.maxi-advanced-number-control_value,
 // input.maxi-advanced-number-control__value {
-// 	transition: all 0.3s ease;
-// 	border: 1.5px solid var(--maxi-grey-light) !important;
+// 	transition: $t;
+// 	border: $bg !important;
 // 	border-radius: 5px 0 0 5px !important;
 // 	height: 31px !important;
 // 	padding: 0 0 0 8px !important;
 // 	width: 55px !important;
 
 // 	&:hover {
-// 		border-color: var(--maxi-grey-dark) !important;
+// 		border-color: $gd !important;
 // 	}
 
 // 	&:focus {
-// 		border-color: var(--maxi-secondary-color) !important;
+// 		border-color: $sc !important;
 // 		outline: none !important;
 // 	}
 // }
@@ -812,20 +813,20 @@ body.maxi-blocks--active
 // Unit selector
 // .maxi-base-control.maxi-dimensions-control__units {
 // 	select {
-// 		transition: all 0.3s ease;
-// 		border: 1.5px solid var(--maxi-grey-light) !important;
+// 		transition: $t;
+// 		border: $bg !important;
 // 		border-radius: 0 5px 5px 0px !important;
 // 		height: 31px !important;
 // 		padding: 0 8px !important;
 // 		min-width: 45px !important;
-// 		cursor: pointer !important;
+// 		cursor: $ptr !important;
 
 // 		&:hover {
-// 			border-color: var(--maxi-primary-color) !important;
+// 			border-color: $pc !important;
 // 		}
 
 // 		&:focus {
-// 			border-color: var(--maxi-secondary-color) !important;
+// 			border-color: $sc !important;
 // 			outline: none !important;
 // 		}
 // 	}
@@ -833,7 +834,7 @@ body.maxi-blocks--active
 
 // Reset button
 .maxi-components-button.maxi-reset-button {
-	transition: all 0.3s ease;
+	transition: $t;
 	width: 9px !important;
 	height: 31px !important;
 	padding: 0 !important;
@@ -844,13 +845,13 @@ body.maxi-blocks--active
 	svg {
 		width: 10px !important;
 		height: 10px !important;
-		fill: var(--maxi-grey) !important;
+		fill: $g !important;
 	}
 
 	&:hover {
-		border-color: var(--maxi-grey-dark) !important;
+		border-color: $gd !important;
 		svg {
-			fill: var(--maxi-secondary-color) !important;
+			fill: $sc !important;
 		}
 	}
 }
@@ -867,7 +868,7 @@ body.maxi-blocks--active
 // Accordion icon
 .maxi-accordion-icon,
 .maxi-video-block-icon {
-	fill: var(--maxi-primary-color) !important;
+	fill: $pc !important;
 }
 
 // Transitions
@@ -875,7 +876,7 @@ body {
 	.maxi-settingstab-control {
 		button,
 		input {
-			transition: all 0.3s ease;
+			transition: $t;
 		}
 	}
 }

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -1,4 +1,21 @@
 @import '../../src/css/backend-variables.scss';
+
+@mixin transit {
+	transition: $t;
+}
+
+@mixin flex-center($important: false) {
+	@if $important {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+	} @else {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
 /**
  * #.# Common SCSS
  *
@@ -53,7 +70,7 @@ h2.gx_error {
 		*):not([class*='maxi-transform-control']):not([class*='maxi-transform-control']
 		*):not(.w-tc-editor-text):not(.maxi-css-code-editor__code-editor *),
 .maxi-popover *:not(i) {
-	transition: $t;
+	@include transit;
 	color: $gd;
 	font-family: $f !important;
 	font-weight: normal;
@@ -76,14 +93,14 @@ h2.gx_error {
 }
 
 .block-editor-inserter {
-	transition: $t;
+	@include transit;
 	color: $w !important;
 	height: 100%;
 
 	&__toggle {
-		transition: $t;
+		@include transit;
 		svg {
-			transition: $t;
+			@include transit;
 			fill: $w !important;
 		}
 	}
@@ -126,16 +143,16 @@ body {
 	}
 }
 .maxi-block {
-	transition: $t;
+	@include transit;
 
 	.block-editor-block-list__layout {
-		transition: $t;
+		@include transit;
 		&:focus:after {
 			box-shadow: none !important;
 		}
 	}
 	&:hover {
-		transition: $t;
+		@include transit;
 		& > .block-editor-block-list__layout {
 			& > .block-list-appender {
 				.block-editor-button-block-appender {
@@ -259,7 +276,7 @@ body .toolbar-item__popover {
 	input[type='number'],
 	textarea:not(.w-tc-editor-text),
 	select {
-		transition: $t;
+		@include transit;
 		flex: 1;
 		max-height: unset !important;
 		min-height: unset;
@@ -277,7 +294,7 @@ body .toolbar-item__popover {
 		// &:hover:not(#inspector-select-control-0):not([id^='inspector-input-control']):not([id^='url-input-control']):not(.w-tc-editor-text):not(.maxi-css-code-editor__code-editor) {
 		// 	color: $gd !important;
 		// 	border: 1.5px solid $pc !important;
-		// 	transition: $t;
+		// 	@include transit;
 		// }
 		&:active {
 			color: $gd;
@@ -311,7 +328,7 @@ body .toolbar-item__popover {
 			color: $gd;
 		}
 		&:hover {
-			transition: $t;
+			@include transit;
 			&:before {
 				content: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.34 11.5" role="img" aria-hidden="true" focusable="false"><path fill="rgba(99,186,121, 0.8)" d="M11.32.75a.74.74 0 0 0-.75-.75.76.76 0 0 0-.75.75v1.49A5.6 5.6 0 1 0 5.6 11.5a5.44 5.44 0 0 0 1.48-.2.74.74 0 0 0 .52-.92.76.76 0 0 0-.92-.53A4.1 4.1 0 1 1 9.22 4H6.57a.75.75 0 0 0 0 1.5h4a.75.75 0 0 0 .53-.22.77.77 0 0 0 .22-.54Z"></path></svg>') !important;
 			}
@@ -461,7 +478,7 @@ svg path#styleCardBoat_b,
 
 .maxi-block {
 	&::after {
-		transition: $t;
+		@include transit;
 		content: '';
 		position: $pa;
 		pointer-events: none;
@@ -485,7 +502,7 @@ svg path#styleCardBoat_b,
 
 	&:not(.is-selected) {
 		&:hover {
-			transition: $t;
+			@include transit;
 			&::after {
 				content: '';
 				position: $pa;
@@ -793,7 +810,7 @@ body.maxi-blocks--active
 // Number input field
 // input.maxi-advanced-number-control_value,
 // input.maxi-advanced-number-control__value {
-// 	transition: $t;
+// 	@include transit;
 // 	border: $bg !important;
 // 	border-radius: 5px 0 0 5px !important;
 // 	height: 31px !important;
@@ -813,7 +830,7 @@ body.maxi-blocks--active
 // Unit selector
 // .maxi-base-control.maxi-dimensions-control__units {
 // 	select {
-// 		transition: $t;
+// 		@include transit;
 // 		border: $bg !important;
 // 		border-radius: 0 5px 5px 0px !important;
 // 		height: 31px !important;
@@ -834,7 +851,7 @@ body.maxi-blocks--active
 
 // Reset button
 .maxi-components-button.maxi-reset-button {
-	transition: $t;
+	@include transit;
 	width: 9px !important;
 	height: 31px !important;
 	padding: 0 !important;
@@ -876,7 +893,7 @@ body {
 	.maxi-settingstab-control {
 		button,
 		input {
-			transition: $t;
+			@include transit;
 		}
 	}
 }

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -1,20 +1,6 @@
 @import '../../src/css/backend-variables.scss';
 
-@mixin transit {
-	transition: $t;
-}
 
-@mixin flex-center($important: false) {
-	@if $important {
-		display: flex !important;
-		align-items: center !important;
-		justify-content: center !important;
-	} @else {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-}
 
 /**
  * #.# Common SCSS

--- a/src/css/inserter-card.scss
+++ b/src/css/inserter-card.scss
@@ -19,9 +19,9 @@
 	}
 	.block-editor-block-inspector {
 		.block-editor-block-card {
-			position: relative;
+			position: $pr;
 			padding: 8px;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 			letter-spacing: 0;
 
 			&__content,
@@ -39,7 +39,7 @@
 				display: none;
 				width: 100%;
 				margin: 0;
-				position: relative;
+				position: $pr;
 				left: -25px;
 				padding-top: 5px;
 			}

--- a/src/css/maxi-themes-banner.scss
+++ b/src/css/maxi-themes-banner.scss
@@ -1,3 +1,4 @@
+@import 'backend-variables.scss';
 /********
 * This styles should provide not just a base for all Maxi Block blocks,
 * it has the objective to remove other theme/plugins styles that can affect them
@@ -12,7 +13,7 @@
 }
 
 body.maxi-blocks--active .maxi-block {
-	position: relative;
+	position: $pr;
 	margin: 0 auto;
 	padding: 0;
 	/* max-width: none; */ /* Not sure if it can create and interfere with theme styles */
@@ -42,7 +43,7 @@ body.maxi-blocks--active .maxi-block {
 	}
 
 	&.maxi-button-block .maxi-button-block__button {
-		background-color: transparent;
+		background-color: $tr;
 	}
 
 	/*Seedlet theme overrides*/
@@ -158,7 +159,7 @@ body.maxi-blocks--active {
 
 /* Fix for links inside of map maxi */
 body.maxi-blocks--active .maxi-map-block .leaflet-bar a {
-	color: var(--maxi-black);
+	color: $bk;
 }
 
 /* Fix custom blocks display in maxi wrapper blocks with added bg layers */
@@ -166,7 +167,7 @@ body.maxi-blocks--active
 	*
 	:has(> .maxi-background-displayer)
 	> *:not(.maxi-background-displayer):not(.maxi-block-indicators):not(.maxi-container-arrow) {
-	position: relative;
+	position: $pr;
 }
 
 /*******************************

--- a/src/css/native-components.scss
+++ b/src/css/native-components.scss
@@ -12,27 +12,27 @@
 	hr {
 		margin-top: 12px !important;
 		margin-bottom: 12px !important;
-		border: 1.5px solid var(--maxi-grey-light);
+		border: $bg;
 	}
 	.block-editor-link-control {
 		.block-editor-url-input__input {
-			color: var(--maxi-grey-dark);
+			color: $gd;
 
 			&::placeholder {
-				color: var(--maxi-grey-dark) !important;
+				color: $gd !important;
 			}
 		}
 		&__search-item-info {
-			color: var(--maxi-grey-dark);
+			color: $gd;
 		}
 		&__search-item-action {
-			color: var(--maxi-white);
-			background-color: var(--maxi-black);
-			box-shadow: inset 0 0 0 1px var(--maxi-white);
+			color: $w;
+			background-color: $bk;
+			box-shadow: inset 0 0 0 1px $w;
 
 			&:hover {
-				color: var(--maxi-primary-color) !important;
-				box-shadow: inset 0 0 0 1px var(--maxi-primary-color) !important;
+				color: $pc !important;
+				box-shadow: inset 0 0 0 1px $pc !important;
 			}
 		}
 		&__search-item-header {
@@ -47,34 +47,34 @@
 				outline: none;
 			}
 			mark {
-				color: var(--maxi-primary-color);
+				color: $pc;
 			}
 		}
 		&__search-results-wrapper {
 			margin-bottom: 8px;
 		}
 		&__search-item-type {
-			background-color: var(--maxi-black);
+			background-color: $bk;
 			border-radius: 2px;
 		}
 		&__search-item {
 			margin-bottom: 3px;
-			color: var(--maxi-white);
-			background-color: var(--maxi-grey-dark);
+			color: $w;
+			background-color: $gd;
 
 			&.is-current {
 				margin-bottom: 8px;
-				color: var(--maxi-white);
-				background-color: var(--maxi-grey-dark);
+				color: $w;
+				background-color: $gd;
 
 				a {
 					margin-bottom: 5px;
-					color: var(--maxi-primary-color);
+					color: $pc;
 					text-decoration: none;
 				}
 			}
 			&:hover {
-				background-color: var(--maxi-grey-dark);
+				background-color: $gd;
 			}
 		}
 		&__search-results-wrapper:before,
@@ -110,35 +110,35 @@
 				overflow: hidden;
 				padding: 8px;
 				border-radius: 0;
-				background-color: var(--maxi-white);
+				background-color: $w;
 				text-decoration: none;
 				transition: 0.5s linear;
-				cursor: pointer;
+				cursor: $ptr;
 				-webkit-appearance: none;
 				opacity: 1;
 
 				&:hover {
-					border-color: var(--maxi-grey-light);
+					border-color: $gl;
 					box-shadow: none !important;
-					cursor: pointer;
+					cursor: $ptr;
 				}
 
 				&.is-primary {
-					border-color: var(--maxi-primary-color);
+					border-color: $pc;
 
 					&:focus:enabled {
-						box-shadow: 0 0 0 1px var(--maxi-white),
-							0 0 0 3px var(--maxi-primary-color);
+						box-shadow: 0 0 0 1px $w,
+							0 0 0 3px $pc;
 					}
 				}
 
 				&.is-secondary {
-					border: 1px solid var(--maxi-grey-light);
+					border: $bl;
 					box-shadow: none !important;
 
 					&:hover {
-						background-color: var(--maxi-white);
-						border-color: var(--maxi-grey-light);
+						background-color: $w;
+						border-color: $gl;
 					}
 
 					svg {
@@ -149,7 +149,7 @@
 
 				&[type='reset'] {
 					svg {
-						fill: var(--maxi-grey-dark);
+						fill: $gd;
 					}
 				}
 
@@ -171,7 +171,7 @@
 			}
 		}
 		.components-base-control__label {
-			position: absolute;
+			position: $pa;
 			overflow: hidden;
 			width: 1px;
 			height: 1px;
@@ -193,47 +193,47 @@
 			.components-range-control__tooltip {
 				top: auto;
 				bottom: -26px !important;
-				background-color: var(--maxi-grey-dark);
+				background-color: $gd;
 			}
 			.components-range-control__slider {
 				& + span {
 					height: 2px;
 					margin-top: 6px;
 					margin-right: -8px;
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 			}
 			.components-range-control__track {
 				height: 2px;
 				margin-top: 6px;
 				margin-left: -8px;
-				background: var(--maxi-secondary-color) !important;
+				background: $sc !important;
 
 				& + span {
 					top: -10px;
 					width: 16px;
 					height: 16px;
 					transform: translateX(0);
-					background-color: transparent;
+					background-color: $tr;
 					margin-left: -9px;
 
 					span {
-						position: relative;
+						position: $pr;
 						width: 16px;
 						height: 16px;
 						margin-right: -3px;
-						border: 2px solid var(--maxi-black);
-						background-color: var(--maxi-white);
+						border: 2px solid $bk;
+						background-color: $w;
 
 						&:after {
 							content: '';
-							position: absolute;
+							position: $pa;
 							top: 2px;
 							left: 2px;
 							width: 8px;
 							height: 8px;
 							border-radius: 50%;
-							background: var(--maxi-black);
+							background: $bk;
 						}
 						&::before {
 							display: none !important;

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -17,7 +17,7 @@
 }
 
 .maxi-block {
-	position: relative;
+	position: $pr;
 	z-index: 0;
 
 	// To not break pages full-width which wasn't updated after #3269
@@ -27,7 +27,7 @@
 	}
 
 	span.maxi-block-anchor {
-		position: absolute;
+		position: $pa;
 		top: 0;
 	}
 
@@ -38,7 +38,7 @@
 		opacity: 0.7;
 	}
 	&__disabled {
-		position: absolute;
+		position: $pa;
 		top: 0;
 		left: 0;
 		width: 100%;
@@ -48,13 +48,13 @@
 		align-items: center;
 		justify-content: center;
 		background-color: rgba(0, 0, 0, 0.5);
-		box-shadow: inset 0 0 0px 1px var(--maxi-white);
+		box-shadow: inset 0 0 0px 1px $w;
 
 		p {
 			padding: 10px;
 			margin: auto;
-			color: var(--maxi-white);
-			background-color: var(--maxi-black);
+			color: $w;
+			background-color: $bk;
 			font-family: Inter, sans-serif;
 			font-size: 14px;
 			text-align: center;
@@ -100,7 +100,7 @@
 
 	// Override the default button style that makes cursor default for links
 	button {
-		cursor: pointer;
+		cursor: $ptr;
 	}
 }
 
@@ -133,6 +133,6 @@ body.maxi-blocks--active .maxi-block--use-sc .entry-content:has(.maxi-block) {
 	}
 
 	&:active:not(:disabled) {
-		background: var(--maxi-grey-light) !important;
+		background: $gl !important;
 	}
 }

--- a/src/editor/export/editor.scss
+++ b/src/editor/export/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-export-popover {
 	height: auto !important;
 	left: 20% !important;
@@ -6,15 +7,15 @@
 		justify-content: center;
 		margin: 8px 0;
 		padding: 10px;
-		background-color: var(--maxi-primary-color);
-		color: var(--maxi-white);
+		background-color: $pc;
+		color: $w;
 		border: none;
 		border-radius: 4px;
-		cursor: pointer;
+		cursor: $ptr;
 		transition: background-color 0.3s ease;
 
 		&:hover {
-			background-color: var(--maxi-secondary-color);
+			background-color: $sc;
 		}
 
 		& + & {

--- a/src/editor/library/editor.scss
+++ b/src/editor/library/editor.scss
@@ -1,5 +1,35 @@
 @import '../../../src/css/backend-variables.scss';
 
+@mixin scrollbar($width: 5px, $track: $w, $thumb: $gl) {
+	&::-webkit-scrollbar {
+		width: $width;
+	}
+
+	&::-webkit-scrollbar-track {
+		background: $track;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background: $thumb;
+	}
+
+	&::-webkit-scrollbar-thumb:hover {
+		background: $thumb;
+	}
+}
+
+@mixin flex-center($important: false) {
+	@if $important {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+	} @else {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
 .maxi-library-modal {
 	width: 85%;
 	min-height: 90%;
@@ -50,9 +80,7 @@
 				border: 1.5px solid $mg;
 				color: $bk;
 				transition: $t;
-				display: flex; // Simplified from separate align/justify
-				justify-content: center;
-				align-items: center;
+				@include flex-center;
 
 				&:hover {
 					background: $pg !important;
@@ -135,9 +163,7 @@
 			}
 
 			& > div {
-				display: flex;
-				align-items: center;
-				justify-content: center;
+				@include flex-center;
 				height: 100%;
 			}
 		}
@@ -154,21 +180,7 @@
 				$w 40px
 			) !important;
 			.maxi-cloud-container {
-				&::-webkit-scrollbar {
-					width: 5px;
-				}
-
-				&::-webkit-scrollbar-track {
-					background: $cpw;
-				}
-
-				&::-webkit-scrollbar-thumb {
-					background: $gl;
-				}
-
-				&::-webkit-scrollbar-thumb:hover {
-					background: $gl;
-				}
+				@include scrollbar(5px, $cpw, $gl);
 				&__patterns {
 					position: $pr;
 					grid-template-columns: none;
@@ -369,39 +381,7 @@
 		}
 	}
 
-	.spinner {
-		display: none; // TEMPORARY
-		position: $pr;
-		height: 100px;
-		width: 100px;
 
-		&:before,
-		&:after {
-			content: '';
-			border-left: 6px solid $tr;
-			border-radius: 50%;
-			bottom: 0;
-			box-sizing: border-box;
-			left: 0;
-			margin: auto;
-			position: $pa;
-			right: 0;
-			top: 0;
-			transform-origin: center center;
-		}
-
-		&:before {
-			animation: rotate 1s ease-in-out infinite;
-			height: 100%;
-			width: 100%;
-		}
-
-		&:after {
-			animation: rotate 1s ease-in-out infinite reverse;
-			height: 50%;
-			width: 50%;
-		}
-	}
 
 	.maxi-cloud-toolbar {
 		position: $pa;
@@ -420,9 +400,7 @@
 		word-spacing: 4px;
 		font-weight: 500;
 		&__sign-in {
-			display: flex;
-			justify-content: center;
-			align-items: center;
+			@include flex-center;
 			position: $pa;
 			right: 100px;
 			column-gap: 15px;
@@ -433,9 +411,7 @@
 
 		&__help-button {
 			z-index: 9;
-			display: flex;
-			align-items: center;
-			justify-content: center;
+			@include flex-center;
 			padding: 0;
 			background-color: $tr;
 			color: $cp;
@@ -1053,21 +1029,7 @@
 				height: 100%;
 				overflow-y: scroll;
 
-				&::-webkit-scrollbar {
-					width: 2px;
-				}
-
-				&::-webkit-scrollbar-track {
-					background: $w;
-				}
-
-				&::-webkit-scrollbar-thumb {
-					background: $gl;
-				}
-
-				&::-webkit-scrollbar-thumb:hover {
-					background: $gl;
-				}
+				@include scrollbar(2px, $w, $gl);
 			}
 		}
 
@@ -1645,9 +1607,7 @@
 								min-width: 90px;
 								padding: 5px 10px;
 								text-align: center !important;
-								display: flex !important;
-								justify-content: center !important;
-								align-items: center !important;
+								@include flex-center(true);
 								transition: $t; // Add transition
 
 								&:hover {
@@ -1988,21 +1948,7 @@
 			overflow-y: scroll;
 			padding: 10px 12px 6px;
 
-			&::-webkit-scrollbar {
-				width: 5px;
-			}
-
-			&::-webkit-scrollbar-track {
-				background: $w;
-			}
-
-			&::-webkit-scrollbar-thumb {
-				background: $gl;
-			}
-
-			&::-webkit-scrollbar-thumb:hover {
-				background: $gl;
-			}
+			@include scrollbar(5px, $w, $gl);
 		}
 	}
 }
@@ -2022,21 +1968,7 @@
 			overflow-x: hidden;
 			overflow-y: scroll;
 			padding: 8px 8px 6px;
-			&::-webkit-scrollbar {
-				width: 5px;
-			}
-
-			&::-webkit-scrollbar-track {
-				background: $w;
-			}
-
-			&::-webkit-scrollbar-thumb {
-				background: $gl;
-			}
-
-			&::-webkit-scrollbar-thumb:hover {
-				background: $gl;
-			}
+			@include scrollbar(5px, $w, $gl);
 		}
 	}
 }
@@ -2749,9 +2681,7 @@ html[dir='rtl'] {
 						min-width: 90px;
 						padding: 5px 10px;
 						text-align: center !important;
-						display: flex !important;
-						justify-content: center !important;
-						align-items: center !important;
+						@include flex-center(true);
 						transition: $t;
 
 						&:hover {

--- a/src/editor/library/editor.scss
+++ b/src/editor/library/editor.scss
@@ -1,15 +1,13 @@
-// At the top of your file:
-$standard-margin: 8px;
-$border-light: 1px solid var(--maxi-grey-light);
+@import '../../../src/css/backend-variables.scss';
 
 .maxi-library-modal {
 	width: 85%;
 	min-height: 90%;
 	max-width: 90%;
 	overflow-y: auto;
-	font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+	font-family: $f;
 	font-weight: 600;
-	transition: transform 0.3s ease;
+	transition: $t;
 
 	@keyframes fadeIn {
 		0% {
@@ -23,77 +21,67 @@ $border-light: 1px solid var(--maxi-grey-light);
 	}
 
 	&__action-section {
-		// Main container layout
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
 		flex-wrap: wrap;
 		width: 100%;
 
-		// Full width label
 		& &__label {
 			flex-basis: 100%;
 		}
 
 		&__buttons {
-			// Button container layout
 			width: 100%;
 			flex: 5;
 			display: flex;
 			align-items: center;
-			transition: all 0.4s ease; // Add transition
+			transition: $t; // Add transition
 
-			// Add button hover styles
 			.maxi-cloud-masonry-card__button {
 				&:hover {
-					// border-color: var(--maxi-cloud-primary);
-					// background-color: var(--maxi-cloud-primary-whisper);
 				}
 			}
 
 			&__load-library {
-				// Load library button styles
 				width: 100%;
 				padding: 2rem;
-				background: var(--maxi-whisper-green);
-				border: 1.5px solid var(--maxi-mid-green);
-				color: var(--maxi-black);
-				transition: all 0.3s ease;
+				background: $wg;
+				border: 1.5px solid $mg;
+				color: $bk;
+				transition: $t;
 				display: flex; // Simplified from separate align/justify
 				justify-content: center;
 				align-items: center;
 
 				&:hover {
-					background: var(--maxi-pastel-green) !important;
-					border-color: var(--maxi-secondary-color);
-					color: var(--maxi-black) !important;
+					background: $pg !important;
+					border-color: $sc;
+					color: $bk !important;
 					font-weight: 800;
 				}
 			}
 
 			&__item {
-				// Individual button item styles
 				width: calc(16.6666666667% - 5px);
 				margin: 0 5px 5px 0;
 				padding: 0;
 				height: auto;
-				border: 2px solid var(--maxi-grey-light);
+				border: 2px solid $gl;
 				border-radius: 5px;
-				cursor: pointer;
-				transition: all 0.4s ease; // Add transition
+				cursor: $ptr;
+				transition: $t; // Add transition
 
-				// States
 				&--active,
 				&:hover {
-					background: var(--maxi-cloud-primary-whisper);
-					border-left: 1px solid var(--maxi-white) !important;
+					background: $cpw;
+					border-left: 1px solid $w !important;
 				}
 
 				&:last-child {
 					margin-right: 0;
 				}
 
-				// Button SVG styles
 				svg {
 					width: 100%;
 					height: 100%;
@@ -102,55 +90,50 @@ $border-light: 1px solid var(--maxi-grey-light);
 			}
 		}
 		&__preview {
-			// Preview container layout
-			position: relative;
+			position: $pr;
 			width: 100%;
 			height: 66px;
 			flex: 1;
 			margin: 0 5px;
 			padding: 5px;
 
-			// Preview theme styles
-			background: var(--maxi-whisper-green);
-			border: 1.5px solid var(--maxi-mid-green);
-			color: var(--maxi-black);
-			transition: background-color 0.3s ease, border-color 0.3s ease;
+			background: $wg;
+			border: 1.5px solid $mg;
+			color: $bk;
+			transition: $t;
 
 			&:hover {
-				background: var(--maxi-pastel-green);
-				border-color: var(--maxi-primary-color);
+				background: $pg;
+				border-color: $pc;
 			}
 
-			// SVG styles in preview
 			&__shape svg {
 				max-height: 100%;
-				fill: var(--maxi-black);
+				fill: $bk;
 
 				* {
 					fill: inherit;
 				}
 			}
 
-			// Remove button
 			&--remove {
-				position: absolute;
+				position: $pa;
 				top: -8px;
 				right: -8px;
 				width: 16px;
-				cursor: pointer;
+				cursor: $ptr;
 				z-index: 8400000;
-				background: var(--maxi-white);
+				background: $w;
 				border-radius: 100%;
 				height: 16px;
 				&:hover {
-					background: var(--maxi-primary-color);
+					background: $pc;
 					path {
-						fill: var(--maxi-white);
+						fill: $w;
 					}
 				}
 			}
 
-			// Preview content container
 			& > div {
 				display: flex;
 				align-items: center;
@@ -167,8 +150,8 @@ $border-light: 1px solid var(--maxi-grey-light);
 				-45deg,
 				var(--maxi-cloud-preview-gradient),
 				var(--maxi-cloud-preview-gradient) 20px,
-				var(--maxi-white) 0,
-				var(--maxi-white) 40px
+				$w 0,
+				$w 40px
 			) !important;
 			.maxi-cloud-container {
 				&::-webkit-scrollbar {
@@ -176,18 +159,18 @@ $border-light: 1px solid var(--maxi-grey-light);
 				}
 
 				&::-webkit-scrollbar-track {
-					background: var(--maxi-cloud-primary-whisper);
+					background: $cpw;
 				}
 
 				&::-webkit-scrollbar-thumb {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 
 				&::-webkit-scrollbar-thumb:hover {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 				&__patterns {
-					position: relative;
+					position: $pr;
 					grid-template-columns: none;
 					align-content: unset;
 				}
@@ -195,7 +178,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 		}
 		.maxi-cloud-toolbar {
 			height: 50px !important;
-			background-color: var(--maxi-white);
+			background-color: $w;
 			padding: 5px 8px !important;
 			z-index: 999;
 			&__fullwidth {
@@ -206,29 +189,29 @@ $border-light: 1px solid var(--maxi-grey-light);
 				justify-content: center;
 				flex-direction: column;
 				align-items: center;
-				color: var(--maxi-grey-dark);
-				background-color: var(--maxi-cloud-primary-whisper);
+				color: $gd;
+				background-color: $cpw;
 				border: 0;
 				border-radius: 30px;
 				padding: 8px 6px 4px;
-				cursor: pointer;
+				cursor: $ptr;
 				outline: none;
-				transition: all 0.4s ease; // Add transition
+				transition: $t; // Add transition
 				&_active {
 					svg {
 						path {
-							fill: var(--maxi-cloud-primary);
+							fill: $cp;
 						}
 					}
 					span {
-						color: var(--maxi-cloud-primary);
+						color: $cp;
 					}
 				}
 				&-fullwidth {
 					&.maxi-cloud-toolbar__button_active {
 						svg {
 							path {
-								stroke: var(--maxi-cloud-primary);
+								stroke: $cp;
 							}
 						}
 					}
@@ -240,13 +223,13 @@ $border-light: 1px solid var(--maxi-grey-light);
 					height: 16px;
 				}
 				span {
-					font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+					font-family: $f !important;
 					font-size: 9px;
 					line-height: 100%;
 				}
 				&_active,
 				&:hover {
-					box-shadow: inset 0 0 0px 1px var(--maxi-cloud-primary);
+					box-shadow: inset 0 0 0px 1px $cp;
 				}
 			}
 			&__responsive-buttons {
@@ -255,7 +238,6 @@ $border-light: 1px solid var(--maxi-grey-light);
 				column-gap: 10px;
 				width: 33.33%;
 
-				// Target buttons directly inside responsive-buttons
 				.maxi-cloud-toolbar__button {
 					border-radius: 8px;
 				}
@@ -265,9 +247,9 @@ $border-light: 1px solid var(--maxi-grey-light);
 				align-items: center;
 				column-gap: 17px;
 				width: 33.33%;
-				font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+				font-family: $f !important;
 				h2 {
-					color: var(--maxi-grey-dark);
+					color: $gd;
 					font-size: 16px;
 					font-weight: 700;
 					letter-spacing: -0.5px;
@@ -277,14 +259,14 @@ $border-light: 1px solid var(--maxi-grey-light);
 					span {
 						font-size: 16px;
 						font-weight: 700;
-						color: var(--maxi-grey-dark);
+						color: $gd;
 					}
 				}
 				& > .maxi-cloud-toolbar__line {
 					width: 2px;
 					height: 16px;
 					margin: 0 -8px;
-					background-color: var(--maxi-grey-light);
+					background-color: $gl;
 					font-size: 0;
 				}
 			}
@@ -304,7 +286,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 					span {
 						font-size: 16px;
 						font-weight: 700;
-						color: var(--maxi-grey-dark);
+						color: $gd;
 					}
 				}
 			}
@@ -312,11 +294,11 @@ $border-light: 1px solid var(--maxi-grey-light);
 	}
 
 	.components-modal__content {
-		position: relative;
+		position: $pr;
 		width: 100%;
 		min-height: 100%;
 		max-height: calc(100% - 120px);
-		background: var(--maxi-white);
+		background: $w;
 		margin-top: 0;
 		padding: 46px 0 0;
 		overflow: hidden;
@@ -325,7 +307,6 @@ $border-light: 1px solid var(--maxi-grey-light);
 			margin: 0;
 		}
 
-		// Gutenberg adds div without classname that wraps the modal content
 		> div:last-child {
 			height: 100%;
 		}
@@ -344,7 +325,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 				font-size: 1rem;
 			}
 			.components-button {
-				position: absolute;
+				position: $pa;
 				right: 10px;
 				left: auto;
 				top: 10px !important;
@@ -356,19 +337,19 @@ $border-light: 1px solid var(--maxi-grey-light);
 				display: flex;
 				align-items: center;
 				justify-content: center;
-				background-color: var(--maxi-black);
+				background-color: $bk;
 				border-radius: 50%;
-				transition: background-color 0.3s ease, color 0.3s ease;
+				transition: $t;
 				font-size: 14px;
 				font-weight: bold;
-				color: var(--maxi-white);
+				color: $w;
 				text-decoration: none;
-				transition: all 0.4s ease; // Add transition
+				transition: $t; // Add transition
 
 				&::before {
 					content: '×';
 					font-size: 20px;
-					position: relative;
+					position: $pr;
 					left: 0;
 					top: 1px;
 					padding-bottom: 5px; /* Added padding instead of line-height */
@@ -390,20 +371,20 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 	.spinner {
 		display: none; // TEMPORARY
-		position: relative;
+		position: $pr;
 		height: 100px;
 		width: 100px;
 
 		&:before,
 		&:after {
 			content: '';
-			border-left: 6px solid transparent;
+			border-left: 6px solid $tr;
 			border-radius: 50%;
 			bottom: 0;
 			box-sizing: border-box;
 			left: 0;
 			margin: auto;
-			position: absolute;
+			position: $pa;
 			right: 0;
 			top: 0;
 			transform-origin: center center;
@@ -423,7 +404,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 	}
 
 	.maxi-cloud-toolbar {
-		position: absolute;
+		position: $pa;
 		top: 0;
 		display: flex;
 		align-items: center;
@@ -431,8 +412,8 @@ $border-light: 1px solid var(--maxi-grey-light);
 		width: 100%;
 		height: 46px;
 		padding: 7px 43px 5px 14px;
-		background-color: var(--maxi-white);
-		border-bottom: 1px solid var(--maxi-grey-light);
+		background-color: $w;
+		border-bottom: $bl;
 		margin: 0;
 		font-size: 16px;
 		line-height: 1;
@@ -442,7 +423,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 			display: flex;
 			justify-content: center;
 			align-items: center;
-			position: absolute;
+			position: $pa;
 			right: 100px;
 			column-gap: 15px;
 		}
@@ -456,36 +437,36 @@ $border-light: 1px solid var(--maxi-grey-light);
 			align-items: center;
 			justify-content: center;
 			padding: 0;
-			background-color: transparent;
-			color: var(--maxi-cloud-primary);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			background-color: $tr;
+			color: $cp;
+			font-family: $f !important;
 			text-decoration: none;
 			font-size: 14px;
-			cursor: pointer;
-			transition: all 0.4s ease; // Add transition
+			cursor: $ptr;
+			transition: $t; // Add transition
 
 			svg {
 				width: 12px;
 				height: 12px;
 				padding: 2px;
-				background-color: var(--maxi-cloud-primary);
+				background-color: $cp;
 				border-radius: 50%;
 				margin-right: 5px;
-				transition: background-color 0.3s ease;
+				transition: $t;
 
 				path {
-					fill: var(--maxi-cloud-primary);
-					stroke: var(--maxi-white);
-					transition: all 0.4s ease !important;
+					fill: $cp;
+					stroke: $w;
+					transition: $t !important;
 				}
 			}
 
 			&:hover {
-				color: var(--maxi-grey-dark);
+				color: $gd;
 				svg {
-					background-color: var(--maxi-grey-dark);
+					background-color: $gd;
 					path {
-						fill: var(--maxi-grey-dark);
+						fill: $gd;
 					}
 				}
 			}
@@ -493,7 +474,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 		&__logo {
 			display: flex;
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif !important;
+			font-family: $f !important;
 			font-size: 18px;
 			word-spacing: 0;
 			text-decoration: none;
@@ -516,7 +497,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 		height: 100%;
 		margin: 0;
 		overflow: hidden;
-		font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+		font-family: $f;
 
 		.use-placeholder-all-images,
 		.use-sc-styles {
@@ -539,18 +520,18 @@ $border-light: 1px solid var(--maxi-grey-light);
 						height: 20px;
 						display: flex;
 						padding: 2px 0 0 2px;
-						color: var(--maxi-white);
+						color: $w;
 					}
 				}
 
 				&__input[type='checkbox'] {
-					background: var(--maxi-grey-light);
+					background: $gl;
 					padding: 9px !important;
 					border: none;
 				}
 
 				&__input[type='checkbox']:checked {
-					background: var(--maxi-cloud-primary);
+					background: $cp;
 					border: none;
 
 					border-radius: 4px;
@@ -585,26 +566,26 @@ $border-light: 1px solid var(--maxi-grey-light);
 		.ais-InfiniteHits-loadMore,
 		.ais-ClearRefinements-button {
 			padding: 7px;
-			border: 1px solid var(--maxi-cloud-primary-light);
+			border: 1px solid $cpl;
 			border-radius: 30px;
 			margin: 8px;
-			background-color: var(--maxi-cloud-primary-whisper);
-			color: var(--maxi-grey-dark);
+			background-color: $cpw;
+			color: $gd;
 			font-size: 14px;
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+			font-family: $f;
 			font-weight: 400;
-			cursor: pointer;
-			transition: all 0.4s ease; // Add transition
+			cursor: $ptr;
+			transition: $t; // Add transition
 			outline: 0;
 
 			&:not(&--disabled):hover {
 				background-color: var(--maxi-cloud-hover);
-				color: var(--maxi-white);
+				color: $w;
 			}
 
 			&--disabled {
-				background-color: var(--maxi-cloud-primary-whisper);
-				color: var(--maxi-grey-dark);
+				background-color: $cpw;
+				color: $gd;
 				cursor: not-allowed;
 			}
 		}
@@ -618,7 +599,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 			width: 10px;
 			bottom: 0;
 			right: 0;
-			position: absolute;
+			position: $pa;
 		}
 
 		&__preview-iframe {
@@ -629,12 +610,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 		&__preview-iframe_wrap > div {
 			height: 100%;
 			width: 100%;
-			position: relative;
-			background-color: var(--maxi-white);
+			position: $pr;
+			background-color: $w;
 		}
 
 		&__preview-iframe_main-wrap {
-			position: relative;
+			position: $pr;
 			top: 0;
 			width: 100%;
 			height: 100%;
@@ -647,21 +628,21 @@ $border-light: 1px solid var(--maxi-grey-light);
 		}
 
 		&__accordion {
-			background-color: var(--maxi-white);
-			border-top: 1px solid var(--maxi-grey-light);
-			border-bottom: 1px solid var(--maxi-grey-light);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+			background-color: $w;
+			border-top: $bl;
+			border-bottom: $bl;
+			font-family: $f;
 
 			&__title {
-				position: relative;
-				background: var(--maxi-white);
+				position: $pr;
+				background: $w;
 				font-weight: 400;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				border-radius: 0;
 				padding: 10px;
 				box-shadow: none;
 				margin-bottom: 0;
-				cursor: pointer;
+				cursor: $ptr;
 				font-size: 12px;
 
 				&:after {
@@ -671,12 +652,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 					background-repeat: no-repeat;
 					width: 6px;
 					height: 13px;
-					position: absolute;
+					position: $pa;
 					top: 50%;
 					right: 12px;
 					transform: translateY(-50%) rotate(0);
 					transform-origin: center;
-					transition: all 0.4s ease; // Add transition
+					transition: $t; // Add transition
 				}
 			}
 
@@ -699,9 +680,9 @@ $border-light: 1px solid var(--maxi-grey-light);
 						.ais-HierarchicalMenu-link,
 						.ais-Menu-link {
 							text-decoration: none;
-							color: var(--maxi-grey-dark);
+							color: $gd;
 							font-weight: bold;
-							transition: all 0.4s ease; // Add transition
+							transition: $t; // Add transition
 
 							.ais-HierarchicalMenu-count,
 							.ais-Menu-count {
@@ -741,7 +722,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 				grid-column: span 3;
 
 				.top-Menu {
-					position: absolute;
+					position: $pa;
 					left: 230px;
 					width: calc(100% - 230px);
 					margin-top: -38px;
@@ -749,13 +730,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 					.maxi-cloud-container__content-svg-shape__button {
 						width: auto;
-						color: var(--maxi-black);
-						background-color: var(--maxi-white);
-						font-family: 'Inter', Helvetica, Arial, Lucida,
-							sans-serif;
+						color: $bk;
+						background-color: $w;
+						font-family: $f;
 						font-size: 12px;
 						font-weight: normal;
-						border: 1px solid var(--maxi-grey-light);
+						border: $bl;
 						border-radius: 0;
 						text-align: center;
 						height: 31px;
@@ -763,42 +743,42 @@ $border-light: 1px solid var(--maxi-grey-light);
 						padding: 6px 18px;
 						text-decoration: none;
 						box-shadow: none;
-						cursor: pointer;
-						position: relative;
+						cursor: $ptr;
+						position: $pr;
 						z-index: 1;
 
 						&::before {
 							content: '';
 							display: block;
-							position: absolute;
+							position: $pa;
 							left: -1px;
 							right: -1px;
 							top: -1px;
 							bottom: -1px;
-							background-color: var(--maxi-cloud-primary-light);
+							background-color: $cpl;
 							z-index: -1;
-							transition: all 0.4s ease; // Add transition
+							transition: $t; // Add transition
 							opacity: 0;
 							border-radius: inherit; /* Add border radius to match parent */
 						}
 
 						&:after {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: 1;
 							left: -1px;
 							top: -1px;
 							bottom: -1px;
 							width: 1px;
 							display: block;
-							background-color: var(--maxi-white);
+							background-color: $w;
 							opacity: 0;
 						}
 
 						&:hover,
 						&___pressed {
 							font-weight: 700;
-							color: var(--maxi-black);
+							color: $bk;
 
 							&::before {
 								opacity: 1;
@@ -832,13 +812,13 @@ $border-light: 1px solid var(--maxi-grey-light);
 					overflow: hidden;
 
 					.ais-SearchBox-form {
-						position: relative;
+						position: $pr;
 						overflow: hidden;
 
 						.ais-SearchBox-input {
-							color: var(--maxi-grey-dark);
+							color: $gd;
 							font-weight: bold;
-							border: 1px solid var(--maxi-grey-light);
+							border: $bl;
 							border-radius: 0;
 							box-shadow: 0 5px 15px 0 rgba(119, 119, 119, 0.1);
 							padding: 0.3rem 1rem;
@@ -846,32 +826,32 @@ $border-light: 1px solid var(--maxi-grey-light);
 						}
 
 						.ais-SearchBox-loadingIndicator {
-							position: relative;
+							position: $pr;
 							top: 10px;
 						}
 
 						.ais-SearchBox-reset {
-							position: absolute;
+							position: $pa;
 							border: none;
 							background: none;
 							top: 50%;
 							right: 70px;
 							transform: translateY(-50%);
-							cursor: pointer;
+							cursor: $ptr;
 						}
 
 						.ais-SearchBox-submit {
-							position: absolute;
-							background: var(--maxi-grey-dark);
-							color: var(--maxi-white);
+							position: $pa;
+							background: $gd;
+							color: $w;
 							font-weight: bold;
 							border: none;
-							transition: all 0.4s ease; // Add transition
+							transition: $t; // Add transition
 							top: 0;
 							right: 0;
 							height: 100%;
 							padding: 11px 1rem;
-							cursor: pointer;
+							cursor: $ptr;
 
 							&:hover {
 								opacity: 0.8;
@@ -886,7 +866,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 					strong {
 						margin-right: 3px;
-						color: var(--maxi-cloud-primary);
+						color: $cp;
 					}
 				}
 			}
@@ -910,14 +890,13 @@ $border-light: 1px solid var(--maxi-grey-light);
 				grid-template-columns: repeat(10, 1fr);
 
 				.ais-InfiniteHits-item {
-					position: relative;
+					position: $pr;
 					border: none !important;
 					box-shadow: none !important;
-					//pattern card
 					.maxi-cloud-masonry-card {
-						position: relative;
+						position: $pr;
 						z-index: 1;
-						transition: all 0.4s ease; // Add transition
+						transition: $t; // Add transition
 						padding: 12px 12px 20px 12px;
 						height: 100%;
 						overflow: hidden;
@@ -928,42 +907,38 @@ $border-light: 1px solid var(--maxi-grey-light);
 								height: 50px;
 							}
 						}
-						//svg card
 						&__svg-container {
-							position: relative;
+							position: $pr;
 							z-index: 1;
 							display: flex;
 							align-items: center;
 							flex-direction: column;
-							cursor: pointer;
-							transition: all 0.4s ease !important;
+							cursor: $ptr;
+							transition: $t !important;
 							transform: translateY(19px);
 
 							&__title {
-								font-family: 'Inter', Helvetica, Arial, Lucida,
-									sans-serif;
+								font-family: $f;
 								font-weight: 800;
 								text-align: center;
 								font-size: 12px;
 								margin-bottom: 4px;
-								transition: all 0.4s ease; // Add transition
+								transition: $t; // Add transition
 							}
 
 							&__code {
-								background-color: transparent !important;
+								background-color: $tr !important;
 								text-align: center;
 								width: 64px;
 								margin-bottom: 12px;
 							}
 
-							//span to show button on hover
-
 							&:hover {
 								span {
 									opacity: 1;
-									transition: all 0.4s ease !important;
-									color: var(--maxi-white);
-									background-color: var(--maxi-black);
+									transition: $t !important;
+									color: $w;
+									background-color: $bk;
 
 									&::before {
 										opacity: 1;
@@ -971,25 +946,24 @@ $border-light: 1px solid var(--maxi-grey-light);
 								}
 							}
 							span {
-								position: relative;
-								border: 1.5px solid var(--maxi-black);
+								position: $pr;
+								border: 1.5px solid $bk;
 								border-radius: 20px;
-								color: var(--maxi-grey-dark);
-								font-family: 'Inter', Helvetica, Arial, Lucida,
-									sans-serif;
+								color: $gd;
+								font-family: $f;
 								font-weight: 600;
 								line-height: 100%;
 								padding: 8px 35px;
-								transition: all 0.4s ease !important;
+								transition: $t !important;
 								opacity: 0;
 								margin-top: -5px;
 								margin-bottom: -5px;
 
 								&:before {
 									content: '';
-									position: absolute;
+									position: $pa;
 									display: block;
-									transition: all 0.4s ease; // Add transition
+									transition: $t; // Add transition
 									opacity: 0;
 									top: 0;
 									left: 0;
@@ -999,11 +973,11 @@ $border-light: 1px solid var(--maxi-grey-light);
 								}
 
 								&:hover {
-									transition: all 0.4s ease; // Add transition
-									color: var(--maxi-white);
-									background-color: var(--maxi-black);
+									transition: $t; // Add transition
+									color: $w;
+									background-color: $bk;
 									opacity: 1;
-									transition: all 0.4s ease !important;
+									transition: $t !important;
 									&::before {
 										opacity: 1;
 									}
@@ -1015,21 +989,21 @@ $border-light: 1px solid var(--maxi-grey-light);
 							g[data-stroke],
 							path[data-stroke],
 							svg[data-stroke] {
-								stroke: var(--maxi-black);
+								stroke: $bk;
 							}
 						}
 					}
 
 					&:after {
 						content: '';
-						position: absolute;
+						position: $pa;
 						left: 0;
 						right: 0;
 						top: 0;
 						bottom: 0;
 						display: block;
-						border: 1px solid var(--maxi-grey-light);
-						transition: all 0.4s ease; // Add transition
+						border: $bl;
+						transition: $t; // Add transition
 						z-index: 0;
 						border-radius: 10px;
 					}
@@ -1046,16 +1020,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 								}
 
 								span {
-									transition: all 0.4s ease; // Add transition
+									transition: $t; // Add transition
 								}
 							}
 						}
-						//hidden icon hover
 						&::after {
 							background-color: var(--maxi-off-white);
-							border-color: var(--maxi-cloud-primary-light);
+							border-color: $cpl;
 							box-shadow: 0 0 0 1px
-								var(--maxi-cloud-primary-light);
+								$cpl;
 							transform: scale(1.03);
 						}
 					}
@@ -1085,15 +1058,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 				}
 
 				&::-webkit-scrollbar-track {
-					background: var(--maxi-white);
+					background: $w;
 				}
 
 				&::-webkit-scrollbar-thumb {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 
 				&::-webkit-scrollbar-thumb:hover {
-					background: var(--maxi-grey-light);
+					background: $gl;
 				}
 			}
 		}
@@ -1111,7 +1084,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 			.maxi-cloud-container__preview-tablet__label,
 			.maxi-cloud-container__preview-mobile__label {
-				position: absolute;
+				position: $pa;
 				z-index: 1000;
 				top: 25px;
 				left: 0;
@@ -1119,7 +1092,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 				max-width: 400px;
 				border-radius: 5px;
 				margin: 0 auto;
-				color: var(--maxi-white);
+				color: $w;
 				background: var(--maxi-cloud-iframe-border);
 				font-size: 15px;
 				text-align: center;
@@ -1128,7 +1101,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 			.maxi-cloud-container__patterns__top-menu {
 				display: flex;
 				grid-column: span 3;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 				& > div {
 					&:not(.ais-Menu) {
 						width: 230px;
@@ -1138,31 +1111,30 @@ $border-light: 1px solid var(--maxi-grey-light);
 			}
 
 			&__sidebar {
-				border-right: 1px solid var(--maxi-grey-light);
-				border-left: 1px solid var(--maxi-grey-light);
-				background-color: var(--maxi-white);
-				transition: transform 0.3s ease;
+				border-right: $bl;
+				border-left: $bl;
+				background-color: $w;
+				transition: $t;
 				.top-Menu {
 					display: flex;
 					margin-bottom: 8px;
 					.maxi-cloud-container__content-svg-shape__button {
-						position: relative;
+						position: $pr;
 						z-index: 1;
 						width: 100%;
 						height: 31px;
 						padding: 6px 18px;
 						border: none;
-						border-bottom: 1px solid var(--maxi-grey-light);
-						border-right: 1px solid var(--maxi-grey-light);
+						border-bottom: $bl;
+						border-right: $bl;
 						border-radius: 0;
 						margin-right: 0;
-						color: var(--maxi-grey-dark);
-						background-color: transparent;
-						font-family: 'Inter', Helvetica, Arial, Lucida,
-							sans-serif;
+						color: $gd;
+						background-color: $tr;
+						font-family: $f;
 						font-size: 12px;
 						font-weight: normal;
-						cursor: pointer;
+						cursor: $ptr;
 						outline: 0;
 						&:last-child {
 							margin-right: 0;
@@ -1173,27 +1145,27 @@ $border-light: 1px solid var(--maxi-grey-light);
 						}
 						&::before {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: -1;
 							left: -1px;
 							right: -1px;
 							top: -1px;
 							bottom: -1px;
 							display: block;
-							background-color: var(--maxi-cloud-primary-light);
-							transition: all 0.4s ease !important;
+							background-color: $cpl;
+							transition: $t !important;
 							opacity: 0;
 						}
 						&:after {
 							content: '';
-							position: absolute;
+							position: $pa;
 							z-index: 1;
 							left: -1px;
 							top: -1px;
 							bottom: -1px;
 							display: block;
 							width: 1px;
-							background-color: var(--maxi-white);
+							background-color: $w;
 							opacity: 0;
 						}
 						&:first-child {
@@ -1202,7 +1174,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 							}
 						}
 						&___pressed {
-							color: var(--maxi-black);
+							color: $bk;
 							font-weight: 700;
 							border-bottom: 1px solid;
 							&::after {
@@ -1214,19 +1186,19 @@ $border-light: 1px solid var(--maxi-grey-light);
 						}
 						&___inactive {
 							pointer-events: none !important;
-							color: var(--maxi-grey-light);
+							color: $gl;
 							&:after {
 								top: 50%;
 								left: 50%;
 								width: 109%;
 								height: 1px;
-								background-color: var(--maxi-grey-light);
+								background-color: $gl;
 								transform: translate(-50%, -50%) rotate(-21deg);
 								opacity: 1;
 							}
 						}
 						&:hover {
-							color: var(--maxi-black);
+							color: $bk;
 							&::before {
 								opacity: 1;
 							}
@@ -1243,28 +1215,28 @@ $border-light: 1px solid var(--maxi-grey-light);
 					.ais-SearchBox-form {
 						width: auto;
 						margin: 8px 8px;
-						position: relative;
+						position: $pr;
 
 						.ais-SearchBox-submit {
 							display: none;
 						}
 						.ais-SearchBox-reset {
-							position: absolute;
+							position: $pa;
 							top: 50%;
 							right: 5px;
 							display: block;
 							padding: 2px 6px;
 							border: none;
-							color: var(--maxi-grey-dark);
-							background-color: var(--maxi-white) !important;
+							color: $gd;
+							background-color: $w !important;
 							background: none;
 							font-size: 18px;
 							font-weight: 500;
 							transform: translateY(-50%);
-							cursor: pointer;
+							cursor: $ptr;
 							outline: 0;
 							&:hover {
-								color: var(--maxi-cloud-primary);
+								color: $cp;
 							}
 						}
 						.ais-SearchBox-input {
@@ -1272,17 +1244,16 @@ $border-light: 1px solid var(--maxi-grey-light);
 							width: 100%;
 							min-height: 36px;
 							padding: 5px 10px;
-							border: 1px solid var(--maxi-grey-light);
+							border: $bl;
 							border-radius: 20px;
-							background: var(--maxi-white);
-							color: var(--maxi-grey-dark);
-							font-family: 'Inter', Helvetica, Arial, Lucida,
-								sans-serif;
+							background: $w;
+							color: $gd;
+							font-family: $f;
 							font-size: 12px;
 							transition: all 0.5s;
 							&:hover,
 							&:focus {
-								border-color: var(--maxi-cloud-primary-light);
+								border-color: $cpl;
 								box-shadow: none;
 								outline: none;
 							}
@@ -1290,12 +1261,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 					}
 				}
 				.components-checkbox-control {
-					font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+					font-family: $f;
 					font-size: 11px;
 					font-weight: 400;
 					&__input {
 						border-radius: 0;
-						border-color: var(--maxi-grey-light);
+						border-color: $gl;
 						margin: 0;
 					}
 					&__input-container {
@@ -1316,14 +1287,14 @@ $border-light: 1px solid var(--maxi-grey-light);
 						box-shadow: none;
 					}
 					&__label {
-						color: var(--maxi-grey-dark);
+						color: $gd;
 						margin-top: -1px;
 						margin-bottom: 5px;
 					}
 					.components-base-control__help {
 						margin: 0 8px 8px;
 						font-size: 12px;
-						color: var(--maxi-grey-dark);
+						color: $gd;
 					}
 					&.use-placeholder-all-images,
 					&.use-sc-styles {
@@ -1341,12 +1312,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 					margin: 0;
 					padding: 0;
 					align-items: center;
-					transition: all 0.4s ease !important; // Added transition here
+					transition: $t !important; // Added transition here
 
 					&--selected {
 						a {
-							background-color: var(--maxi-cloud-primary-whisper);
-							color: var(--maxi-white);
+							background-color: $cpw;
+							color: $w;
 						}
 					}
 					a {
@@ -1355,24 +1326,23 @@ $border-light: 1px solid var(--maxi-grey-light);
 						padding-top: 3px;
 						padding: 8px;
 						box-shadow: none;
-						color: var(--maxi-grey-dark);
-						font-family: 'Inter', Helvetica, Arial, Lucida,
-							sans-serif;
+						color: $gd;
+						font-family: $f;
 						font-weight: 500;
 						font-size: 13px;
-						transition: all 0.4s ease !important;
+						transition: $t !important;
 						text-decoration: none;
 						outline: none;
 
 						&:focus {
 							box-shadow: inset 0 0 0 1px
-								var(--maxi-cloud-primary-light);
+								$cpl;
 						}
 
 						&:hover {
-							background-color: var(--maxi-cloud-primary-whisper);
+							background-color: $cpw;
 							box-shadow: none;
-							transition: all 0.4s ease !important;
+							transition: $t !important;
 						}
 						.ais-RefinementList-checkbox {
 							display: none;
@@ -1389,7 +1359,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 							&.ais-HierarchicalMenu-item-arrow {
 								display: inline-block;
 								margin-left: -15.78px;
-								transition: all 0.4s ease !important;
+								transition: $t !important;
 								opacity: 0;
 							}
 							&[visible='visible'] {
@@ -1418,12 +1388,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 							}
 							a {
 								&:hover {
-									background-color: var(--maxi-white);
+									background-color: $w;
 								}
 							}
 							&--selected {
 								a {
-									background-color: var(--maxi-white);
+									background-color: $w;
 
 									&:hover {
 										background-color: var(
@@ -1436,10 +1406,10 @@ $border-light: 1px solid var(--maxi-grey-light);
 					}
 					& > ul {
 						clear: both;
-						background-color: var(--maxi-white);
+						background-color: $w;
 						margin: 8px -6px 0;
 						padding: 8px 6px 0;
-						border-top: 1px solid var(--maxi-grey-light);
+						border-top: $bl;
 						.ais-HierarchicalMenu-item {
 							border: none;
 							padding: 0;
@@ -1451,7 +1421,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 					}
 					& > ul {
 						clear: both;
-						background-color: var(--maxi-grey-light);
+						background-color: $gl;
 						margin: 0;
 						padding: 0;
 						border-top: 0;
@@ -1459,7 +1429,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 							border: none;
 							padding: 0;
 							margin-bottom: 0;
-							position: relative;
+							position: $pr;
 							& > a {
 								padding: 4px 15px !important;
 							}
@@ -1471,7 +1441,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 					.sub_menu-wrapper {
 						transform: scaleY(0);
 						transform-origin: top center;
-						transition: all 0.4s ease !important;
+						transition: $t !important;
 					}
 					&--selected {
 						.sub_menu-wrapper {
@@ -1480,12 +1450,11 @@ $border-light: 1px solid var(--maxi-grey-light);
 						a {
 							&:focus {
 								box-shadow: inset 0 0 0 1px
-									var(--maxi-cloud-primary-light);
+									$cpl;
 							}
 						}
 					}
 				}
-				//hack to fix issue #3930: top level tags resetting when we choose a second-level tag
 				ul.maxi__hide-top-tags
 					li.ais-HierarchicalMenu-item__firstLevel:not(.maxi__show-top-tag) {
 					display: none;
@@ -1499,19 +1468,18 @@ $border-light: 1px solid var(--maxi-grey-light);
 					}
 					&-item {
 						display: flex;
-						position: relative;
+						position: $pr;
 						flex-direction: column;
 						width: 100%;
 						margin-bottom: 0;
 						margin-top: -1px;
 						a {
-							color: var(--maxi-black);
-							background-color: var(--maxi-cloud-primary-whisper);
-							font-family: 'Inter', Helvetica, Arial, Lucida,
-								sans-serif;
+							color: $bk;
+							background-color: $cpw;
+							font-family: $f;
 							font-size: 12px;
 							font-weight: normal;
-							border: 1px solid transparent;
+							border: 1px solid $tr;
 							border-radius: 5px;
 							text-align: center;
 							width: 100%;
@@ -1519,14 +1487,14 @@ $border-light: 1px solid var(--maxi-grey-light);
 							padding: 6px 8px;
 							text-decoration: none;
 							box-shadow: none;
-							position: relative;
+							position: $pr;
 							z-index: 1;
-							transition: all 0.4s ease !important;
+							transition: $t !important;
 							&:hover {
 								background-color: var(
 									--maxi-cloud-primary-light
 								);
-								transition: all 0.4s ease !important;
+								transition: $t !important;
 							}
 						}
 						&--selected {
@@ -1542,33 +1510,32 @@ $border-light: 1px solid var(--maxi-grey-light);
 			}
 			&__top-menu {
 				.ais-Menu {
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 					&-list {
 						display: flex;
 						margin: 0;
 					}
 					&-item {
 						display: flex;
-						position: relative;
+						position: $pr;
 						flex-direction: column;
 						width: 100%;
 						margin-bottom: 0;
 						margin-top: -1px;
 						a {
-							position: relative;
+							position: $pr;
 							z-index: 1;
 							width: 100%;
 							height: 31px;
 							padding: 6px 8px;
-							border-bottom: 1px solid var(--maxi-grey-light);
-							border-top: 1px solid var(--maxi-grey-light);
-							border-right: 1px solid var(--maxi-grey-light);
+							border-bottom: $bl;
+							border-top: $bl;
+							border-right: $bl;
 							border-radius: 0;
 							box-shadow: none;
-							color: var(--maxi-black);
-							background-color: var(--maxi-white);
-							font-family: 'Inter', Helvetica, Arial, Lucida,
-								sans-serif;
+							color: $bk;
+							background-color: $w;
+							font-family: $f;
 							font-size: 12px;
 							font-weight: normal;
 							text-align: center;
@@ -1577,7 +1544,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 							&:before {
 								content: '';
 								display: block;
-								position: absolute;
+								position: $pa;
 								left: -1px;
 								right: -1px;
 								top: -1px;
@@ -1586,25 +1553,25 @@ $border-light: 1px solid var(--maxi-grey-light);
 									--maxi-cloud-primary-light
 								);
 								z-index: -1;
-								transition: all 0.4s ease !important;
+								transition: $t !important;
 								opacity: 0;
 								border-radius: inherit; /* Inherit border radius from parent */
 							}
 							&:after {
 								content: '';
-								position: absolute;
+								position: $pa;
 								z-index: 1;
 								left: -1px;
 								top: -1px;
 								bottom: -1px;
 								width: 1px;
 								display: block;
-								background-color: var(--maxi-white);
+								background-color: $w;
 								opacity: 0;
 							}
 							&:hover {
-								color: var(--maxi-black);
-								transition: all 0.4s ease !important;
+								color: $bk;
+								transition: $t !important;
 								&::before {
 									opacity: 1;
 								}
@@ -1632,7 +1599,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 						&--selected {
 							a {
 								font-weight: 700;
-								color: var(--maxi-black);
+								color: $bk;
 
 								&::before {
 									opacity: 1;
@@ -1646,16 +1613,16 @@ $border-light: 1px solid var(--maxi-grey-light);
 				}
 			}
 			.ais-InfiniteHits-list {
-				position: relative;
+				position: $pr;
 				grid-template-columns: repeat(3, 1fr);
 				margin-top: 0;
 
 				.ais-InfiniteHits-item {
-					background: var(--maxi-white);
-					border: 1px solid var(--maxi-grey-light);
+					background: $w;
+					border: $bl;
 					padding: 0;
-					cursor: pointer;
-					transition: transform 0.3s ease, box-shadow 0.3s ease;
+					cursor: $ptr;
+					transition: $t;
 					animation: 1s ease-out 0s 1 fadeIn;
 					border-radius: 8px;
 
@@ -1668,14 +1635,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 						}
 						&__patterns {
 							padding: 10px;
-							//button for patterns preview and go pro base
 							.maxi-cloud-masonry-card__button {
-								font-family: 'Inter', Helvetica, Arial, Lucida,
-									sans-serif;
+								font-family: $f;
 								font-weight: 600;
 								margin-right: 0;
-								border: 1px solid var(--maxi-grey-light);
-								color: var(--maxi-grey-dark);
+								border: $bl;
+								color: $gd;
 								border-radius: 30px;
 								min-width: 90px;
 								padding: 5px 10px;
@@ -1683,22 +1648,21 @@ $border-light: 1px solid var(--maxi-grey-light);
 								display: flex !important;
 								justify-content: center !important;
 								align-items: center !important;
-								transition: all 0.3s ease; // Add transition
+								transition: $t; // Add transition
 
 								&:hover {
 									background-color: var(
 										--maxi-cloud-primary-light
 									);
 									border: 1px solid
-										var(--maxi-cloud-primary-light);
-									color: var(--maxi-black);
-									transition: all 0.4s ease !important;
+										$cpl;
+									color: $bk;
+									transition: $t !important;
 								}
 							}
 						}
 						/* Common button styles for both buttons */
 
-						// aligmnent of the patterns 2 buttons
 						&__buttons {
 							display: flex;
 							align-items: center;
@@ -1710,12 +1674,11 @@ $border-light: 1px solid var(--maxi-grey-light);
 						}
 					}
 
-					//Button hover on card
 					&:hover {
-						box-shadow: 0 0 0 1px var(--maxi-cloud-primary-light);
+						box-shadow: 0 0 0 1px $cpl;
 						.maxi-cloud-masonry-card__button {
 							box-shadow: 0 0 0 1px
-								var(--maxi-cloud-primary-light);
+								$cpl;
 						}
 					}
 				}
@@ -1725,11 +1688,10 @@ $border-light: 1px solid var(--maxi-grey-light);
 			.ais-InfiniteHits-list {
 				.ais-InfiniteHits-item {
 					.maxi-cloud-masonry-card {
-						// Add button styles for SC content section
 						&__button {
 							margin-right: 0;
-							border: 1px solid var(--maxi-grey-light);
-							color: var(--maxi-grey-dark);
+							border: $bl;
+							color: $gd;
 							font-weight: bold;
 							border-radius: 30px;
 							min-width: 90px;
@@ -1738,20 +1700,19 @@ $border-light: 1px solid var(--maxi-grey-light);
 							display: flex !important;
 							justify-content: center !important;
 							align-items: center !important;
-							transition: all 0.4s ease;
+							transition: $t;
 
 							&:hover {
 								background-color: var(
 									--maxi-cloud-primary-light
 								);
 								border: 1px solid
-									var(--maxi-cloud-primary-light);
-								color: var(--maxi-black);
-								transition: all 0.4s ease !important;
+									$cpl;
+								color: $bk;
+								transition: $t !important;
 							}
 						}
 
-						// Add button container styles if needed
 						&__buttons {
 							display: flex;
 							align-items: center;
@@ -1777,9 +1738,9 @@ $border-light: 1px solid var(--maxi-grey-light);
 			&__sidebar {
 				.ais-RefinementList-item,
 				.ais-HierarchicalMenu-item {
-					border-bottom: 1px solid var(--maxi-grey-light);
+					border-bottom: $bl;
 					&:first-child {
-						border-top: 1px solid var(--maxi-grey-light);
+						border-top: $bl;
 					}
 					.maxi-toggle-switch {
 						margin-bottom: 8px;
@@ -1804,7 +1765,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 		&__svg-shape,
 		&__svg-icon {
 			.ais-InfiniteHits-list {
-				position: relative;
+				position: $pr;
 				grid-template-columns: repeat(8, 1fr);
 			}
 		}
@@ -1812,10 +1773,10 @@ $border-light: 1px solid var(--maxi-grey-light);
 			.ais-InfiniteHits-list {
 				.ais-InfiniteHits-item {
 					/* Card base styles */
-					background: var(--maxi-white);
+					background: $w;
 					border-radius: 10px;
 					overflow: hidden;
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 
 					/* Pro version card style */
 					&-pro {
@@ -1825,13 +1786,13 @@ $border-light: 1px solid var(--maxi-grey-light);
 					/* Card hover state */
 					&:hover {
 						background: var(--maxi-off-white) !important;
-						transition: all 0.4s ease !important;
+						transition: $t !important;
 					}
 				}
 				.maxi-cloud-masonry-card__image {
 					padding: 0;
-					background: var(--maxi-white);
-					border: 1px solid var(--maxi-grey-light);
+					background: $w;
+					border: $bl;
 				}
 			}
 			&__content-patterns {
@@ -1847,7 +1808,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 			height: 10px;
 			.ais-Menu {
 				display: block;
-				position: absolute;
+				position: $pa;
 				left: 230px;
 				max-width: 450px;
 				margin-top: -38px;
@@ -1861,12 +1822,12 @@ $border-light: 1px solid var(--maxi-grey-light);
 					}
 					&:first-child {
 						a {
-							border-left: 1px solid var(--maxi-grey-light);
+							border-left: $bl;
 						}
 					}
 					&:last-child {
 						a {
-							border-right: 1px solid var(--maxi-grey-light);
+							border-right: $bl;
 						}
 					}
 				}
@@ -1877,18 +1838,18 @@ $border-light: 1px solid var(--maxi-grey-light);
 				height: 31px;
 				padding: 6px 18px;
 				border-radius: 30px;
-				background-color: var(--maxi-cloud-primary-whisper);
-				color: var(--maxi-grey-dark);
-				border: 1px solid var(--maxi-cloud-primary);
+				background-color: $cpw;
+				color: $gd;
+				border: 1px solid $cp;
 				z-index: 100000;
 				line-height: 100%;
-				transition: all 0.3s ease;
+				transition: $t;
 
 				&:hover {
-					background-color: var(--maxi-cloud-primary);
-					color: var(--maxi-black);
-					border-color: var(--maxi-cloud-primary);
-					transition: all 0.4s ease !important;
+					background-color: $cp;
+					color: $bk;
+					border-color: $cp;
+					transition: $t !important;
 				}
 			}
 			&__button-connect-pro {
@@ -1897,14 +1858,14 @@ $border-light: 1px solid var(--maxi-grey-light);
 			&__text_pro {
 				margin: 0;
 				.maxi-username:hover {
-					cursor: pointer;
+					cursor: $ptr;
 				}
 				.maxi-network-license-notice {
 					a {
-						color: var(--maxi-cloud-primary);
-						transition: all 0.4s ease;
+						color: $cp;
+						transition: $t;
 						&:hover {
-							color: var(--maxi-grey-dark);
+							color: $gd;
 						}
 					}
 				}
@@ -1916,23 +1877,23 @@ $border-light: 1px solid var(--maxi-grey-light);
 					margin-top: 10px;
 					margin-right: -15px;
 					padding: 1px 20px 2px 8px !important;
-					border: 1px solid var(--maxi-grey-light) !important;
+					border: $bl !important;
 					border-radius: 0 !important;
 					border-top-left-radius: 30px !important;
 					border-bottom-left-radius: 30px !important;
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 					&:focus,
 					&:active,
 					&:hover {
-						border-color: var(--maxi-cloud-primary) !important;
+						border-color: $cp !important;
 					}
 				}
 				span {
-					position: absolute;
+					position: $pa;
 					bottom: -14px;
 					padding: 5px;
 					color: #f2a600;
-					background: var(--maxi-white);
+					background: $w;
 					font-style: italic;
 					font-size: 12px;
 				}
@@ -1948,8 +1909,8 @@ $border-light: 1px solid var(--maxi-grey-light);
 
 	.ais-InfiniteHits-item {
 		margin: 0 0 0.6rem;
-		background-color: var(--maxi-white);
-		position: relative;
+		background-color: $w;
+		position: $pr;
 		border-radius: 8px;
 
 		.maxi-cloud-masonry-card {
@@ -1970,7 +1931,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 					align-items: center;
 					margin-bottom: 8px;
 					.maxi-cloud-masonry__serial-tag {
-						color: var(--maxi-grey-dark);
+						color: $gd;
 						font-weight: 700;
 						font-size: 14px;
 					}
@@ -1986,15 +1947,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 			&__tags {
 				display: flex;
 				justify-content: space-between;
-				position: absolute;
+				position: $pa;
 				top: 6px;
 				right: 8px;
 
 				&__tag {
-					position: relative;
+					position: $pr;
 					display: inline-block;
 					padding: 0;
-					color: var(--maxi-grey-dark);
+					color: $gd;
 					font-size: 14px;
 					font-weight: bold;
 					text-transform: capitalize;
@@ -2032,15 +1993,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 			}
 
 			&::-webkit-scrollbar-track {
-				background: var(--maxi-white);
+				background: $w;
 			}
 
 			&::-webkit-scrollbar-thumb {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 
 			&::-webkit-scrollbar-thumb:hover {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 		}
 	}
@@ -2066,15 +2027,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 			}
 
 			&::-webkit-scrollbar-track {
-				background: var(--maxi-white);
+				background: $w;
 			}
 
 			&::-webkit-scrollbar-thumb {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 
 			&::-webkit-scrollbar-thumb:hover {
-				background: var(--maxi-grey-light);
+				background: $gl;
 			}
 		}
 	}
@@ -2090,15 +2051,15 @@ $border-light: 1px solid var(--maxi-grey-light);
 		margin: 0;
 		.ais-Stats {
 			margin-bottom: 0;
-			border-bottom: 1px solid var(--maxi-grey-light);
+			border-bottom: $bl;
 		}
 		.ais-Stats-text {
-			color: var(--maxi-grey-dark);
-			font-family: 'Inter', Helvetica, Arial, Lucida, sans-serif;
+			color: $gd;
+			font-family: $f;
 			font-weight: 500;
 			font-size: 12px;
 			strong {
-				color: var(--maxi-cloud-primary);
+				color: $cp;
 			}
 		}
 	}
@@ -2472,7 +2433,7 @@ $border-light: 1px solid var(--maxi-grey-light);
 				display: block !important;
 				height: auto;
 				margin: 0;
-				border-bottom: 1px solid var(--maxi-grey-light);
+				border-bottom: $bl;
 			}
 			&__patterns {
 				&__top-menu {
@@ -2701,7 +2662,7 @@ html[dir='rtl'] {
 		transform: scaleX(-1);
 	}
 	.maxi-responsive-selector .action-buttons__button.style-card-button {
-		border-left: 1px solid var(--maxi-grey-light);
+		border-left: $bl;
 	}
 	.maxi-responsive-selector .action-buttons__help {
 		margin-left: 0;
@@ -2750,7 +2711,7 @@ html[dir='rtl'] {
 		}
 	}
 	.maxi-style-card-settings .maxi-tabs-control__button:first-child {
-		border-right: 1px solid var(--maxi-grey-light) !important;
+		border-right: $bl !important;
 	}
 	.maxi-style-cards__quick-color-presets__reset {
 		left: 8px;
@@ -2779,11 +2740,10 @@ html[dir='rtl'] {
 		.ais-InfiniteHits-list {
 			.ais-InfiniteHits-item {
 				.maxi-cloud-masonry-card {
-					// Add button styles for SC content section
 					&__button {
 						margin-right: 0;
-						border: 1px solid var(--maxi-grey-light);
-						color: var(--maxi-grey-dark);
+						border: $bl;
+						color: $gd;
 						font-weight: bold;
 						border-radius: 30px;
 						min-width: 90px;
@@ -2792,16 +2752,15 @@ html[dir='rtl'] {
 						display: flex !important;
 						justify-content: center !important;
 						align-items: center !important;
-						transition: all 0.3s ease;
+						transition: $t;
 
 						&:hover {
-							background-color: var(--maxi-cloud-primary);
-							border: 1px solid var(--maxi-cloud-primary);
-							color: var(--maxi-white);
+							background-color: $cp;
+							border: 1px solid $cp;
+							color: $w;
 						}
 					}
 
-					// Add button container styles if needed
 					&__buttons {
 						display: flex;
 						align-items: center;
@@ -2828,32 +2787,32 @@ html[dir='rtl'] {
 			a {
 				&:before {
 					content: '';
-					position: absolute;
+					position: $pa;
 					left: -1px;
 					right: -1px;
 					top: -1px;
 					bottom: -1px;
 					display: block;
-					background-color: var(--maxi-cloud-primary-light);
+					background-color: $cpl;
 					z-index: -1;
-					transition: all 0.4s ease !important;
+					transition: $t !important;
 					opacity: 0;
 				}
 				&:after {
 					content: '';
-					position: absolute;
+					position: $pa;
 					z-index: 1;
 					left: -1px;
 					top: -1px;
 					bottom: -1px;
 					width: 1px;
 					display: block;
-					background-color: var(--maxi-white);
+					background-color: $w;
 					opacity: 0;
 				}
 				&:hover {
-					color: var(--maxi-black);
-					transition: all 0.4s ease !important;
+					color: $bk;
+					transition: $t !important;
 					&::before {
 						opacity: 1;
 					}
@@ -2871,15 +2830,13 @@ html[dir='rtl'] {
 		&__sidebar {
 			.ais-RefinementList-item,
 			.ais-HierarchicalMenu-item {
-				// Add transition for background hover
-				transition: all 0.4s ease !important;
+				transition: $t !important;
 
 				a {
-					// Existing styles...
 					&:hover {
-						background-color: var(--maxi-cloud-primary-whisper);
+						background-color: $cpw;
 						box-shadow: none;
-						transition: all 0.4s ease !important;
+						transition: $t !important;
 					}
 				}
 			}

--- a/src/editor/library/editor.scss
+++ b/src/editor/library/editor.scss
@@ -1,34 +1,5 @@
 @import '../../../src/css/backend-variables.scss';
 
-@mixin scrollbar($width: 5px, $track: $w, $thumb: $gl) {
-	&::-webkit-scrollbar {
-		width: $width;
-	}
-
-	&::-webkit-scrollbar-track {
-		background: $track;
-	}
-
-	&::-webkit-scrollbar-thumb {
-		background: $thumb;
-	}
-
-	&::-webkit-scrollbar-thumb:hover {
-		background: $thumb;
-	}
-}
-
-@mixin flex-center($important: false) {
-	@if $important {
-		display: flex !important;
-		align-items: center !important;
-		justify-content: center !important;
-	} @else {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-}
 
 .maxi-library-modal {
 	width: 85%;

--- a/src/editor/responsive-selector/editor.scss
+++ b/src/editor/responsive-selector/editor.scss
@@ -1,8 +1,9 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-responsive-selector {
-	position: absolute;
+	position: $pa;
 	display: flex;
-	background: var(--maxi-white);
-	border-color: var(--maxi-grey-light);
+	background: $w;
+	border-color: $gl;
 	border-style: solid;
 	border-width: 1px;
 	top: 60px;
@@ -22,13 +23,13 @@
 	.action-buttons {
 		display: inline-block;
 		&__button {
-			position: relative;
-			color: var(--maxi-grey-dark);
-			background-color: var(--maxi-white);
+			position: $pr;
+			color: $gd;
+			background-color: $w;
 			font-family: Inter, sans-serif;
 			font-size: 12px;
 			letter-spacing: 0px;
-			border-right: 1px solid var(--maxi-grey-light);
+			border-right: $bl;
 			border-radius: 0;
 			transition: all 0.5s;
 			margin-left: 0;
@@ -43,9 +44,9 @@
 			}
 			&::after {
 				content: '';
-				position: absolute;
+				position: $pa;
 				display: block;
-				background-color: transparent;
+				background-color: $tr;
 				transition: 0.3s;
 				bottom: -1px;
 				left: 0;
@@ -53,14 +54,14 @@
 				height: 2px;
 			}
 			&:hover {
-				background-color: var(--maxi-pastel-green);
-				color: var(--maxi-grey-dark);
+				background-color: $pg;
+				color: $gd;
 			}
 		}
 		&__help {
-			position: relative;
+			position: $pr;
 			display: flex;
-			color: var(--maxi-grey-dark);
+			color: $gd;
 			font-family: Inter, sans-serif;
 			font-size: 12px;
 			line-height: 100%;
@@ -74,13 +75,13 @@
 			justify-content: center;
 			align-items: center;
 			box-shadow: none;
-			border-right: 1px solid var(--maxi-grey-light);
+			border-right: $bl;
 
 			&::after {
 				content: '';
-				position: absolute;
+				position: $pa;
 				display: block;
-				background-color: transparent;
+				background-color: $tr;
 				transition: 0.3s;
 				bottom: -1px;
 				left: 0;
@@ -88,10 +89,10 @@
 				height: 2px;
 			}
 			&:hover {
-				background-color: var(--maxi-white);
+				background-color: $w;
 
 				&::after {
-					background-color: var(--maxi-grey-dark);
+					background-color: $gd;
 				}
 			}
 			svg {
@@ -103,11 +104,11 @@
 		}
 	}
 	&__close {
-		position: absolute;
+		position: $pa;
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		cursor: pointer;
+		cursor: $ptr;
 		z-index: 99;
 		padding: 0 7px 0 9px;
 		right: 0;
@@ -115,9 +116,9 @@
 
 		&::after {
 			content: '';
-			position: absolute;
+			position: $pa;
 			display: block;
-			background-color: transparent;
+			background-color: $tr;
 			transition: 0.3s;
 			bottom: -1px;
 			left: 0;
@@ -130,18 +131,18 @@
 			}
 		}
 		&:hover {
-			background-color: var(--maxi-white);
+			background-color: $w;
 			&::after {
-				background-color: var(--maxi-grey-dark);
+				background-color: $gd;
 			}
 		}
 	}
 	&__button {
 		&-item {
-			position: relative;
+			position: $pr;
 			display: flex;
 			line-height: 100%;
-			border-right: 1px solid var(--maxi-grey-light);
+			border-right: $bl;
 			border-radius: 0;
 			transition: border-color 0.5s;
 			margin: 0;
@@ -155,7 +156,7 @@
 				opacity: 0;
 				transition: all 0.2s;
 				font-weight: bold !important;
-				position: absolute;
+				position: $pa;
 				height: 100%;
 				width: 100%;
 				display: flex;
@@ -171,9 +172,9 @@
 				transition: all 0.2s;
 			}
 			&:hover {
-				color: var(--maxi-black);
+				color: $bk;
 				font-weight: bold !important;
-				background-color: var(--maxi-pastel-green) !important;
+				background-color: $pg !important;
 
 				.maxi-responsive-selector__button-current-size,
 				svg {
@@ -190,9 +191,9 @@
 
 			&::after {
 				content: '';
-				position: absolute;
+				position: $pa;
 				display: block;
-				background-color: transparent;
+				background-color: $tr;
 				transition: 0.3s;
 				bottom: -1px;
 				left: 0;
@@ -201,33 +202,33 @@
 				height: 2px;
 			}
 			&[aria-pressed='true'] {
-				background-color: var(--maxi-whisper-green) !important;
+				background-color: $wg !important;
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
 				&::after {
 					height: 0px;
-					background-color: var(--maxi-secondary-color);
+					background-color: $sc;
 				}
 				svg {
 					&:not(.maxi-tabs-control__notification) {
-						color: var(--maxi-secondary-color);
+						color: $sc;
 					}
 				}
 			}
 			&:hover {
-				background-color: var(--maxi-white);
-				color: var(--maxi-black) !important;
-				transition: all 0.4s ease !important;
+				background-color: $w;
+				color: $bk !important;
+				transition: $t !important;
 				&::after {
-					background-color: var(--maxi-grey-dark);
+					background-color: $gd;
 				}
 			}
 			&:focus {
 				box-shadow: none !important;
 			}
 			.maxi-tabs-control__notification {
-				transition: all 0.5s ease;
-				position: absolute;
+				transition: $t;
+				position: $pa;
 				z-index: 8;
 				top: 0;
 				right: 0;
@@ -235,8 +236,8 @@
 				height: 0;
 				border-style: solid;
 				border-width: 0 8px 8px 0;
-				border-color: transparent var(--maxi-primary-color) transparent
-					transparent;
+				border-color: $tr $pc $tr
+					$tr;
 			}
 		}
 		&-wrapper {
@@ -249,7 +250,7 @@
 				.maxi-components-button {
 					&[aria-pressed='true'] {
 						.maxi-responsive-selector__button-current-size {
-							color: var(--maxi-primary-color);
+							color: $pc;
 						}
 					}
 				}
@@ -261,7 +262,7 @@
 			line-height: 100%;
 			margin-top: 2px;
 			font-weight: 800;
-			color: var(--maxi-secondary-color) !important;
+			color: $sc !important;
 		}
 	}
 }

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .has-tooltip {
 	.tooltip {
 		display: none;
@@ -13,10 +14,10 @@
 	border-radius: 100px !important;
 }
 .active-style-card {
-	position: relative;
+	position: $pr;
 	display: flex;
 	padding: 8px 8px 8px 8px;
-	border-bottom: 1px solid var(--maxi-grey-light);
+	border-bottom: $bl;
 
 	.active-style-card_icon {
 		width: 50px;
@@ -32,7 +33,7 @@
 		}
 	}
 	.maxi-responsive-close {
-		position: absolute;
+		position: $pa;
 		right: 10px;
 		display: flex;
 		align-items: center;
@@ -41,9 +42,9 @@
 		width: 20px !important;
 		padding: 0 0 1px !important;
 		border-radius: 50%;
-		background-color: var(--maxi-black);
+		background-color: $bk;
 		text-align: center;
-		cursor: pointer;
+		cursor: $ptr;
 		transition: background-color 0.3s ease;
 
 		&:hover {
@@ -58,7 +59,7 @@
 			height: 9.11px;
 			width: 9.11px;
 			path {
-				stroke: var(--maxi-white);
+				stroke: $w;
 			}
 		}
 	}
@@ -97,7 +98,7 @@
 	}
 
 	span {
-		color: var(--maxi-primary-color) !important;
+		color: $pc !important;
 		padding-bottom: 5px;
 		display: block;
 	}
@@ -130,7 +131,7 @@
 	}
 }
 .maxi-style-cards__sc__actions--save {
-	border: 1.5px solid var(--maxi-grey-light) !important;
+	border: $bg !important;
 }
 .maxi-style-card-settings-disabled {
 	display: none;
@@ -141,12 +142,12 @@
 	h3 {
 		font-weight: 700 !important;
 		margin: 15px 0 0 0;
-		color: var(--maxi-black);
+		color: $bk;
 	}
 }
 .edit-activate {
 	button {
-		border: 1.5px solid var(--maxi-grey-light) !important;
+		border: $bg !important;
 	}
 }
 
@@ -158,14 +159,14 @@ body .maxi-style-cards__popover {
 	height: 100%;
 	width: 350px;
 	box-shadow: 0 4px 0px rgba(0, 0, 0, 0.1);
-	background-color: var(--maxi-white);
-	border-left: 1.5px solid var(--maxi-grey-light);
+	background-color: $w;
+	border-left: 1.5px solid $gl;
 
 	button:not(.maxi-reset-button):not(.maxi-color-control__palette-box):not(.maxi-style-cards__custom-color-presets__remove-button):hover {
-		background-color: var(--maxi-whisper-green) !important;
+		background-color: $wg !important;
 		opacity: 1;
-		color: var(--maxi-primary-color) !important;
-		transition: all 0.3s ease !important;
+		color: $pc !important;
+		transition: $t !important;
 	}
 
 	.maxi-accordion-control__item {
@@ -173,7 +174,7 @@ body .maxi-style-cards__popover {
 			margin: 0 0 8px;
 		}
 		&.maxi-blocks-sc__type--color:not(.maxi-blocks-sc__type--custom-color-presets) {
-			position: relative;
+			position: $pr;
 			.maxi-color-control__color {
 				.chrome-picker {
 					& > div {
@@ -230,7 +231,7 @@ body .maxi-style-cards__popover {
 		gap: 8px;
 		.maxi-color-control__palette-box {
 			width: 32px !important;
-			border: 1.5px solid var(--maxi-grey-light) !important;
+			border: $bg !important;
 			height: 32px !important;
 		}
 	}
@@ -246,27 +247,27 @@ body .maxi-style-cards__popover {
 			width: 32px;
 			height: 32px;
 			padding: 0;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			margin: 0;
 			border-radius: 50% !important;
-			background-color: var(--maxi-white);
-			cursor: pointer;
+			background-color: $w;
+			cursor: $ptr;
 			transition: all 0.2s;
 			align-items: center;
 			justify-content: center;
-			cursor: pointer;
+			cursor: $ptr;
 
 			&:hover {
-				background: var(--maxi-white);
-				border-color: var(--maxi-grey);
+				background: $w;
+				border-color: $g;
 			}
 			&--active {
-				border: 1.5px solid var(--maxi-primary-color);
+				border: 1.5px solid $pc;
 			}
 			&__item {
 				width: 24px;
 				height: 24px;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 50% !important;
 			}
 		}
@@ -279,32 +280,32 @@ body .maxi-style-cards__popover {
 		margin-bottom: 8px;
 
 		&__box {
-			position: relative;
+			position: $pr;
 			display: flex;
 			width: 32px;
 			height: 32px;
 			padding: 0;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			border-radius: 50% !important;
 			background-color: #fff;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: all 0.2s;
 			align-items: center;
 			justify-content: center;
 
 			&:hover {
-				background: var(--maxi-white);
-				border-color: var(--maxi-grey);
+				background: $w;
+				border-color: $g;
 			}
 
 			&--active {
-				border: 2px solid var(--maxi-primary-color);
+				border: 2px solid $pc;
 			}
 
 			&__item {
 				width: 24px;
 				height: 24px;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 50% !important;
 			}
 		}
@@ -314,26 +315,26 @@ body .maxi-style-cards__popover {
 			width: 32px;
 			height: 32px;
 			padding: 0 !important;
-			border: 1.5px dashed var(--maxi-grey-light) !important;
+			border: 1.5px dashed $gl !important;
 			border-radius: 50% !important;
 			background-color: #fff;
-			cursor: pointer;
+			cursor: $ptr;
 			transition: all 0.2s;
 			align-items: center;
 			justify-content: center;
 			font-size: 18px;
 			font-weight: bold;
-			color: var(--maxi-grey);
+			color: $g;
 			line-height: 1;
 
 			&:hover {
 				background: var(--maxi-white-1);
-				border-color: var(--maxi-grey) !important;
+				border-color: $g !important;
 			}
 		}
 
 		&__remove-button {
-			position: absolute;
+			position: $pa;
 			bottom: -5px;
 			right: -5px;
 			width: 16px !important;
@@ -348,20 +349,20 @@ body .maxi-style-cards__popover {
 			font-size: 20px;
 			font-weight: bold;
 			line-height: 24px;
-			color: var(--maxi-grey-dark);
-			border: 1px solid var(--maxi-grey) !important;
-			background-color: var(--maxi-white);
-			transition: all 0.5s ease;
+			color: $gd;
+			border: 1px solid $g !important;
+			background-color: $w;
+			transition: $t;
 
 			&:hover {
-				color: var(--maxi-white) !important;
-				border: 1px solid var(--maxi-grey) !important;
-				background-color: var(--maxi-grey-dark) !important;
+				color: $w !important;
+				border: 1px solid $g !important;
+				background-color: $gd !important;
 			}
 		}
 		.maxi-style-cards__custom-color-presets__box:hover {
 			.maxi-style-cards__custom-color-presets__remove-button {
-				transition: all 0.5s ease;
+				transition: $t;
 				display: flex;
 			}
 		}
@@ -381,7 +382,7 @@ body .maxi-style-cards__popover {
 	}
 
 	.maxi-style-cards__quick-color-presets__reset {
-		position: absolute;
+		position: $pa;
 		bottom: 8px;
 		right: 8px;
 		display: flex;
@@ -390,8 +391,8 @@ body .maxi-style-cards__popover {
 		width: 58px;
 		height: 32px;
 		padding-left: 2px !important;
-		color: var(--maxi-grey-dark);
-		border: 1.5px solid var(--maxi-grey-light) !important;
+		color: $gd;
+		border: $bg !important;
 		border-radius: 5px !important;
 
 		&-button__preview {
@@ -399,7 +400,7 @@ body .maxi-style-cards__popover {
 			min-width: 20px;
 			height: 20px;
 			border-radius: 50% !important;
-			border: 1.5px solid var(--maxi-grey-light);
+			border: $bg;
 			margin-left: 5px;
 		}
 		&-button {
@@ -414,10 +415,10 @@ body .maxi-style-cards__popover {
 			justify-content: space-around;
 
 			&:hover:not(:disabled) {
-				background: var(--maxi-white);
+				background: $w;
 
 				svg {
-					fill: var(--maxi-black);
+					fill: $bk;
 				}
 			}
 		}
@@ -425,20 +426,20 @@ body .maxi-style-cards__popover {
 		svg {
 			width: 14px;
 			height: 14px;
-			fill: var(--maxi-grey);
+			fill: $g;
 			transition: all 0.3s;
 		}
 	}
 	hr {
 		border: 0;
-		border-top: 1.5px solid var(--maxi-grey-light);
+		border-top: 1.5px solid $gl;
 		margin: 0;
 		height: 1px;
 	}
 	&__sub-title {
 		font-size: 14px;
-		color: var(--maxi-grey-dark);
-		background: var(--maxi-white);
+		color: $gd;
+		background: $w;
 		padding: 10px;
 		margin-bottom: 1px;
 	}
@@ -446,11 +447,11 @@ body .maxi-style-cards__popover {
 		display: flex;
 		align-items: center;
 		font-size: 1rem;
-		color: var(--maxi-black);
+		color: $bk;
 		font-weight: bold !important;
 		margin: 0;
 		padding: 10px;
-		background: var(--maxi-white);
+		background: $w;
 
 		& > svg {
 			width: 35px;
@@ -461,7 +462,7 @@ body .maxi-style-cards__popover {
 	.maxi-style-cards__sc {
 		&:not(.maxi-style-cards__settings) {
 			z-index: 9;
-			position: relative;
+			position: $pr;
 			button:not(.maxi-reset-button):not(.maxi-color-control__palette-box):not(.maxi-style-cards__custom-color-presets__remove-button),
 			a.components-button {
 				&:disabled {
@@ -471,15 +472,15 @@ body .maxi-style-cards__popover {
 				align-items: center;
 				justify-content: center;
 				transition: all 0.5s;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 20px;
 				padding: 8px;
-				color: var(--maxi-grey-dark);
+				color: $gd;
 				line-height: 90%;
 			}
 		}
 		padding: 8px 8px 1px;
-		background: var(--maxi-white);
+		background: $w;
 
 		button:last-of-type {
 			margin-right: 0;
@@ -518,7 +519,7 @@ body .maxi-style-cards__popover {
 				display: flex;
 				justify-content: center;
 				align-items: center;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 20px;
 				margin-right: 8px;
 				padding: 0;
@@ -530,7 +531,7 @@ body .maxi-style-cards__popover {
 				.maxi-select-control__input {
 					height: 36px !important;
 					padding: 0 25px 0 0;
-					border-color: var(--maxi-grey-light);
+					border-color: $gl;
 					line-height: 36px;
 					text-align: center;
 					overflow-wrap: break-word;
@@ -558,9 +559,9 @@ body .maxi-style-cards__popover {
 					}
 				}
 				background: none;
-				border: 1.5px solid var(--maxi-grey-light) !important;
+				border: $bg !important;
 				padding: 0;
-				cursor: pointer;
+				cursor: $ptr;
 
 				svg {
 					width: 15px;
@@ -568,15 +569,15 @@ body .maxi-style-cards__popover {
 				}
 
 				&:hover svg {
-					stroke: var(--maxi-primary-color) !important;
+					stroke: $pc !important;
 				}
 			}
 			&--reset[type='button'] {
-				position: relative;
+				position: $pr;
 				right: -2px;
 			}
 			&--delete[type='button'] {
-				position: relative;
+				position: $pr;
 				width: 15%;
 			}
 		}
@@ -621,7 +622,7 @@ body .maxi-style-cards__popover {
 				flex: 2;
 				margin-right: 8px;
 				justify-content: center;
-				border: 1.5px solid var(--maxi-grey-light);
+				border: $bg;
 				border-radius: 20px;
 				transition: 0.1s;
 			}
@@ -662,7 +663,7 @@ body .maxi-style-cards__popover {
 
 			&__button {
 				&__button[aria-pressed='true'] {
-					border-bottom-color: var(--maxi-primary-color);
+					border-bottom-color: $pc;
 				}
 			}
 		}
@@ -678,15 +679,15 @@ body .maxi-style-cards__popover {
 			padding-bottom: 7px;
 		}
 		> * {
-			border-right: 1.5px solid var(--maxi-grey-light);
+			border-right: 1.5px solid $gl;
 		}
 		> :last-child {
-			border-bottom: 1.5px solid var(--maxi-grey-light);
+			border-bottom: 1.5px solid $gl;
 		}
-		background-color: var(--maxi-white);
-		border-right: 1.5px solid var(--maxi-grey-light);
+		background-color: $w;
+		border-right: 1.5px solid $gl;
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		position: relative;
+		position: $pr;
 	}
 	.maxi-base-control__field {
 		.components-range-control {
@@ -861,11 +862,11 @@ html[dir='rtl'] {
 /* delete SVG hover */
 .maxi-style-cards__sc__more-sc--delete.has-tooltip {
 	svg {
-		stroke: var(--maxi-grey-dark);
+		stroke: $gd;
 		transition: stroke 0.3s ease;
 	}
 
 	&:hover svg {
-		stroke: var(--maxi-primary-color) !important;
+		stroke: $pc !important;
 	}
 }

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -1,4 +1,21 @@
 @import '../../../src/css/backend-variables.scss';
+
+@mixin transit {
+	transition: $t;
+}
+
+@mixin flex-center($important: false) {
+	@if $important {
+		display: flex !important;
+		align-items: center !important;
+		justify-content: center !important;
+	} @else {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
 .has-tooltip {
 	.tooltip {
 		display: none;
@@ -352,7 +369,7 @@ body .maxi-style-cards__popover {
 			color: $gd;
 			border: 1px solid $g !important;
 			background-color: $w;
-			transition: $t;
+			@include transit;
 
 			&:hover {
 				color: $w !important;
@@ -362,7 +379,7 @@ body .maxi-style-cards__popover {
 		}
 		.maxi-style-cards__custom-color-presets__box:hover {
 			.maxi-style-cards__custom-color-presets__remove-button {
-				transition: $t;
+				@include transit;
 				display: flex;
 			}
 		}
@@ -516,9 +533,7 @@ body .maxi-style-cards__popover {
 			}
 
 			&--add-more {
-				display: flex;
-				justify-content: center;
-				align-items: center;
+				@include flex-center;
 				border: $bg;
 				border-radius: 20px;
 				margin-right: 8px;

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -1,20 +1,6 @@
 @import '../../../src/css/backend-variables.scss';
 
-@mixin transit {
-	transition: $t;
-}
 
-@mixin flex-center($important: false) {
-	@if $important {
-		display: flex !important;
-		align-items: center !important;
-		justify-content: center !important;
-	} @else {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-}
 
 .has-tooltip {
 	.tooltip {

--- a/src/editor/toolbar-buttons/editor.scss
+++ b/src/editor/toolbar-buttons/editor.scss
@@ -1,3 +1,4 @@
+@import '../../../src/css/backend-variables.scss';
 .maxi-toolbar-layout {
 	&__button {
 		display: flex;
@@ -5,12 +6,12 @@
 		font-family: Inter, sans-serif;
 		font-size: 14px;
 		letter-spacing: 0.5px;
-		color: var(--maxi-black);
-		background-color: var(--maxi-white);
+		color: $bk;
+		background-color: $w;
 		margin-left: 10px;
 		border-radius: 10px;
 		float: right;
-		border: 2px solid var(--maxi-grey-light);
+		border: 2px solid $gl;
 		box-shadow: none !important;
 		padding: 10px 7px;
 		justify-content: center;
@@ -25,7 +26,7 @@
 		}
 		&:hover,
 		&[aria-pressed='true'] {
-			border-color: var(--maxi-primary-color);
+			border-color: $pc;
 		}
 	}
 }
@@ -48,7 +49,7 @@ body.maxi-blocks--active .edit-post-header-toolbar {
 		}
 	}
 	.maxi-toolbar-layout__button {
-		position: absolute;
+		position: $pa;
 		left: 280px;
 		top: 7px;
 		margin-left: 0;


### PR DESCRIPTION
Replaced hardcoded CSS values and color variables with SCSS variables and mixins imported from backend-variables.scss across admin and starter-sites styles. This improves maintainability and consistency of styles throughout the codebase.


