### PR TITLE
Fix deprecated block API versions

### DIFF
--- a/core/blocks/class-maxi-block.php
+++ b/core/blocks/class-maxi-block.php
@@ -257,6 +257,13 @@ if (!class_exists('MaxiBlocks_Block')):
             // Construct the file path
             $file_path = MAXI_PLUGIN_DIR_PATH . 'build/blocks/' . $this->block_name . '/block.json';
 
+            $basic_config = [
+                'api_version' => 3,
+                'editor_script' => 'maxi-blocks-block-editor',
+                'editor_style' => 'maxi-blocks-block-editor',
+                'render_callback' => [$this, 'render_block'],
+            ];
+
             // First try direct file reading
             if (file_exists($file_path) && is_readable($file_path)) {
                 $file_contents = file_get_contents($file_path);
@@ -266,12 +273,6 @@ if (!class_exists('MaxiBlocks_Block')):
                     if ($block_json === null) {
                         return false; // Handle JSON decoding error
                     }
-
-                    $basic_config = [
-                        'api_version' => 3,
-                        'editor_script' => 'maxi-blocks-block-editor',
-                        'render_callback' => [$this, 'render_block'],
-                    ];
 
                     // Add dynamic content attributes to dynamic blocks
                     $config = in_array($this->block_name, $this->dynamic_blocks)
@@ -309,12 +310,6 @@ if (!class_exists('MaxiBlocks_Block')):
                             return false;
                         }
 
-                        $basic_config = [
-                            'api_version' => 3,
-                            'editor_script' => 'maxi-blocks-block-editor',
-                            'render_callback' => [$this, 'render_block'],
-                        ];
-
                         $config = in_array($this->block_name, $this->dynamic_blocks)
                             ? array_merge($basic_config, [
                                 'attributes' => self::$dynamic_content_attributes,
@@ -345,12 +340,6 @@ if (!class_exists('MaxiBlocks_Block')):
             if ($block_json === null) {
                 return false;
             }
-
-            $basic_config = [
-                'api_version' => 3,
-                'editor_script' => 'maxi-blocks-block-editor',
-                'render_callback' => [$this, 'render_block'],
-            ];
 
             $config = in_array($this->block_name, $this->dynamic_blocks)
                 ? array_merge($basic_config, [

--- a/core/blocks/class-maxi-block.php
+++ b/core/blocks/class-maxi-block.php
@@ -268,7 +268,7 @@ if (!class_exists('MaxiBlocks_Block')):
                     }
 
                     $basic_config = [
-                        'api_version' => 2,
+                        'api_version' => 3,
                         'editor_script' => 'maxi-blocks-block-editor',
                         'render_callback' => [$this, 'render_block'],
                     ];
@@ -310,7 +310,7 @@ if (!class_exists('MaxiBlocks_Block')):
                         }
 
                         $basic_config = [
-                            'api_version' => 2,
+                            'api_version' => 3,
                             'editor_script' => 'maxi-blocks-block-editor',
                             'render_callback' => [$this, 'render_block'],
                         ];
@@ -347,7 +347,7 @@ if (!class_exists('MaxiBlocks_Block')):
             }
 
             $basic_config = [
-                'api_version' => 2,
+                'api_version' => 3,
                 'editor_script' => 'maxi-blocks-block-editor',
                 'render_callback' => [$this, 'render_block'],
             ];

--- a/core/class-maxi-core.php
+++ b/core/class-maxi-core.php
@@ -46,8 +46,16 @@ if (!class_exists('MaxiBlocks_Core')):
                 99,
             );
 
-            // Add fonts for the editor
-            add_action('enqueue_block_editor_assets', function () {
+            // Add fonts and editor-only CSS for both iframe and non-iframe editors
+            add_action('enqueue_block_assets', function () {
+                if (
+                    !is_admin() &&
+                    (!function_exists('wp_should_load_block_editor_scripts_and_styles') ||
+                        !wp_should_load_block_editor_scripts_and_styles())
+                ) {
+                    return;
+                }
+
                 wp_enqueue_style('maxi-blocks-editor-font', esc_url(MAXI_PLUGIN_URL_PATH) . 'core/admin/fonts/inter/style.css');
 
                 // Add inline CSS to hide resizable handles in Site Editor if option is enabled

--- a/core/class-maxi-core.php
+++ b/core/class-maxi-core.php
@@ -46,13 +46,9 @@ if (!class_exists('MaxiBlocks_Core')):
                 99,
             );
 
-            // Add fonts and editor-only CSS for both iframe and non-iframe editors
+            // Add fonts for the editor.
             add_action('enqueue_block_assets', function () {
-                if (
-                    !is_admin() &&
-                    (!function_exists('wp_should_load_block_editor_scripts_and_styles') ||
-                        !wp_should_load_block_editor_scripts_and_styles())
-                ) {
+                if (!is_admin()) {
                     return;
                 }
 

--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@
  * Author: MaxiBlocks
  * Author URI: https://maxiblocks.com/go/plugin-author
  * Version: 2.1.8
- * Requires at least: 6.2.2
+ * Requires at least: 6.3
  * Requires PHP: 8.0
  * License: GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.txt

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: ckp267, kyrapieterse, svitlana41319, serifkonjevic, olekrut, naaaaiix, rustamsamsonyan, andriivalenia, dashaversha, myroslavv, fitsedivi, maxiblocks
 Tags: block, blocks, gutenberg blocks, page builder, starter sites
 Donate link: https://ko-fi.com/maxiblocks
-Requires at least: 6.2.2
+Requires at least: 6.3
 Tested up to: 6.8
 Requires PHP: 8.0
 Stable tag: 2.1.8

--- a/src/blocks/accordion-maxi/block.json
+++ b/src/blocks/accordion-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/accordion-maxi",
 	"title": "Accordion Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/button-maxi/block.json
+++ b/src/blocks/button-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/button-maxi",
 	"title": "Button Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/cloud-maxi/index.js
+++ b/src/blocks/cloud-maxi/index.js
@@ -21,6 +21,7 @@ import { registerBlockType } from '@wordpress/blocks';
  * Register the Layout block
  */
 registerBlockType('maxi-blocks/maxi-cloud', {
+	apiVersion: 3,
 	title: __('Cloud library Maxi', 'maxi-blocks'),
 	description: __('Find templates or patterns', 'maxi-blocks'),
 	icon: librarySmall,

--- a/src/blocks/column-maxi/block.json
+++ b/src/blocks/column-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/column-maxi",
 	"title": "Column Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/container-maxi/block.json
+++ b/src/blocks/container-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/container-maxi",
 	"title": "Container Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/divider-maxi/block.json
+++ b/src/blocks/divider-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/divider-maxi",
 	"title": "Divider Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/group-maxi/block.json
+++ b/src/blocks/group-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/group-maxi",
 	"title": "Group Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/image-maxi/block.json
+++ b/src/blocks/image-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/image-maxi",
 	"title": "Image Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -55,7 +55,14 @@ const Inspector = props => {
 	const { selectors, categories } = customCss;
 
 	const imageData = useSelect(
-		select => select('core').getEntityRecord('postType', 'attachment', mediaID),
+		select =>
+			mediaID
+				? select('core').getEntityRecord(
+						'postType',
+						'attachment',
+						mediaID
+				  )
+				: null,
 		[mediaID]
 	);
 

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -55,7 +55,7 @@ const Inspector = props => {
 	const { selectors, categories } = customCss;
 
 	const imageData = useSelect(
-		select => select('core').getMedia(mediaID),
+		select => select('core').getEntityRecord('postType', 'attachment', mediaID),
 		[mediaID]
 	);
 

--- a/src/blocks/list-item-maxi/block.json
+++ b/src/blocks/list-item-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/list-item-maxi",
 	"title": "List Item Maxi",
 	"category": "maxi-blocks",
@@ -6077,7 +6077,8 @@
 	"supports": {
 		"align": false,
 		"anchor": false,
-		"html": false
+		"html": false,
+		"splitting": true
 	},
 	"editorScript": "maxi-blocks-block-editor",
 	"customCss": {

--- a/src/blocks/list-item-maxi/edit.js
+++ b/src/blocks/list-item-maxi/edit.js
@@ -22,7 +22,6 @@ import { MaxiBlock, getMaxiBlockAttributes } from '@components/maxi-block';
 import getStyles from './styles';
 import onMerge from '@blocks/text-maxi/utils';
 import {
-	handleSplit,
 	onChangeRichText,
 	processContent,
 	TextContext,
@@ -83,14 +82,6 @@ class edit extends MaxiBlockComponent {
 					typingTimeoutContent => {
 						this.typingTimeoutContent = typingTimeoutContent;
 					}
-				),
-			onSplit: (value, isOriginal) =>
-				handleSplit(
-					value,
-					isOriginal,
-					attributes,
-					clientId,
-					'maxi-blocks/list-item-maxi'
 				),
 			onReplace,
 			onMerge: forward => onMerge(this.props, forward),

--- a/src/blocks/map-maxi/block.json
+++ b/src/blocks/map-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/map-maxi",
 	"title": "Map Maxi (beta)",
 	"category": "maxi-blocks",

--- a/src/blocks/number-counter-maxi/block.json
+++ b/src/blocks/number-counter-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/number-counter-maxi",
 	"title": "Number Counter Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/pane-maxi/block.json
+++ b/src/blocks/pane-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/pane-maxi",
 	"title": "Pane Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/row-maxi/block.json
+++ b/src/blocks/row-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/row-maxi",
 	"title": "Row Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/search-maxi/block.json
+++ b/src/blocks/search-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/search-maxi",
 	"title": "Search Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/slide-maxi/block.json
+++ b/src/blocks/slide-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/slide-maxi",
 	"title": "Slide Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/slider-maxi/block.json
+++ b/src/blocks/slider-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/slider-maxi",
 	"title": "Slider Maxi (beta)",
 	"category": "maxi-blocks",

--- a/src/blocks/slider-maxi/edit.js
+++ b/src/blocks/slider-maxi/edit.js
@@ -59,7 +59,8 @@ const SliderWrapper = props => {
 	const ALLOWED_BLOCKS = ['maxi-blocks/slide-maxi'];
 	const wrapperRef = useRef(null);
 	const iconRef = useRef(null);
-	const editor = document.querySelector('#editor');
+	const editorEl =
+		document.querySelector('.edit-site-visual-editor') || document.body;
 	let initPosition = 0;
 	let dragPosition = 0;
 
@@ -156,8 +157,8 @@ const SliderWrapper = props => {
 			setWrapperTranslate(getSlidePosition(currentSlide));
 		}
 
-		editor.removeEventListener('mousemove', onDragAction);
-		editor.removeEventListener('mouseup', onDragEnd);
+		editorEl.removeEventListener('mousemove', onDragAction);
+		editorEl.removeEventListener('mouseup', onDragEnd);
 	};
 
 	const onDragStart = e => {
@@ -166,8 +167,8 @@ const SliderWrapper = props => {
 			initPosition = e.touches[0].clientX;
 		} else {
 			initPosition = e.clientX;
-			editor.addEventListener('mousemove', onDragAction);
-			editor.addEventListener('mouseup', onDragEnd);
+			editorEl.addEventListener('mousemove', onDragAction);
+			editorEl.addEventListener('mouseup', onDragEnd);
 		}
 		dragPosition = initPosition;
 	};

--- a/src/blocks/slider-maxi/edit.js
+++ b/src/blocks/slider-maxi/edit.js
@@ -59,8 +59,7 @@ const SliderWrapper = props => {
 	const ALLOWED_BLOCKS = ['maxi-blocks/slide-maxi'];
 	const wrapperRef = useRef(null);
 	const iconRef = useRef(null);
-	const editorEl =
-		document.querySelector('.edit-site-visual-editor') || document.body;
+	const getEditorDocument = () => wrapperRef.current?.ownerDocument || document;
 	let initPosition = 0;
 	let dragPosition = 0;
 
@@ -157,8 +156,9 @@ const SliderWrapper = props => {
 			setWrapperTranslate(getSlidePosition(currentSlide));
 		}
 
-		editorEl.removeEventListener('mousemove', onDragAction);
-		editorEl.removeEventListener('mouseup', onDragEnd);
+		const editorDocument = getEditorDocument();
+		editorDocument.removeEventListener('mousemove', onDragAction);
+		editorDocument.removeEventListener('mouseup', onDragEnd);
 	};
 
 	const onDragStart = e => {
@@ -167,8 +167,9 @@ const SliderWrapper = props => {
 			initPosition = e.touches[0].clientX;
 		} else {
 			initPosition = e.clientX;
-			editorEl.addEventListener('mousemove', onDragAction);
-			editorEl.addEventListener('mouseup', onDragEnd);
+			const editorDocument = getEditorDocument();
+			editorDocument.addEventListener('mousemove', onDragAction);
+			editorDocument.addEventListener('mouseup', onDragEnd);
 		}
 		dragPosition = initPosition;
 	};
@@ -261,6 +262,9 @@ const SliderWrapper = props => {
 			slider.removeEventListener('touchstart', onDragStart);
 			slider.removeEventListener('touchmove', onDragAction);
 			slider.removeEventListener('touchend', onDragEnd);
+			const editorDocument = getEditorDocument();
+			editorDocument.removeEventListener('mousemove', onDragAction);
+			editorDocument.removeEventListener('mouseup', onDragEnd);
 		};
 	}, [
 		currentSlide,

--- a/src/blocks/svg-icon-maxi/block.json
+++ b/src/blocks/svg-icon-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/svg-icon-maxi",
 	"title": "Icon Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/text-maxi/block.json
+++ b/src/blocks/text-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/text-maxi",
 	"title": "Text Maxi",
 	"category": "maxi-blocks",

--- a/src/blocks/video-maxi/block.json
+++ b/src/blocks/video-maxi/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "maxi-blocks/video-maxi",
 	"title": "Video Maxi",
 	"category": "maxi-blocks",

--- a/src/components/advanced-number-control/index.js
+++ b/src/components/advanced-number-control/index.js
@@ -555,6 +555,7 @@ const AdvancedNumberControl = props => {
 						withInputField={false}
 						initialPosition={value || initial}
 						__nextHasNoMarginBottom
+						__next40pxDefaultSize
 					/>
 				)}
 			</BaseControl>

--- a/src/components/image-alt-control/index.js
+++ b/src/components/image-alt-control/index.js
@@ -25,15 +25,11 @@ const ImageAltControl = ({
 		select => {
 			const { getEntityRecord } = select('core');
 
-			const mediaData = getEntityRecord('postType', 'attachment', mediaID) ?? {
-				alt_text: { wpAlt: '' },
-				title: { rendered: { titleAlt: '' } },
-			};
-
-			const {
-				alt_text: wpAlt,
-				title: { rendered: titleAlt },
-			} = mediaData;
+			const mediaData = mediaID
+				? getEntityRecord('postType', 'attachment', mediaID)
+				: null;
+			const wpAlt = mediaData?.alt_text ?? '';
+			const titleAlt = mediaData?.title?.rendered ?? '';
 
 			return { wpAlt, titleAlt };
 		},

--- a/src/components/image-alt-control/index.js
+++ b/src/components/image-alt-control/index.js
@@ -23,9 +23,9 @@ const ImageAltControl = ({
 }) => {
 	const { wpAlt, titleAlt } = useSelect(
 		select => {
-			const { getMedia } = select('core');
+			const { getEntityRecord } = select('core');
 
-			const mediaData = getMedia(mediaID) ?? {
+			const mediaData = getEntityRecord('postType', 'attachment', mediaID) ?? {
 				alt_text: { wpAlt: '' },
 				title: { rendered: { titleAlt: '' } },
 			};

--- a/src/components/image-crop-control/index.js
+++ b/src/components/image-crop-control/index.js
@@ -52,10 +52,10 @@ const ImageCropControl = props => {
 
 	const { imageData } = useSelect(
 		select => {
-			const { getMedia } = select('core');
+			const { getEntityRecord } = select('core');
 
 			return {
-				imageData: getMedia(mediaID),
+				imageData: getEntityRecord('postType', 'attachment', mediaID),
 			};
 		},
 		[mediaID]

--- a/src/components/media-uploader-control/index.js
+++ b/src/components/media-uploader-control/index.js
@@ -194,11 +194,11 @@ const MediaUploader = props => {
 };
 
 const MediaUploaderControl = withSelect((select, props) => {
-	const { getMedia } = select('core');
+	const { getEntityRecord } = select('core');
 	const { mediaID } = props;
 
 	return {
-		imageData: mediaID ? getMedia(mediaID) : null,
+		imageData: mediaID ? getEntityRecord('postType', 'attachment', mediaID) : null,
 	};
 })(MediaUploader);
 

--- a/src/extensions/DC/getDCMedia.js
+++ b/src/extensions/DC/getDCMedia.js
@@ -25,10 +25,10 @@ const getAvatar = (user, size) => {
 };
 
 const getMediaById = async (id, type) => {
-	const { getMedia } = resolveSelect('core');
+	const { getEntityRecord } = resolveSelect('core');
 
 	try {
-		const media = await getMedia(id);
+		const media = await getEntityRecord('postType', 'attachment', id);
 		if (isNil(media)) return null;
 
 		return {

--- a/src/extensions/DC/test/getDCMedia.js
+++ b/src/extensions/DC/test/getDCMedia.js
@@ -98,7 +98,7 @@ describe('getDCMedia', () => {
 		getDCEntity.mockResolvedValue(mockPost);
 		getACFFieldContent.mockResolvedValue(mockACFField);
 		resolveSelect.mockImplementation(() => ({
-			getMedia: () => Promise.resolve(mockMedia),
+			getEntityRecord: () => Promise.resolve(mockMedia),
 		}));
 
 		const result = await getDCMedia(
@@ -123,7 +123,7 @@ describe('getDCMedia', () => {
 		getDCEntity.mockResolvedValue(mockProduct);
 		getProductsContent.mockResolvedValue(456);
 		resolveSelect.mockImplementation(() => ({
-			getMedia: () => Promise.resolve(mockMedia),
+			getEntityRecord: () => Promise.resolve(mockMedia),
 		}));
 
 		const result = await getDCMedia(
@@ -147,7 +147,7 @@ describe('getDCMedia', () => {
 
 		getDCEntity.mockResolvedValue(mockPost);
 		resolveSelect.mockImplementation(() => ({
-			getMedia: () => Promise.resolve(mockMedia),
+			getEntityRecord: () => Promise.resolve(mockMedia),
 		}));
 
 		const result = await getDCMedia(
@@ -168,7 +168,7 @@ describe('getDCMedia', () => {
 
 		getDCEntity.mockResolvedValue(mockPost);
 		resolveSelect.mockImplementation(() => ({
-			getMedia: () => Promise.reject(new Error('Media not found')),
+			getEntityRecord: () => Promise.reject(new Error('Media not found')),
 		}));
 
 		const result = await getDCMedia(
@@ -190,7 +190,7 @@ describe('getDCMedia', () => {
 
 		getDCEntity.mockResolvedValueOnce(mockPost);
 		resolveSelect.mockImplementation(() => ({
-			getMedia: () => Promise.resolve(mockMedia),
+			getEntityRecord: () => Promise.resolve(mockMedia),
 		}));
 
 		// First call


### PR DESCRIPTION
Fix deprecated block API versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded many blocks to Block Editor API v3.
  * Switched media/image controls to the modern entity-based media retrieval.
  * Editor assets enqueue behavior adjusted; plugin/readme minimum WordPress version bumped to 6.3.
  * Added an extra sizing hint to the number control.
  * Adjusted list-item split handling and refined slider drag target selection.

* **Tests**
  * Updated tests and mocks to reflect the new media retrieval approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->