### PR TITLE
Remove custom select chevron styling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
 		"editor.formatOnSave": true
 	},
 	"[scss]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
+		"editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
 	},
 	"eslint.alwaysShowStatus": true,
 	"prettier.tabWidth": 4,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
 		"editor.formatOnSave": true
 	},
 	"[scss]": {
-		"editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
 	"eslint.alwaysShowStatus": true,
 	"prettier.tabWidth": 4,

--- a/src/components/accordion-control/editor.scss
+++ b/src/components/accordion-control/editor.scss
@@ -10,7 +10,8 @@
 		&[data-name='box shadow'],
 		&[data-name='icon'],
 		&[data-name='border'],
-		&[data-name='active icon'] {
+		&[data-name='active icon'],
+		&[data-name='clip path'] {
 			.maxi-accordion-control__item__panel {
 				padding: 0;
 			}
@@ -137,7 +138,7 @@
 	.maxi-accordion-control__item__button.maxi-accordion-control__item--active {
 		color: var(--maxi-interaction-pink) !important;
 		font-weight: 700 !important;
-		
+
 		&:before {
 			background-color: var(--maxi-interaction-pink) !important;
 		}
@@ -149,7 +150,7 @@
 	.maxi-accordion-control__item__button.maxi-accordion-control__item--active {
 		color: var(--maxi-background-yellow) !important;
 		font-weight: 700 !important;
-		
+
 		&:before {
 			background-color: var(--maxi-background-yellow) !important;
 		}

--- a/src/components/advanced-number-control/editor.scss
+++ b/src/components/advanced-number-control/editor.scss
@@ -34,7 +34,7 @@
 	&__input-wrapper {
 		position: relative;
 		flex: none;
-		width: 55px !important;
+		width: 70px !important;
 
 		// Focus state (Keyboard Accessibility)
 		&:focus-within {

--- a/src/components/advanced-number-control/editor.scss
+++ b/src/components/advanced-number-control/editor.scss
@@ -47,6 +47,7 @@
 		height: 36px;
 		padding: 0 5px 0 4px !important;
 		z-index: 0;
+		max-width: 60px;
 
 		// Browser Spinner Hides
 		&::-webkit-outer-spin-button,

--- a/src/components/aspect-ratio-control/editor.scss
+++ b/src/components/aspect-ratio-control/editor.scss
@@ -1,0 +1,11 @@
+.maxi-aspect-ratio-control__custom-value {
+	.maxi-advanced-number-control__controls-group {
+		width: 100% !important;
+	}
+	.maxi-advanced-number-control__input-wrapper {
+		width: 94% !important;
+	}
+	.maxi-advanced-number-control__value {
+		max-width: 92% !important;
+	}
+}

--- a/src/components/aspect-ratio-control/index.js
+++ b/src/components/aspect-ratio-control/index.js
@@ -10,6 +10,11 @@ import AdvancedNumberControl from '@components/advanced-number-control';
 import SelectControl from '@components/select-control';
 import { convertAspectRatioToDecimal } from '@extensions/styles';
 
+/**
+ * Styles
+ */
+import './editor.scss';
+
 const AspectRatioControl = ({
 	additionalOptions,
 	customValue,
@@ -53,6 +58,7 @@ const AspectRatioControl = ({
 		{props.value === 'custom' && (
 			<>
 				<AdvancedNumberControl
+					className='maxi-aspect-ratio-control__custom-value'
 					newStyle
 					value={customValue}
 					min={0}

--- a/src/components/clip-path-control/editor.scss
+++ b/src/components/clip-path-control/editor.scss
@@ -1,8 +1,3 @@
-// Remove padding from accordion panel for clip-path control
-.maxi-accordion-control__item__panel:not(.maxi-accordion-control__item__panel--disable-padding):has(.maxi-clip-path-control__wrapper) {
-	padding: 0;
-}
-
 .maxi-clip-path-mode-control {
 	.maxi-tabs-control__button {
 		&:first-child {
@@ -81,6 +76,10 @@
 				fill: var(--maxi-grey-light);
 			}
 		}
+	}
+
+	&__wrapper {
+		padding-top: 6px;
 	}
 
 	.maxi-clip-path-controller {

--- a/src/components/inspector-tabs/inspector-clip-path.js
+++ b/src/components/inspector-tabs/inspector-clip-path.js
@@ -113,6 +113,7 @@ const clipPath = ({ props, selector, prefix = '' }) => {
 						),
 					},
 				]}
+				contentClassName='maxi-clip-path-tabs-content'
 			/>
 		),
 	};

--- a/src/components/select-control/editor.scss
+++ b/src/components/select-control/editor.scss
@@ -31,12 +31,7 @@ body.maxi-blocks--active {
 	// Consolidate hover rule to avoid empty ruleset warning
 	.maxi-select-control__input:hover,
 	.maxi-text-control__input:hover {
-		/* Intentionally left for future hover tweaks; keep non-empty to satisfy linter */
 		outline: none;
-	}
-	.maxi-select-control__input:focus,
-	.maxi-text-control__input:focus {
-		border-color: transparent !important;
 	}
 	.maxi-option {
 		&__in-use {
@@ -89,7 +84,6 @@ body.maxi-blocks--active {
 			&:not(.maxi-dc-type):not(.maxi-dc-field):not(.maxi-context-loop-control__type)
 				#inspector-select-control-4.maxi-select-control__input {
 				flex: 0 0 auto !important;
-				width: 104px !important;
 				height: 36px !important;
 				line-height: 36px !important;
 				padding-top: 0 !important;

--- a/src/components/select-control/editor.scss
+++ b/src/components/select-control/editor.scss
@@ -14,29 +14,13 @@ body.maxi-blocks--active {
 		font-size: 12px;
 		line-height: 14px;
 		vertical-align: middle;
-		-webkit-appearance: none;
-		appearance: none;
+		-webkit-appearance: auto;
+		appearance: auto;
 		-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 		cursor: pointer;
 		opacity: 1;
 		outline: 0;
-		background-image: linear-gradient(
-				var(--maxi-grey-light),
-				var(--maxi-grey-light)
-			),
-			url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(180, 180, 180, 0.9)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
-		background-repeat: no-repeat, no-repeat !important;
-		background-size: 1px 18px, 8px 8px !important;
-		background-position: right 1px center, right 5px center !important;
-		&:hover,
-		&:focus,
-		&:active {
-			background-image: linear-gradient(
-					var(--maxi-grey-light),
-					var(--maxi-grey-light)
-				),
-				url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(99, 186, 121, 1)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
-		}
+		background-image: none !important;
 		svg {
 			fill: var(--maxi-grey);
 		}
@@ -94,25 +78,8 @@ body.maxi-blocks--active {
 			.maxi-select-control__input {
 				padding: 10px 11px;
 				border: none !important;
-				/* Short right divider + chevron */
 				background-color: var(--maxi-white) !important;
-				background-image: linear-gradient(
-						var(--maxi-grey-light),
-						var(--maxi-grey-light)
-					),
-					url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(180, 180, 180, 0.9)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
-				background-repeat: no-repeat, no-repeat !important;
-				background-size: 1px 18px, 8px 8px !important;
-				background-position: right 1px center, right 5px center !important;
-				&:hover,
-				&:focus,
-				&:active {
-					background-image: linear-gradient(
-							var(--maxi-grey-light),
-							var(--maxi-grey-light)
-						),
-						url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"> <path fill="rgba(99, 186, 121, 1)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/> </svg>') !important;
-				}
+				background-image: none !important;
 			}
 			#inspector-select-control-5 {
 				border: none !important;

--- a/src/components/select-control/editor.scss
+++ b/src/components/select-control/editor.scss
@@ -10,7 +10,6 @@ body.maxi-blocks--active {
 		border: 1.5px solid var(--maxi-grey-light);
 		margin: 0;
 		color: var(--maxi-grey);
-		background-size: 9px 9px;
 		font-size: 12px;
 		line-height: 14px;
 		vertical-align: middle;
@@ -37,7 +36,7 @@ body.maxi-blocks--active {
 	}
 	.maxi-select-control__input:focus,
 	.maxi-text-control__input:focus {
-		border-color: none !important;
+		border-color: transparent !important;
 	}
 	.maxi-option {
 		&__in-use {

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -247,8 +247,7 @@
 					padding-top: 0;
 				}
 
-				.maxi-tabs-control--disable-padding
-					+ .maxi-responsive-tabs-control {
+				.maxi-tabs-control--disable-padding + .maxi-responsive-tabs-control {
 			margin-top: -6px;
 		}
 

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -229,7 +229,7 @@
 
 	.maxi-tabs-content {
 		&:not(.maxi-tabs-content--disable-padding) {
-			padding: 0px 8px 0px;
+			padding: 0;
 			background-color: var(--maxi-white);
 		}
 

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -253,6 +253,11 @@
 				border-bottom: 1.5px solid var(--maxi-grey-light);
 				background-color: var(--maxi-white);
 
+				.maxi-tabs-control {
+					margin-left: -8px;
+					margin-right: -8px;
+				}
+
 				&:after {
 					content: '';
 					position: absolute;

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -239,11 +239,12 @@
 		}
 
 		&.maxi-clip-path-tabs-content {
-			padding-left: 0;
-			padding-right: 0;
+			// padding-left: 0;
+			// padding-right: 0;
 
-			.maxi-tabs-control + .maxi-responsive-tabs-control {
-				margin-top: -6px;
+			// Hide the empty tabs content inside responsive tabs control
+			.maxi-responsive-tabs-control > .maxi-tabs-content {
+				display: none;
 			}
 		}
 
@@ -252,11 +253,11 @@
 			margin-right: -8px;
 		}
 
-				&:has(.maxi-tabs-control--disable-padding) {
-					padding-top: 0;
-				}
+		&:has(.maxi-tabs-control--disable-padding) {
+			padding-top: 0;
+		}
 
-				.maxi-tabs-control--disable-padding + .maxi-responsive-tabs-control {
+		.maxi-tabs-control--disable-padding + .maxi-responsive-tabs-control {
 			margin-top: -6px;
 		}
 

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -51,8 +51,8 @@
 		padding-top: 0;
 
 		&--disable-padding {
-			margin-left: -8px;
-			margin-right: -8px;
+			padding-left: 8px;
+			padding-right: 8px;
 		}
 
 		&--nested {
@@ -234,7 +234,7 @@
 
 	.maxi-tabs-content {
 		&:not(.maxi-tabs-content--disable-padding) {
-			padding: 0;
+			padding: 0 8px;
 			background-color: var(--maxi-white);
 		}
 
@@ -257,11 +257,6 @@
 				border-top: 1.5px solid var(--maxi-grey-light);
 				border-bottom: 1.5px solid var(--maxi-grey-light);
 				background-color: var(--maxi-white);
-
-				.maxi-tabs-control {
-					margin-left: -8px;
-					margin-right: -8px;
-				}
 
 				&:after {
 					content: '';

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -238,6 +238,15 @@
 			background-color: var(--maxi-white);
 		}
 
+		&.maxi-clip-path-tabs-content {
+			padding-left: 0;
+			padding-right: 0;
+
+			.maxi-tabs-control + .maxi-responsive-tabs-control {
+				margin-top: -6px;
+			}
+		}
+
 		.maxi-tabs-control--disable-padding {
 			margin-left: -8px;
 			margin-right: -8px;

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -50,6 +50,11 @@
 		display: flex;
 		padding-top: 0;
 
+		&--disable-padding {
+			margin-left: -8px;
+			margin-right: -8px;
+		}
+
 		&--nested {
 			padding: 8px 8px 0;
 			margin-bottom: -18px;

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -243,6 +243,10 @@
 			margin-right: -8px;
 		}
 
+		.maxi-tabs-control + .maxi-responsive-tabs-control {
+			margin-top: -6px;
+		}
+
 		&--nested {
 			background: var(--maxi-white);
 			border: 1.5px solid var(--maxi-secondary-color);

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -243,7 +243,8 @@
 			margin-right: -8px;
 		}
 
-		.maxi-tabs-control + .maxi-responsive-tabs-control {
+				.maxi-tabs-control--disable-padding
+					+ .maxi-responsive-tabs-control {
 			margin-top: -6px;
 		}
 

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -243,6 +243,10 @@
 			margin-right: -8px;
 		}
 
+				&:has(.maxi-tabs-control--disable-padding) {
+					padding-top: 0;
+				}
+
 				.maxi-tabs-control--disable-padding
 					+ .maxi-responsive-tabs-control {
 			margin-top: -6px;

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -238,6 +238,11 @@
 			background-color: var(--maxi-white);
 		}
 
+		.maxi-tabs-control--disable-padding {
+			margin-left: -8px;
+			margin-right: -8px;
+		}
+
 		&--nested {
 			background: var(--maxi-white);
 			border: 1.5px solid var(--maxi-secondary-color);

--- a/src/components/setting-tabs-control/editor.scss
+++ b/src/components/setting-tabs-control/editor.scss
@@ -51,8 +51,8 @@
 		padding-top: 0;
 
 		&--disable-padding {
-			padding-left: 8px;
-			padding-right: 8px;
+			padding-left: 0;
+			padding-right: 0;
 		}
 
 		&--nested {
@@ -234,7 +234,7 @@
 
 	.maxi-tabs-content {
 		&:not(.maxi-tabs-content--disable-padding) {
-			padding: 0 8px;
+			padding: 6px 8px 0;
 			background-color: var(--maxi-white);
 		}
 

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -10,6 +10,7 @@
 	--typography-button-transition: all 200ms ease;
 	--typography-interactive-border: 1px solid var(--maxi-grey-light);
 	--typography-button-radius: 4px;
+	--typography-chevron-icon: url('data:image/svg+xml; utf8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 6"><path fill="rgb(147, 147, 147)" d="M4.82 5.783a.963.963 0 0 1-.684-.283L.283 1.651A.967.967 0 0 1 1.651.283L4.82 3.462 7.988.293a.963.963 0 0 1 1.358 1.358L5.494 5.5a.963.963 0 0 1-.674.283Z"/></svg>');
 
 	/*-------------------------------------------
 	 SHARED COMPONENT PATTERNS
@@ -113,6 +114,16 @@
 		}
 	}
 
+	.maxi-select-control__input {
+		-webkit-appearance: none;
+		appearance: none;
+		background-image: var(--typography-chevron-icon) !important;
+		background-repeat: no-repeat !important;
+		background-size: 10px 6px !important;
+		background-position: right 10px center !important;
+		padding-right: 26px !important;
+	}
+
 	/*-------------------------------------------
 	 WEIGHT & SIZE ROW LAYOUT
 	-------------------------------------------*/
@@ -174,7 +185,7 @@
 	.maxi-typography-control__weight {
 		.maxi-select-control__input {
 			padding-left: 5px !important;
-			padding-right: 19px !important;
+			padding-right: 26px !important;
 			height: 36px !important;
 			min-height: 36px !important;
 			font-size: 11px !important;
@@ -293,15 +304,6 @@
 	/*-------------------------------------------
 	 ADVANCED CONTROLS & ANIMATIONS
 	-------------------------------------------*/
-	.maxi-typography-control__toggle-arrow {
-		transition: transform 200ms ease;
-		transform: rotate(0);
-
-		&--expanded {
-			transform: rotate(180deg);
-		}
-	}
-
 	.maxi-typography-control-button {
 		@extend %flex-center-pattern;
 		justify-content: space-between;
@@ -315,7 +317,18 @@
 	}
 
 	.maxi-typography-control-arrow-span {
+		display: inline-block;
+		width: 10px;
+		height: 6px;
+		margin-left: 8px;
+		background-image: var(--typography-chevron-icon);
+		background-repeat: no-repeat;
+		background-size: 10px 6px;
 		transition: transform 300ms ease;
+
+		&.maxi-typography-control__toggle-arrow--expanded {
+			transform: rotate(180deg);
+		}
 	}
 
 	.maxi-typography-control__advanced-options {

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -130,7 +130,7 @@
 	.maxi-typography-control__weight-size-row {
 		display: flex;
 		flex-wrap: nowrap; /* Change from wrap to nowrap */
-		gap: 10px;
+		gap: 8px;
 		width: 100%;
 		align-items: stretch;
 
@@ -161,6 +161,9 @@
 			width: 265px !important;
 			margin-bottom: 10px !important;
 		}
+		.maxi-advanced-number-control__input-wrapper {
+			width: 50px !important;
+		}
 	}
 
 	/*-------------------------------------------
@@ -185,7 +188,7 @@
 	.maxi-typography-control__weight {
 		.maxi-select-control__input {
 			padding-left: 5px !important;
-			padding-right: 26px !important;
+			padding-right: 10px !important;
 			height: 36px !important;
 			min-height: 36px !important;
 			font-size: 11px !important;
@@ -211,7 +214,7 @@
 		}
 
 		.maxi-typography-control__line-height {
-			margin-right: 10px !important;
+			margin-right: 8px !important;
 		}
 
 		.maxi-base-control__field {
@@ -220,6 +223,9 @@
 
 		.maxi-base-control__label {
 			@extend %floating-label;
+		}
+		.maxi-advanced-number-control__input-wrapper {
+			width: 50px !important;
 		}
 	}
 

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -121,12 +121,16 @@
 		flex-wrap: nowrap; /* Change from wrap to nowrap */
 		gap: 10px;
 		width: 100%;
-		align-items: flex-end; /* Align items to the bottom */
+		align-items: stretch;
 
 		> div {
 			flex: 1 1 auto; /* Allow items to grow and shrink */
 			position: relative;
 			width: auto !important; /* Remove fixed width */
+		}
+
+		.maxi-base-control__field {
+			align-items: stretch !important;
 		}
 
 		&:has(.maxi-typography-control__weight-warning) {
@@ -171,6 +175,8 @@
 		.maxi-select-control__input {
 			padding-left: 5px !important;
 			padding-right: 19px !important;
+			height: 36px !important;
+			min-height: 36px !important;
 			font-size: 11px !important;
 		}
 	}

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -161,9 +161,6 @@
 			width: 265px !important;
 			margin-bottom: 10px !important;
 		}
-		.maxi-advanced-number-control__input-wrapper {
-			width: 50px !important;
-		}
 	}
 
 	/*-------------------------------------------
@@ -223,9 +220,6 @@
 
 		.maxi-base-control__label {
 			@extend %floating-label;
-		}
-		.maxi-advanced-number-control__input-wrapper {
-			width: 50px !important;
 		}
 	}
 
@@ -421,4 +415,10 @@
 ===============================================*/
 .maxi-link-settings-panel {
 	padding: 0px 8px;
+}
+
+.maxi-typography-control:not([class*='maxi-style-cards-control']) {
+	.maxi-advanced-number-control__input-wrapper {
+		width: 50px !important;
+	}
 }

--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -1327,9 +1327,8 @@ const TypographyControl = props => {
 											? 'maxi-typography-control__toggle-arrow--expanded'
 											: ''
 									}`}
-								>
-									▼
-								</span>
+									aria-hidden='true'
+								/>
 							</Button>
 						</div>
 

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -19,7 +19,7 @@ $breakpoints: (
 	'xs': 347px,
 	'sm': 768px,
 	'md': 782px,
-	'xxl': 2500px
+	'xxl': 2500px,
 );
 
 @mixin flex-center {
@@ -31,14 +31,20 @@ $breakpoints: (
 @mixin respond-to($breakpoint) {
 	$width: map-get($breakpoints, $breakpoint);
 	@if $breakpoint == 'xxl' {
-		@media only screen and (min-width: $width) { @content; }
+		@media only screen and (min-width: $width) {
+			@content;
+		}
 	} @else {
-		@media only screen and (max-width: $width) { @content; }
+		@media only screen and (max-width: $width) {
+			@content;
+		}
 	}
 }
 
 @mixin rtl {
-	html[dir='rtl'] & { @content; }
+	html[dir='rtl'] & {
+		@content;
+	}
 }
 
 @mixin control-row {
@@ -67,7 +73,7 @@ $breakpoints: (
 	background-color: $white;
 	cursor: pointer;
 	transition: $transition-fast;
-	
+
 	&:hover {
 		background: $white;
 		border-color: var(--maxi-grey);
@@ -81,7 +87,6 @@ $breakpoints: (
 		opacity: 0.3;
 	}
 }
-
 
 .has-tooltip {
 	.tooltip {
@@ -742,6 +747,10 @@ body .maxi-style-cards__popover {
 		&__size {
 			margin-top: $control-spacing;
 		}
+		.maxi-typography-control__spacing-controls
+			.maxi-typography-control__line-height {
+			margin-right: 10px !important;
+		}
 	}
 	.maxi-toggle-switch {
 		&:last-child {
@@ -829,13 +838,17 @@ body .maxi-style-cards__popover {
 }
 
 @include respond-to('md') {
-	body:not(.is-fullscreen-mode):not(.folded) .maxi-responsive-selector .maxi-style-cards__popover {
+	body:not(.is-fullscreen-mode):not(.folded)
+		.maxi-responsive-selector
+		.maxi-style-cards__popover {
 		margin: 148px 0 0 25px;
 	}
 }
 
 @include respond-to('xs') {
-	.maxi-responsive-selector .maxi-style-cards__popover .components-popover__content {
+	.maxi-responsive-selector
+		.maxi-style-cards__popover
+		.components-popover__content {
 		margin-left: -25px;
 		left: 100%;
 		transform: none;
@@ -941,11 +954,11 @@ html[dir='rtl'] {
 
 	.maxi-tabs-content {
 		padding: 0;
-		
+
 		.maxi-tab-content__box {
 			padding: 0;
 			border: none;
-			
+
 			&:after {
 				display: none;
 			}
@@ -956,7 +969,7 @@ html[dir='rtl'] {
 // Fix z-index for font-family dropdown menu in style cards
 // React-select can portal menu to body, so we need a global rule
 // Scoped to maxi-blocks context to avoid affecting other libraries
-body.maxi-blocks--active [class*="menu"][class*="css-"],
-.maxi-style-cards__popover [class*="menu"][class*="css-"] {
+body.maxi-blocks--active [class*='menu'][class*='css-'],
+.maxi-style-cards__popover [class*='menu'][class*='css-'] {
 	z-index: 100 !important;
 }


### PR DESCRIPTION
### Motivation
- The embedded SVG chevrons and custom dropdown divider constrained native select rendering and prevented flexible, stretchable controls.
- Letting the platform/browser render the dropdown arrow improves sizing and accessibility for different UI contexts.

### Description
- Updated `src/components/select-control/editor.scss` to change `-webkit-appearance`/`appearance` from `none` to `auto` so native styling is allowed.
- Removed inline `data:image/svg+xml` background chevrons by replacing the custom `background-image` rules with `background-image: none !important` for the main select and the `.maxi-select-control__input` second-style.
- Preserved existing layout, padding, and scoped width rules (including the font-weight selector width rule) so spacing and behavior remain consistent.

### Testing
- No automated tests were run for this change.

------
fixes https://github.com/maxi-blocks/maxi-blocks/issues/6154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed custom decorative dropdown backgrounds and restored native select appearance; refined paddings, heights and alignment for consistent layout.
  * Introduced an icon-based chevron for typography controls (rotates when expanded) and replaced the visible glyph with an accessibility-friendly, non-rendered element.
  * Minor spacing and formatting tweaks across editor styles.

* **New Features**
  * Added a modifier to disable side padding for tabs and applied a matching content class for clip-path tabs.
  * Added targeted styling scope for custom aspect-ratio inputs.

* **Chores**
  * Increased numeric input wrapper widths for improved usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->