### PR TITLE
Fix indicator detection for default values

### DIFF
--- a/e2e-tests/editor/sc-variable.spec.js
+++ b/e2e-tests/editor/sc-variable.spec.js
@@ -27,7 +27,25 @@ describe('sc-variable', () => {
 		await page.evaluate(() => window.location.reload());
 
 		await page.waitForTimeout(5000);
+
+		// Wait for the SC vars element and ensure content is fully generated
 		await page.waitForSelector('#maxi-blocks-sc-vars-inline-css');
+
+		// Wait for content to be complete by checking for all breakpoints
+		await page.waitForFunction(
+			() => {
+				const el = document.getElementById('maxi-blocks-sc-vars-inline-css');
+				if (!el || !el.innerText) return false;
+				const content = el.innerText;
+				// Check that all breakpoints are present and content is substantial
+				const hasAllBreakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs']
+					.every(bp => content.includes(`-${bp}:`));
+				// Also verify minimum content length to ensure it's fully generated
+				const hasMinimumContent = content.length > 10000;
+				return hasAllBreakpoints && hasMinimumContent;
+			},
+			{ timeout: 15000 }
+		);
 
 		const scVariable = await page.$eval(
 			'#maxi-blocks-sc-vars-inline-css',
@@ -39,7 +57,24 @@ describe('sc-variable', () => {
 		const previewPage = await openPreviewPage(page);
 		await previewPage.waitForSelector('.entry-content');
 
+		// Wait for the SC vars element and ensure content is fully generated on preview page
 		await page.waitForSelector('#maxi-blocks-sc-vars-inline-css');
+
+		// Wait for content to be complete by checking for all breakpoints
+		await page.waitForFunction(
+			() => {
+				const el = document.getElementById('maxi-blocks-sc-vars-inline-css');
+				if (!el || !el.innerText) return false;
+				const content = el.innerText;
+				// Check that all breakpoints are present and content is substantial
+				const hasAllBreakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs']
+					.every(bp => content.includes(`-${bp}:`));
+				// Also verify minimum content length to ensure it's fully generated
+				const hasMinimumContent = content.length > 10000;
+				return hasAllBreakpoints && hasMinimumContent;
+			},
+			{ timeout: 15000 }
+		);
 
 		const scVariableFront = await page.$eval(
 			'#maxi-blocks-sc-vars-inline-css',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^1.3.0",
-				"@langchain/core": "^0.3.37",
+				"@langchain/core": "^0.3.80",
 				"@langchain/openai": "^0.4.2",
 				"@uiw/react-textarea-code-editor": "latest",
 				"@wordpress/block-editor": "latest",
@@ -34,7 +34,7 @@
 				"dompurify": "latest",
 				"html-react-parser": "latest",
 				"is-mobile": "latest",
-				"langchain": "^0.3.34",
+				"langchain": "^0.3.37",
 				"leaflet": "latest",
 				"leaflet.gridlayer.googlemutant": "^0.15.0",
 				"masonry-layout": "latest",
@@ -3748,21 +3748,21 @@
 			"dev": true
 		},
 		"node_modules/@langchain/core": {
-			"version": "0.3.37",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.37.tgz",
-			"integrity": "sha512-LFk9GqHxcyCFx0oXvCBP7vDZIOUHYzzNU7JR+2ofIMnfkBLzcCKzBLySQDfPtd13PrpGHkaeOeLq8H1Tqi9lSw==",
+			"version": "0.3.80",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+			"integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
 			"dependencies": {
 				"@cfworker/json-schema": "^4.0.2",
 				"ansi-styles": "^5.0.0",
 				"camelcase": "6",
 				"decamelize": "1.2.0",
 				"js-tiktoken": "^1.0.12",
-				"langsmith": ">=0.2.8 <0.4.0",
+				"langsmith": "^0.3.67",
 				"mustache": "^4.2.0",
 				"p-queue": "^6.6.2",
 				"p-retry": "4",
 				"uuid": "^10.0.0",
-				"zod": "^3.22.4",
+				"zod": "^3.25.32",
 				"zod-to-json-schema": "^3.22.3"
 			},
 			"engines": {
@@ -3778,39 +3778,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@langchain/core/node_modules/langsmith": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.4.tgz",
-			"integrity": "sha512-Klyy7HtOEh3RqQsKStUfVwE8NMrLCp1+ng50ddeEjJyF5WI+LsgBDIpJGRVjmgNbNeX+rGnUk0kBKIU5gZjVFQ==",
-			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^4.1.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"p-retry": "4",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
-			},
-			"peerDependencies": {
-				"openai": "*"
-			},
-			"peerDependenciesMeta": {
-				"openai": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@langchain/core/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@langchain/core/node_modules/uuid": {
@@ -3843,59 +3810,17 @@
 			}
 		},
 		"node_modules/@langchain/textsplitters": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.0.3.tgz",
-			"integrity": "sha512-cXWgKE3sdWLSqAa8ykbCcUsUF1Kyr5J3HOWYGuobhPEycXW4WI++d5DhzdpL238mzoEXTi90VqfSCra37l5YqA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.1.0.tgz",
+			"integrity": "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==",
 			"dependencies": {
-				"@langchain/core": ">0.2.0 <0.3.0",
 				"js-tiktoken": "^1.0.12"
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@langchain/textsplitters/node_modules/@langchain/core": {
-			"version": "0.2.36",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.36.tgz",
-			"integrity": "sha512-qHLvScqERDeH7y2cLuJaSAlMwg3f/3Oc9nayRSXRU2UuaK/SOhI42cxiPLj1FnuHJSmN0rBQFkrLx02gI4mcVg==",
-			"dependencies": {
-				"ansi-styles": "^5.0.0",
-				"camelcase": "6",
-				"decamelize": "1.2.0",
-				"js-tiktoken": "^1.0.12",
-				"langsmith": "^0.1.56-rc.1",
-				"mustache": "^4.2.0",
-				"p-queue": "^6.6.2",
-				"p-retry": "4",
-				"uuid": "^10.0.0",
-				"zod": "^3.22.4",
-				"zod-to-json-schema": "^3.22.3"
 			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@langchain/textsplitters/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@langchain/textsplitters/node_modules/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/bin/uuid"
+			"peerDependencies": {
+				"@langchain/core": ">=0.2.21 <0.4.0"
 			}
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
@@ -13302,24 +13227,23 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
+				"bytes": "~3.1.2",
 				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.14.0",
+				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8",
@@ -13346,6 +13270,26 @@
 				"ms": "2.0.0"
 			}
 		},
+		"node_modules/body-parser/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/body-parser/node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -13365,6 +13309,15 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/body-parser/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/body-scroll-lock": {
 			"version": "3.1.5",
@@ -17630,21 +17583,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-			"dev": true,
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/express/node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -21410,9 +21348,9 @@
 			"license": "MIT"
 		},
 		"node_modules/langchain": {
-			"version": "0.3.34",
-			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.34.tgz",
-			"integrity": "sha512-OADHLQYRX+36EqQBxIoryCdMKfHex32cJBSWveadIIeRhygqivacIIDNwVjX51Y++c80JIdR0jaQHWn2r3H1iA==",
+			"version": "0.3.37",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.37.tgz",
+			"integrity": "sha512-1jPsZ6xsxkcQPUvqRjvfuOLwZLLyt49hzcOK7OYAJovIkkOxd5gzK4Yw6giPUQ8g4XHyvULNlWBz+subdkcokw==",
 			"dependencies": {
 				"@langchain/openai": ">=0.1.0 <0.7.0",
 				"@langchain/textsplitters": ">=0.0.0 <0.2.0",
@@ -21503,51 +21441,6 @@
 				}
 			}
 		},
-		"node_modules/langchain/node_modules/langsmith": {
-			"version": "0.3.69",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.69.tgz",
-			"integrity": "sha512-YKzu92YAP2o+d+1VmR38xqFX0RIRLKYj1IqdflVEY83X0FoiVlrWO3xDLXgnu7vhZ2N2M6jx8VO9fVF8yy9gHA==",
-			"dependencies": {
-				"@types/uuid": "^10.0.0",
-				"chalk": "^4.1.2",
-				"console-table-printer": "^2.12.1",
-				"p-queue": "^6.6.2",
-				"p-retry": "4",
-				"semver": "^7.6.3",
-				"uuid": "^10.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "*",
-				"@opentelemetry/exporter-trace-otlp-proto": "*",
-				"@opentelemetry/sdk-trace-base": "*",
-				"openai": "*"
-			},
-			"peerDependenciesMeta": {
-				"@opentelemetry/api": {
-					"optional": true
-				},
-				"@opentelemetry/exporter-trace-otlp-proto": {
-					"optional": true
-				},
-				"@opentelemetry/sdk-trace-base": {
-					"optional": true
-				},
-				"openai": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/langchain/node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/langchain/node_modules/uuid": {
 			"version": "10.0.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -21572,38 +21465,42 @@
 			}
 		},
 		"node_modules/langsmith": {
-			"version": "0.1.68",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.68.tgz",
-			"integrity": "sha512-otmiysWtVAqzMx3CJ4PrtUBhWRG5Co8Z4o7hSZENPjlit9/j3/vm3TSvbaxpDYakZxtMjhkcJTqrdYFipISEiQ==",
+			"version": "0.3.87",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+			"integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
 			"dependencies": {
 				"@types/uuid": "^10.0.0",
-				"commander": "^10.0.1",
+				"chalk": "^4.1.2",
+				"console-table-printer": "^2.12.1",
 				"p-queue": "^6.6.2",
-				"p-retry": "4",
 				"semver": "^7.6.3",
 				"uuid": "^10.0.0"
 			},
 			"peerDependencies": {
+				"@opentelemetry/api": "*",
+				"@opentelemetry/exporter-trace-otlp-proto": "*",
+				"@opentelemetry/sdk-trace-base": "*",
 				"openai": "*"
 			},
 			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-proto": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				},
 				"openai": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/langsmith/node_modules/commander": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/langsmith/node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -25175,13 +25072,12 @@
 			]
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -25273,16 +25169,15 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.8"
@@ -25293,9 +25188,28 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/raw-body/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/raw-body/node_modules/iconv-lite": {
@@ -25303,12 +25217,20 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/raw-body/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/re-resizable": {
@@ -33352,21 +33274,21 @@
 			"dev": true
 		},
 		"@langchain/core": {
-			"version": "0.3.37",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.37.tgz",
-			"integrity": "sha512-LFk9GqHxcyCFx0oXvCBP7vDZIOUHYzzNU7JR+2ofIMnfkBLzcCKzBLySQDfPtd13PrpGHkaeOeLq8H1Tqi9lSw==",
+			"version": "0.3.80",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.80.tgz",
+			"integrity": "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==",
 			"requires": {
 				"@cfworker/json-schema": "^4.0.2",
 				"ansi-styles": "^5.0.0",
 				"camelcase": "6",
 				"decamelize": "1.2.0",
 				"js-tiktoken": "^1.0.12",
-				"langsmith": ">=0.2.8 <0.4.0",
+				"langsmith": "^0.3.67",
 				"mustache": "^4.2.0",
 				"p-queue": "^6.6.2",
 				"p-retry": "4",
 				"uuid": "^10.0.0",
-				"zod": "^3.22.4",
+				"zod": "^3.25.32",
 				"zod-to-json-schema": "^3.22.3"
 			},
 			"dependencies": {
@@ -33374,25 +33296,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
-				},
-				"langsmith": {
-					"version": "0.3.4",
-					"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.4.tgz",
-					"integrity": "sha512-Klyy7HtOEh3RqQsKStUfVwE8NMrLCp1+ng50ddeEjJyF5WI+LsgBDIpJGRVjmgNbNeX+rGnUk0kBKIU5gZjVFQ==",
-					"requires": {
-						"@types/uuid": "^10.0.0",
-						"chalk": "^4.1.2",
-						"console-table-printer": "^2.12.1",
-						"p-queue": "^6.6.2",
-						"p-retry": "4",
-						"semver": "^7.6.3",
-						"uuid": "^10.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-					"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
 				},
 				"uuid": {
 					"version": "10.0.0",
@@ -33413,42 +33316,11 @@
 			}
 		},
 		"@langchain/textsplitters": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.0.3.tgz",
-			"integrity": "sha512-cXWgKE3sdWLSqAa8ykbCcUsUF1Kyr5J3HOWYGuobhPEycXW4WI++d5DhzdpL238mzoEXTi90VqfSCra37l5YqA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.1.0.tgz",
+			"integrity": "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==",
 			"requires": {
-				"@langchain/core": ">0.2.0 <0.3.0",
 				"js-tiktoken": "^1.0.12"
-			},
-			"dependencies": {
-				"@langchain/core": {
-					"version": "0.2.36",
-					"resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.36.tgz",
-					"integrity": "sha512-qHLvScqERDeH7y2cLuJaSAlMwg3f/3Oc9nayRSXRU2UuaK/SOhI42cxiPLj1FnuHJSmN0rBQFkrLx02gI4mcVg==",
-					"requires": {
-						"ansi-styles": "^5.0.0",
-						"camelcase": "6",
-						"decamelize": "1.2.0",
-						"js-tiktoken": "^1.0.12",
-						"langsmith": "^0.1.56-rc.1",
-						"mustache": "^4.2.0",
-						"p-queue": "^6.6.2",
-						"p-retry": "4",
-						"uuid": "^10.0.0",
-						"zod": "^3.22.4",
-						"zod-to-json-schema": "^3.22.3"
-					}
-				},
-				"ansi-styles": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
-				},
-				"uuid": {
-					"version": "10.0.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-					"integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
-				}
 			}
 		},
 		"@leichtgewicht/ip-codec": {
@@ -40354,23 +40226,23 @@
 			"dev": true
 		},
 		"body-parser": {
-			"version": "1.20.3",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.2",
+				"bytes": "~3.1.2",
 				"content-type": "~1.0.5",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
+				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
 				"bytes": {
@@ -40388,6 +40260,19 @@
 						"ms": "2.0.0"
 					}
 				},
+				"http-errors": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+					"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+					"dev": true,
+					"requires": {
+						"depd": "~2.0.0",
+						"inherits": "~2.0.4",
+						"setprototypeof": "~1.2.0",
+						"statuses": "~2.0.2",
+						"toidentifier": "~1.0.1"
+					}
+				},
 				"iconv-lite": {
 					"version": "0.4.24",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -40401,6 +40286,12 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+					"dev": true
+				},
+				"statuses": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+					"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
 					"dev": true
 				}
 			}
@@ -43423,7 +43314,7 @@
 			"requires": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "^1.20.4",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "^0.7.0",
@@ -43442,7 +43333,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "^6.14.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -43468,15 +43359,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 					"dev": true
-				},
-				"qs": {
-					"version": "6.14.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-					"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-					"dev": true,
-					"requires": {
-						"side-channel": "^1.1.0"
-					}
 				},
 				"safe-buffer": {
 					"version": "5.2.1",
@@ -46179,12 +46061,12 @@
 			"dev": true
 		},
 		"langchain": {
-			"version": "0.3.34",
-			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.34.tgz",
-			"integrity": "sha512-OADHLQYRX+36EqQBxIoryCdMKfHex32cJBSWveadIIeRhygqivacIIDNwVjX51Y++c80JIdR0jaQHWn2r3H1iA==",
+			"version": "0.3.37",
+			"resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.37.tgz",
+			"integrity": "sha512-1jPsZ6xsxkcQPUvqRjvfuOLwZLLyt49hzcOK7OYAJovIkkOxd5gzK4Yw6giPUQ8g4XHyvULNlWBz+subdkcokw==",
 			"requires": {
 				"@langchain/openai": ">=0.1.0 <0.7.0",
-				"@langchain/textsplitters": ">=0.0.0 <0.2.0",
+				"@langchain/textsplitters": "^0.1.0",
 				"js-tiktoken": "^1.0.12",
 				"js-yaml": "^4.1.1",
 				"jsonpointer": "^5.0.1",
@@ -46196,25 +46078,6 @@
 				"zod": "^3.25.32"
 			},
 			"dependencies": {
-				"langsmith": {
-					"version": "0.3.69",
-					"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.69.tgz",
-					"integrity": "sha512-YKzu92YAP2o+d+1VmR38xqFX0RIRLKYj1IqdflVEY83X0FoiVlrWO3xDLXgnu7vhZ2N2M6jx8VO9fVF8yy9gHA==",
-					"requires": {
-						"@types/uuid": "^10.0.0",
-						"chalk": "^4.1.2",
-						"console-table-printer": "^2.12.1",
-						"p-queue": "^6.6.2",
-						"p-retry": "4",
-						"semver": "^7.6.3",
-						"uuid": "^10.0.0"
-					}
-				},
-				"semver": {
-					"version": "7.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-					"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
-				},
 				"uuid": {
 					"version": "10.0.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -46228,27 +46091,22 @@
 			}
 		},
 		"langsmith": {
-			"version": "0.1.68",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.68.tgz",
-			"integrity": "sha512-otmiysWtVAqzMx3CJ4PrtUBhWRG5Co8Z4o7hSZENPjlit9/j3/vm3TSvbaxpDYakZxtMjhkcJTqrdYFipISEiQ==",
+			"version": "0.3.87",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+			"integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
 			"requires": {
 				"@types/uuid": "^10.0.0",
-				"commander": "^10.0.1",
+				"chalk": "^4.1.2",
+				"console-table-printer": "^2.12.1",
 				"p-queue": "^6.6.2",
-				"p-retry": "4",
 				"semver": "^7.6.3",
 				"uuid": "^10.0.0"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "10.0.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-					"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
-				},
 				"semver": {
-					"version": "7.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-					"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+					"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
 				},
 				"uuid": {
 					"version": "10.0.0",
@@ -48784,12 +48642,12 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"dev": true,
 			"requires": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			}
 		},
 		"querystringify": {
@@ -48850,15 +48708,15 @@
 			"dev": true
 		},
 		"raw-body": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
 				"bytes": {
@@ -48866,6 +48724,19 @@
 					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 					"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 					"dev": true
+				},
+				"http-errors": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+					"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+					"dev": true,
+					"requires": {
+						"depd": "~2.0.0",
+						"inherits": "~2.0.4",
+						"setprototypeof": "~1.2.0",
+						"statuses": "~2.0.2",
+						"toidentifier": "~1.0.1"
+					}
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
@@ -48875,6 +48746,12 @@
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
+				},
+				"statuses": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+					"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"@floating-ui/react-dom": "^1.3.0",
-		"@langchain/core": "^0.3.37",
+		"@langchain/core": "^0.3.80",
 		"@langchain/openai": "^0.4.2",
 		"@uiw/react-textarea-code-editor": "latest",
 		"@wordpress/block-editor": "latest",
@@ -55,7 +55,7 @@
 		"dompurify": "latest",
 		"html-react-parser": "latest",
 		"is-mobile": "latest",
-		"langchain": "^0.3.34",
+		"langchain": "^0.3.37",
 		"leaflet": "latest",
 		"leaflet.gridlayer.googlemutant": "^0.15.0",
 		"masonry-layout": "latest",
@@ -145,6 +145,9 @@
 		"js-yaml": "^4.1.1",
 		"del": "^6.1.1",
 		"node-forge": "^1.3.2",
-		"express": "^4.22.0"
+		"express": "^4.22.0",
+		"qs": "^6.14.1",
+		"body-parser": "^1.20.4",
+		"@langchain/textsplitters": "^0.1.0"
 	}
 }

--- a/src/blocks/column-maxi/components/column-size-control/index.js
+++ b/src/blocks/column-maxi/components/column-size-control/index.js
@@ -70,10 +70,12 @@ const ColumnSizeControl = props => {
 							clientId,
 							breakpoint
 						);
+						const isEmptyValue =
+							val === undefined || val === null || val === '';
 
 						onChange({
 							[`column-size-${breakpoint}`]:
-								val !== undefined && val !== '' ? val : '',
+								isEmptyValue ? '' : val,
 							isReset: true,
 						});
 					}}

--- a/src/components/accordion-control/Accordion.js
+++ b/src/components/accordion-control/Accordion.js
@@ -17,7 +17,7 @@ import {
 /**
  * External dependencies
  */
-import { lowerCase, isEmpty } from 'lodash';
+import { lowerCase, isEmpty, isEqual } from 'lodash';
 import classnames from 'classnames';
 
 const Accordion = props => {
@@ -85,11 +85,15 @@ const Accordion = props => {
 					) {
 						const { attributes, name } = block;
 						const defaultAttributes = getBlockAttributes(name);
-						isActiveTab = !item.indicatorProps.every(prop =>
-							Array.isArray(attributes[prop])
-								? isEmpty(attributes[prop])
-								: attributes[prop] === defaultAttributes[prop]
-						);
+						isActiveTab = !item.indicatorProps.every(prop => {
+							if (Array.isArray(attributes[prop]))
+								return isEmpty(attributes[prop]);
+
+							return isEqual(
+								attributes[prop],
+								defaultAttributes[prop]
+							);
+						});
 					}
 				}
 

--- a/src/components/color-control/index.js
+++ b/src/components/color-control/index.js
@@ -202,9 +202,10 @@ const ColorControl = props => {
 			if (showPalette)
 				onChange({
 					paletteStatus: defaultColorAttr.paletteStatus,
+					paletteSCStatus: defaultColorAttr.paletteSCStatus,
 					paletteColor: defaultColorAttr.paletteColor,
-					paletteOpacity: paletteOpacity || 1,
-					color,
+					paletteOpacity: defaultColorAttr.paletteOpacity,
+					color: defaultColorAttr.color,
 				});
 			else {
 				let defaultColor;

--- a/src/components/color-control/index.js
+++ b/src/components/color-control/index.js
@@ -208,27 +208,12 @@ const ColorControl = props => {
 					color: defaultColorAttr.color,
 				});
 			else {
-				let defaultColor;
-
-				if (typeof paletteColor === 'number' && paletteColor >= 1000) {
-					const customIndex = paletteColor - 1000;
-					defaultColor =
-						customColors?.[customIndex]?.value ||
-						color ||
-						'rgba(0, 0, 0, 1)';
-				} else {
-					defaultColor = `rgba(${getPaletteColor({
-						clientId,
-						color: paletteColor,
-						blockStyle,
-					})},${paletteOpacity || 1})`;
-				}
-
 				onChange({
-					paletteStatus,
-					paletteColor,
-					paletteOpacity,
-					color: defaultColor,
+					paletteStatus: defaultColorAttr.paletteStatus,
+					paletteSCStatus: defaultColorAttr.paletteSCStatus,
+					paletteColor: defaultColorAttr.paletteColor,
+					paletteOpacity: defaultColorAttr.paletteOpacity,
+					color: defaultColorAttr.color,
 					isReset: true,
 				});
 			}

--- a/src/components/inspector-tabs/inspector-link-settings.js
+++ b/src/components/inspector-tabs/inspector-link-settings.js
@@ -40,12 +40,7 @@ const linkSettings = ({
 			disablePadding: true,
 			content: (
 				<TypographyControl
-					{...getGroupAttributes(
-						attributes,
-						['typography', 'link'],
-						false,
-						prefix
-					)}
+					{...getGroupAttributes(attributes, 'link', false, prefix)}
 					onChangeInline={(obj, target, isMultiplySelector) =>
 						insertInlineStyles({ obj, target, isMultiplySelector })
 					}

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -59,7 +59,7 @@ const size = ({
 			/>
 		),
 		extraIndicators: [
-			...(isFirstOnHierarchy ? 'blockFullWidth' : 'fullWidth'),
+			isFirstOnHierarchy ? 'blockFullWidth' : 'fullWidth',
 		],
 	};
 };

--- a/src/extensions/indicators/getIsActiveTab.js
+++ b/src/extensions/indicators/getIsActiveTab.js
@@ -98,13 +98,20 @@ const getIsActiveTab = (
 		if (excludedAttributes.includes(attribute)) return true;
 		if (!(attribute in defaultAttributes)) return true;
 		if (currentAttributes[attribute] === undefined) return true;
+		if (currentAttributes[attribute] === null) return true;
 		if (currentAttributes[attribute] === false) return true;
 
 		if (breakpoint) {
 			const breakpointAttributeChecker = bp => {
 				if (currentAttributes[attribute] === undefined) return true;
+				if (currentAttributes[attribute] === null) return true;
 				if (currentAttributes[attribute] === false) return true;
 				if (currentAttributes[attribute] === '') return true;
+				if (
+					['none', 'unset'].includes(currentAttributes[attribute]) &&
+					defaultAttributes[attribute] == null
+				)
+					return true;
 				if (
 					isArray(currentAttributes[attribute]) &&
 					currentAttributes[attribute].length !== 0
@@ -200,6 +207,12 @@ const getIsActiveTab = (
 		if (
 			isPlainObject(currentAttributes[attribute]) &&
 			isEmpty(currentAttributes[attribute]) &&
+			defaultAttributes[attribute] == null
+		)
+			return true;
+
+		if (
+			['none', 'unset'].includes(currentAttributes[attribute]) &&
 			defaultAttributes[attribute] == null
 		)
 			return true;

--- a/src/extensions/indicators/getIsActiveTab.js
+++ b/src/extensions/indicators/getIsActiveTab.js
@@ -3,7 +3,7 @@
  */
 import { getBlockAttributes } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { isArray, isEqual } from 'lodash';
+import { isArray, isEqual, isEmpty } from 'lodash';
 import { getGroupAttributes } from '@extensions/styles';
 
 const getIsActiveTab = (
@@ -118,6 +118,16 @@ const getIsActiveTab = (
 				currentAttributes[attribute],
 				defaultAttributes[attribute]
 			);
+		}
+
+		if (
+			attribute === 'transition' &&
+			currentAttributes[attribute] &&
+			Object.values(currentAttributes[attribute]).every(value =>
+				isEmpty(value)
+			)
+		) {
+			return true;
 		}
 
 		// Check if background layers have any non-color layer

--- a/src/extensions/indicators/getIsActiveTab.js
+++ b/src/extensions/indicators/getIsActiveTab.js
@@ -3,7 +3,7 @@
  */
 import { getBlockAttributes } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { isArray, isEqual, isEmpty } from 'lodash';
+import { isArray, isEqual, isEmpty, isPlainObject } from 'lodash';
 import { getGroupAttributes } from '@extensions/styles';
 import getColumnDefaultValue from '@extensions/column-templates/getColumnDefaultValue';
 
@@ -123,10 +123,29 @@ const getIsActiveTab = (
 					attribute.lastIndexOf(`-${bp}`) ===
 					attribute.length - `-${bp}`.length
 				) {
-					return isEqual(
-						currentAttributes[attribute],
-						defaultAttributes[attribute]
+					if (
+						isEqual(
+							currentAttributes[attribute],
+							defaultAttributes[attribute]
+						)
+					)
+						return true;
+
+					const generalAttribute = attribute.replace(
+						`-${bp}`,
+						'-general'
 					);
+
+					if (
+						generalAttribute in defaultAttributes &&
+						isEqual(
+							currentAttributes[attribute],
+							defaultAttributes[generalAttribute]
+						)
+					)
+						return true;
+
+					return false;
 				}
 
 				return true;
@@ -177,6 +196,13 @@ const getIsActiveTab = (
 			);
 			if (!hasNonColorLayer) return true;
 		}
+
+		if (
+			isPlainObject(currentAttributes[attribute]) &&
+			isEmpty(currentAttributes[attribute]) &&
+			defaultAttributes[attribute] == null
+		)
+			return true;
 
 		if (currentAttributes[attribute] === '') return true;
 

--- a/src/extensions/indicators/getIsActiveTab.js
+++ b/src/extensions/indicators/getIsActiveTab.js
@@ -3,7 +3,7 @@
  */
 import { getBlockAttributes } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { isArray } from 'lodash';
+import { isArray, isEqual } from 'lodash';
 import { getGroupAttributes } from '@extensions/styles';
 
 const getIsActiveTab = (
@@ -89,8 +89,8 @@ const getIsActiveTab = (
 					attribute.lastIndexOf(`-${bp}`) ===
 					attribute.length - `-${bp}`.length
 				) {
-					return (
-						currentAttributes[attribute] ===
+					return isEqual(
+						currentAttributes[attribute],
 						defaultAttributes[attribute]
 					);
 				}
@@ -111,8 +111,9 @@ const getIsActiveTab = (
 			isArray(currentAttributes[attribute]) &&
 			currentAttributes[attribute].length === 0
 		) {
-			return (
-				currentAttributes[attribute] !== defaultAttributes[attribute]
+			return isEqual(
+				currentAttributes[attribute],
+				defaultAttributes[attribute]
 			);
 		}
 
@@ -126,7 +127,10 @@ const getIsActiveTab = (
 
 		if (currentAttributes[attribute] === '') return true;
 
-		return currentAttributes[attribute] === defaultAttributes[attribute];
+		return isEqual(
+			currentAttributes[attribute],
+			defaultAttributes[attribute]
+		);
 	});
 };
 

--- a/src/extensions/indicators/getIsActiveTab.js
+++ b/src/extensions/indicators/getIsActiveTab.js
@@ -71,6 +71,9 @@ const getIsActiveTab = (
 
 		if (breakpoint) {
 			const breakpointAttributeChecker = bp => {
+				if (currentAttributes[attribute] === undefined) return true;
+				if (currentAttributes[attribute] === false) return true;
+				if (currentAttributes[attribute] === '') return true;
 				if (
 					isArray(currentAttributes[attribute]) &&
 					currentAttributes[attribute].length !== 0


### PR DESCRIPTION
### Motivation
- Indicators were reporting as active when attribute values deeply equal defaults because comparisons used shallow `===` checks. 
- Accordion tab indicator logic and the core helper used different equality semantics, causing inconsistent indicator states. 
- Responsive and complex attributes (arrays/objects) need deep comparison to avoid false positives. 

### Description
- Use `isEqual` from `lodash` to perform deep equality checks instead of `===` in `src/extensions/indicators/getIsActiveTab.js` when comparing `currentAttributes` to `defaultAttributes`. 
- Update `src/components/accordion-control/Accordion.js` to import and use `isEqual` for `item.indicatorProps` checks so accordion tabs match the helper behavior. 
- Preserve existing array-empty checks and breakpoint handling while replacing equality comparisons with deep comparisons. 

### Testing
- No automated tests were run against the changes. 
- Files modified: `src/extensions/indicators/getIsActiveTab.js` and `src/components/accordion-control/Accordion.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ca482c3b883219ebb1c7e8c5daa44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve detection of active tabs/indicators by using deep equality and stronger guards for empty/null values, transitions, background layers and breakpoint defaults.
  * Ensure palette resets use canonical default color values and handle null/empty resets consistently.
  * Better defaults for column sizing when computing fallback values.

* **Refactor**
  * Narrowed attribute groups for link typography controls.
  * Fixed indicator list construction to use a single string entry.

* **Tests**
  * E2E waits added to ensure generated stylesheet content is complete before assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->