### PR TITLE
Fix potential translation issue

### DIFF
--- a/e2e-tests/blocks/map-maxi/index.spec.js
+++ b/e2e-tests/blocks/map-maxi/index.spec.js
@@ -379,7 +379,7 @@ describe('Map Maxi', () => {
 			return tiles.length > 0;
 		});
 		expect(cycleTilesExist).toBe(true);
-	}, 30000);
+	}, 120000);
 
 	it('Map Maxi Custom CSS', async () => {
 		await expect(await addCustomCSS(page)).toMatchSnapshot();

--- a/src/extensions/styles/migrators/opacityTransitionMigrator.js
+++ b/src/extensions/styles/migrators/opacityTransitionMigrator.js
@@ -92,7 +92,7 @@ const migrate = newAttributes => {
 
 	for (const [category, properties] of Object.entries(blockDataTransition)) {
 		for (const name of Object.keys(properties)) {
-			if (name === 'opacity') {
+			if (name === 'opacity' && transition[category]) {
 				transition[category][name] = opacityAttributes;
 			}
 		}


### PR DESCRIPTION
# Description

For automated tests only for now.

The fix adds a transition[category] guard so the migrator skips any category that exists in blockDataTransition but is missing from the block's saved transition object.

The loop iterates over all categories in blockDataTransition (which can have both canvas and block), and if the saved transition is missing any of those categories entirely, transition[category] is undefined.  

The fix already handles this generically — transition[category] is checked before the assignment regardless of which category it is, so both canvas and block (and any future category) are covered.                                                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Opacity transitions now only apply when the matching data category is present, preventing incorrect visual transitions.
* **Tests**
  * Increased end-to-end test timeout for map tile/type scenarios to reduce flakiness in slow environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->