### PR TITLE
Fix hover background reset to normal color

### DIFF
--- a/src/blocks/accordion-maxi/inspector.js
+++ b/src/blocks/accordion-maxi/inspector.js
@@ -198,6 +198,7 @@ const Inspector = props => {
 									},
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/button-maxi/inspector.js
+++ b/src/blocks/button-maxi/inspector.js
@@ -303,6 +303,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/column-maxi/inspector.js
+++ b/src/blocks/column-maxi/inspector.js
@@ -68,6 +68,7 @@ const Inspector = props => {
 									},
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 										disableVideo: true,
 									}),
 									...inspectorTabs.border({

--- a/src/blocks/container-maxi/inspector.js
+++ b/src/blocks/container-maxi/inspector.js
@@ -96,6 +96,7 @@ const Inspector = props => {
 									},
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/divider-maxi/inspector.js
+++ b/src/blocks/divider-maxi/inspector.js
@@ -284,6 +284,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/group-maxi/inspector.js
+++ b/src/blocks/group-maxi/inspector.js
@@ -44,6 +44,7 @@ const Inspector = props => {
 									}),
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -467,6 +467,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/list-item-maxi/inspector.js
+++ b/src/blocks/list-item-maxi/inspector.js
@@ -63,6 +63,7 @@ const Inspector = props => {
 									}),
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/number-counter-maxi/inspector.js
+++ b/src/blocks/number-counter-maxi/inspector.js
@@ -124,6 +124,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/pane-maxi/inspector.js
+++ b/src/blocks/pane-maxi/inspector.js
@@ -123,6 +123,7 @@ const Inspector = props => {
 									},
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/row-maxi/inspector.js
+++ b/src/blocks/row-maxi/inspector.js
@@ -103,6 +103,7 @@ const Inspector = props => {
 									},
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/slide-maxi/inspector.js
+++ b/src/blocks/slide-maxi/inspector.js
@@ -40,6 +40,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 										disableVideo: true,
 									}),
 									...inspectorTabs.border({

--- a/src/blocks/slider-maxi/inspector.js
+++ b/src/blocks/slider-maxi/inspector.js
@@ -171,6 +171,7 @@ const Inspector = props => {
 									}),
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/svg-icon-maxi/inspector.js
+++ b/src/blocks/svg-icon-maxi/inspector.js
@@ -313,6 +313,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 										disableImage: true,
 										disableVideo: true,
 										disableGradient: true,

--- a/src/blocks/text-maxi/inspector.js
+++ b/src/blocks/text-maxi/inspector.js
@@ -82,6 +82,7 @@ const Inspector = props => {
 									}),
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/blocks/video-maxi/inspector.js
+++ b/src/blocks/video-maxi/inspector.js
@@ -234,6 +234,7 @@ const Inspector = props => {
 								items={[
 									...inspectorTabs.blockBackground({
 										props,
+										isIB: props.isIB,
 									}),
 									...inspectorTabs.border({
 										props,

--- a/src/components/background-control/backgroundLayersControl.js
+++ b/src/components/background-control/backgroundLayersControl.js
@@ -404,6 +404,7 @@ const BackgroundLayersControl = ({
 	onChangeInline,
 	onChange,
 	clientId,
+	blockAttributes,
 	breakpoint,
 	disableAddLayer,
 	getBounds,
@@ -414,6 +415,10 @@ const BackgroundLayersControl = ({
 	const layers = cloneDeep(layersOptions);
 	const layersHover = cloneDeep(layersHoverOptions);
 	const allLayers = [...layers, ...layersHover];
+	const normalLayersSource =
+		isIB && blockAttributes?.['background-layers']
+			? blockAttributes['background-layers']
+			: layers;
 
 	const getLayerUniqueParameter = (parameter, layers = allLayers) =>
 		layers && !isEmpty(layers)
@@ -514,11 +519,14 @@ const BackgroundLayersControl = ({
 					<ListControl onListItemsDrag={onLayersDrag}>
 						{[...(!isHover ? layers : allLayers)].map(layer => {
 							const normalLayer = layer.isHover
-								? layers.find(
-										normalLayer =>
-											normalLayer.order === layer.order &&
-											!normalLayer.isHover
-								  )
+								? normalLayersSource.find(normalLayer => {
+										if (normalLayer.isHover) return false;
+										if (normalLayer.id && layer.id)
+											return normalLayer.id === layer.id;
+										return (
+											normalLayer.order === layer.order
+										);
+								  })
 								: null;
 
 							return (

--- a/src/components/background-control/backgroundLayersControl.js
+++ b/src/components/background-control/backgroundLayersControl.js
@@ -54,6 +54,7 @@ const getLayerCardContent = props => {
 		isHover,
 		isIB,
 		layer,
+		normalLayer,
 		onChangeInline = null,
 		onChange,
 		previewRef,
@@ -75,6 +76,7 @@ const getLayerCardContent = props => {
 				<ColorLayer
 					key={`background-color-layer--${layer.order}`}
 					colorOptions={layer}
+					normalLayer={normalLayer}
 					onChangeInline={obj => {
 						previewRef.current.style.background =
 							obj['background-color'];
@@ -511,6 +513,14 @@ const BackgroundLayersControl = ({
 				{!isEmpty(allLayers) && (
 					<ListControl onListItemsDrag={onLayersDrag}>
 						{[...(!isHover ? layers : allLayers)].map(layer => {
+							const normalLayer = layer.isHover
+								? layers.find(
+										normalLayer =>
+											normalLayer.order === layer.order &&
+											!normalLayer.isHover
+								  )
+								: null;
+
 							return (
 								<ListItemControl
 									key={`maxi-background-layers__${
@@ -537,6 +547,7 @@ const BackgroundLayersControl = ({
 										isHover,
 										isIB,
 										layer,
+										normalLayer,
 										onChangeInline,
 										onChange: (rawLayer, target = false) =>
 											onChangeLayer(

--- a/src/components/background-control/backgroundLayersControl.js
+++ b/src/components/background-control/backgroundLayersControl.js
@@ -521,6 +521,8 @@ const BackgroundLayersControl = ({
 							const normalLayer = layer.isHover
 								? normalLayersSource.find(normalLayer => {
 										if (normalLayer.isHover) return false;
+										if (normalLayer.sid && layer.sid)
+											return normalLayer.sid === layer.sid;
 										if (normalLayer.id && layer.id)
 											return normalLayer.id === layer.id;
 										return (

--- a/src/components/background-control/blockBackgroundControl.js
+++ b/src/components/background-control/blockBackgroundControl.js
@@ -27,6 +27,7 @@ const BlockBackgroundControl = props => {
 		isIB = false,
 		prefix = '',
 		clientId,
+		blockAttributes,
 		breakpoint = 'general',
 		disableImage = false,
 		disableVideo = false,
@@ -72,6 +73,7 @@ const BlockBackgroundControl = props => {
 				isHover={isHover}
 				isIB={isIB}
 				prefix={prefix}
+				blockAttributes={blockAttributes}
 				disableImage={disableImage}
 				disableVideo={disableVideo}
 				disableGradient={disableGradient}

--- a/src/components/background-control/colorLayer.js
+++ b/src/components/background-control/colorLayer.js
@@ -37,6 +37,7 @@ const ColorLayer = props => {
 		disableClipPath,
 		isHover = false,
 		isIB = false,
+		normalLayer,
 		prefix = '',
 		clientId,
 		breakpoint,
@@ -147,35 +148,35 @@ const ColorLayer = props => {
 		};
 	};
 
-	const getNormalAttr = () => ({
+	const getNormalAttr = (attributesSource = colorOptions) => ({
 		paletteStatus: getLastBreakpointAttribute({
 			target: `${prefix}background-palette-status`,
 			breakpoint,
-			attributes: colorOptions,
+			attributes: attributesSource,
 			isHover: false,
 		}),
 		paletteSCStatus: getLastBreakpointAttribute({
 			target: `${prefix}background-palette-sc-status`,
 			breakpoint,
-			attributes: colorOptions,
+			attributes: attributesSource,
 			isHover: false,
 		}),
 		paletteColor: getLastBreakpointAttribute({
 			target: `${prefix}background-palette-color`,
 			breakpoint,
-			attributes: colorOptions,
+			attributes: attributesSource,
 			isHover: false,
 		}),
 		paletteOpacity: getLastBreakpointAttribute({
 			target: `${prefix}background-palette-opacity`,
 			breakpoint,
-			attributes: colorOptions,
+			attributes: attributesSource,
 			isHover: false,
 		}),
 		color: getLastBreakpointAttribute({
 			target: `${prefix}background-color`,
 			breakpoint,
-			attributes: colorOptions,
+			attributes: attributesSource,
 			isHover: false,
 		}),
 	});
@@ -189,7 +190,7 @@ const ColorLayer = props => {
 		color,
 	}) => {
 		if (isHover) {
-			const normalColorAttr = getNormalAttr();
+			const normalColorAttr = getNormalAttr(normalLayer || colorOptions);
 			let resetColor = normalColorAttr.color;
 
 			if (!resetColor && normalColorAttr.paletteColor) {

--- a/src/components/background-control/colorLayer.js
+++ b/src/components/background-control/colorLayer.js
@@ -147,6 +147,39 @@ const ColorLayer = props => {
 		};
 	};
 
+	const getNormalAttr = () => ({
+		paletteStatus: getLastBreakpointAttribute({
+			target: `${prefix}background-palette-status`,
+			breakpoint,
+			attributes: colorOptions,
+			isHover: false,
+		}),
+		paletteSCStatus: getLastBreakpointAttribute({
+			target: `${prefix}background-palette-sc-status`,
+			breakpoint,
+			attributes: colorOptions,
+			isHover: false,
+		}),
+		paletteColor: getLastBreakpointAttribute({
+			target: `${prefix}background-palette-color`,
+			breakpoint,
+			attributes: colorOptions,
+			isHover: false,
+		}),
+		paletteOpacity: getLastBreakpointAttribute({
+			target: `${prefix}background-palette-opacity`,
+			breakpoint,
+			attributes: colorOptions,
+			isHover: false,
+		}),
+		color: getLastBreakpointAttribute({
+			target: `${prefix}background-color`,
+			breakpoint,
+			attributes: colorOptions,
+			isHover: false,
+		}),
+	});
+
 	const onReset = ({
 		showPalette = false,
 		paletteStatus,
@@ -155,6 +188,33 @@ const ColorLayer = props => {
 		paletteOpacity,
 		color,
 	}) => {
+		if (isHover) {
+			const normalColorAttr = getNormalAttr();
+			let resetColor = normalColorAttr.color;
+
+			if (!resetColor && normalColorAttr.paletteColor) {
+				const paletteColorResult = getPaletteColor({
+					clientId,
+					color: normalColorAttr.paletteColor,
+					blockStyle: getBlockStyle(clientId),
+				});
+
+				resetColor = `rgba(${paletteColorResult},${
+					normalColorAttr.paletteOpacity || 1
+				})`;
+			}
+
+			onChangeColor({
+				paletteStatus: normalColorAttr.paletteStatus,
+				paletteSCStatus: normalColorAttr.paletteSCStatus,
+				paletteColor: normalColorAttr.paletteColor,
+				paletteOpacity: normalColorAttr.paletteOpacity || 1,
+				color: resetColor,
+			});
+
+			return;
+		}
+
 		const defaultColorAttr = getDefaultAttr();
 
 		if (showPalette)

--- a/src/components/inspector-tabs/inspector-block-background.js
+++ b/src/components/inspector-tabs/inspector-block-background.js
@@ -58,6 +58,7 @@ const blockBackground = ({
 									maxiSetAttributes(obj);
 									if (target) cleanInlineStyles(target);
 								}}
+								blockAttributes={attributes}
 								clientId={clientId}
 								breakpoint={deviceType}
 								disableImage={disableImage}
@@ -98,6 +99,7 @@ const blockBackground = ({
 										)}
 										onChange={obj => maxiSetAttributes(obj)}
 										isHover
+										blockAttributes={attributes}
 										clientId={clientId}
 										breakpoint={deviceType}
 										getBounds={getBounds}

--- a/src/components/inspector-tabs/inspector-block-background.js
+++ b/src/components/inspector-tabs/inspector-block-background.js
@@ -28,6 +28,7 @@ const blockBackground = ({
 		attributes,
 		clientId,
 		deviceType,
+		isIB,
 		maxiSetAttributes,
 		insertInlineStyles,
 		cleanInlineStyles,
@@ -59,6 +60,7 @@ const blockBackground = ({
 									if (target) cleanInlineStyles(target);
 								}}
 								blockAttributes={attributes}
+								isIB={isIB}
 								clientId={clientId}
 								breakpoint={deviceType}
 								disableImage={disableImage}
@@ -100,6 +102,7 @@ const blockBackground = ({
 										onChange={obj => maxiSetAttributes(obj)}
 										isHover
 										blockAttributes={attributes}
+										isIB={isIB}
 										clientId={clientId}
 										breakpoint={deviceType}
 										getBounds={getBounds}


### PR DESCRIPTION
### Motivation
- Resetting a background colour in the hover state was restoring an incorrect palette value instead of the normal-state colour.
- Hover reset should restore the same palette/custom colour and opacity that is set on the normal state for the same breakpoint.
- This addresses incorrect behaviour when a non-first palette colour or a custom colour was selected on the normal state.

### Description
- Added a `getNormalAttr` helper that reads normal-state colour/palette values via `getLastBreakpointAttribute`.
- Updated `onReset` to handle `isHover` by retrieving normal attributes and computing a palette fallback with `getPaletteColor`, then calling `onChangeColor` with those values.
- Preserved existing reset behaviour for non-hover resets and layer/default handling.
- Modified file: `src/components/background-control/colorLayer.js`.

### Testing
- No automated tests were run for this change.
- Manual verification steps were used during development (reset hover background should now match normal state).

------
Fixes https://github.com/maxi-blocks/maxi-blocks/issues/5783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hover reset reliably restores the base (non‑hover) color, palette settings, and opacity when reverting from hover.

* **New Features**
  * Hover layers now reference their corresponding base (non‑hover) layer data to ensure consistent rollbacks.
  * Layer controls and inspector panels now accept block-level background data and an inspector context flag for consistent mapping and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->