### PR TITLE
Optimize breakpoint style cache updates

### DIFF
--- a/src/components/block-inserter/index.js
+++ b/src/components/block-inserter/index.js
@@ -4,7 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { ButtonBlockAppender, Inserter } from '@wordpress/block-editor';
 import { select, useDispatch, useSelect } from '@wordpress/data';
-import { forwardRef, useContext, useRef, useState } from '@wordpress/element';
+import {
+	forwardRef,
+	memo,
+	useContext,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { Tooltip } from '@wordpress/components';
 
 /**
@@ -18,6 +24,7 @@ import Button from '@components/button';
 import Dropdown from '@components/dropdown';
 import Popover from '@components/popover';
 import RepeaterContext from '@blocks/row-maxi/repeaterContext';
+import { countProfile } from '@extensions/performance/profiler';
 
 /**
  * Styles
@@ -33,7 +40,7 @@ const WRAPPER_BLOCKS = [
 	'maxi-blocks/slide-maxi',
 ];
 
-const BlockInserter = props => {
+const BlockInserter = memo(props => {
 	const { className, clientId } = props;
 
 	const { selectBlock } = useDispatch('core/block-editor');
@@ -60,9 +67,9 @@ const BlockInserter = props => {
 			/>
 		</div>
 	);
-};
+});
 
-const ButtonInserter = props => {
+const ButtonInserter = memo(props => {
 	const { onToggle, style = {} } = props;
 
 	const repeaterStatus = useContext(RepeaterContext)?.repeaterStatus;
@@ -99,9 +106,9 @@ const ButtonInserter = props => {
 			</div>
 		</Tooltip>
 	);
-};
+});
 
-const WrapperBlockInserter = forwardRef((props, ref) => {
+const WrapperBlockInserter = memo(forwardRef((props, ref) => {
 	const { clientId, isSelected, hasSelectedChild } = props;
 
 	const { getBlockName, getBlockParents } = select('core/block-editor');
@@ -211,9 +218,11 @@ const WrapperBlockInserter = forwardRef((props, ref) => {
 		);
 
 	return null;
-});
+}));
 
-const InterBlockToggle = props => {
+const InterBlockToggle = memo(props => {
+	countProfile('InterBlockToggle render');
+
 	const { clientId, onToggleInserter, blockRef, isOpen } = props;
 
 	const [isHovered, setHovered] = useState(false);
@@ -292,9 +301,11 @@ const InterBlockToggle = props => {
 			)}
 		</div>
 	);
-};
+});
 
-const InterBlockInserter = forwardRef((props, ref) => {
+const InterBlockInserter = memo(forwardRef((props, ref) => {
+	countProfile('InterBlockInserter render');
+
 	const { clientId } = props;
 	const blockRef = ref?.current?.blockRef?.current;
 
@@ -355,7 +366,7 @@ const InterBlockInserter = forwardRef((props, ref) => {
 			/>
 		</Popover>
 	);
-});
+}));
 
 BlockInserter.WrapperInserter = WrapperBlockInserter;
 BlockInserter.InterBlockInserter = InterBlockInserter;

--- a/src/components/maxi-block/maxiBlock.js
+++ b/src/components/maxi-block/maxiBlock.js
@@ -24,6 +24,7 @@ import { getIsHoverPreview } from '@extensions/maxi-block';
 import InnerBlocksBlock from './innerBlocksBlock';
 import MainMaxiBlock from './mainMaxiBlock';
 import { inlineLinkFields } from '@extensions/DC/constants';
+import { countProfile } from '@extensions/performance/profiler';
 
 /**
  * External dependencies
@@ -54,6 +55,7 @@ const getBlockStyle = (attributes, breakpoint, marginValue) => {
 			target,
 			breakpoint,
 			attributes,
+			forceSingle: true,
 		});
 
 	const isFullWidth = getValue('full-width');
@@ -95,6 +97,8 @@ const getBlockStyle = (attributes, breakpoint, marginValue) => {
 };
 
 const MaxiBlockContent = forwardRef((props, ref) => {
+	countProfile('MaxiBlockContent render');
+
 	const {
 		clientId,
 		blockName,
@@ -137,6 +141,7 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 		target: 'full-width',
 		breakpoint: deviceType,
 		attributes,
+		forceSingle: true,
 	});
 
 	// Gets if the block has to be disabled due to the device type
@@ -311,6 +316,8 @@ const MaxiBlockContent = forwardRef((props, ref) => {
 
 const MaxiBlock = memo(
 	forwardRef((props, ref) => {
+		countProfile('MaxiBlock render');
+
 		const {
 			clientId,
 			attributes,

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -55,6 +55,10 @@ import { removeBlockFromColumns } from '@extensions/repeater';
 import processRelations from '@extensions/relations/processRelations';
 import compareVersions from './compareVersions';
 import batchBlockDispatcher from './batchBlockDispatcher';
+import {
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 /**
  * External dependencies
@@ -67,62 +71,12 @@ import { isLinkObfuscationEnabled } from '@extensions/DC/utils';
  * Constants
  */
 const WHITE_SPACE_REGEX = /white-space:\s*nowrap(?!\s*!important)/g;
+const VIEWPORT_UNIT_VALUE_REGEX =
+	/(?:^|[^a-z])(?:vw|vh|vmin|vmax)(?:$|[^a-z])/i;
 
-const getPerfStart = () => {
-	if (
-		typeof window === 'undefined' ||
-		!window.__MAXI_PROFILE_MAXI_BLOCKS__ ||
-		typeof performance === 'undefined' ||
-		!performance.now
-	) {
-		return null;
-	}
-
-	return performance.now();
-};
-
-const recordPerf = (label, start) => {
-	if (start === null || typeof performance === 'undefined') {
-		return;
-	}
-
-	const duration = performance.now() - start;
-	const perfRoot = typeof window !== 'undefined' ? window : globalThis;
-	const perf =
-		perfRoot.__maxiBlocksPerfCounters__ ||
-		(perfRoot.__maxiBlocksPerfCounters__ = {
-			totals: {},
-			counts: {},
-			logScheduled: false,
-		});
-
-	perf.totals[label] = (perf.totals[label] || 0) + duration;
-	perf.counts[label] = (perf.counts[label] || 0) + 1;
-
-	if (!perf.logScheduled && typeof setTimeout === 'function') {
-		perf.logScheduled = true;
-		setTimeout(() => {
-			perf.logScheduled = false;
-			if (typeof console === 'undefined' || !console.info) {
-				perf.totals = {};
-				perf.counts = {};
-				return;
-			}
-
-			const totals = perf.totals;
-			const counts = perf.counts;
-			perf.totals = {};
-			perf.counts = {};
-
-			const parts = Object.keys(totals).map(
-				key => `${key} ${totals[key].toFixed(1)}ms/${counts[key]}`
-			);
-			if (parts.length) {
-				console.info('MaxiBlocks perf (1s):', parts.join(', '));
-			}
-		}, 1000);
-	}
-};
+const getPerfStart = getProfileStart;
+const recordPerf = (label, start) =>
+	recordProfile(`maxiBlockComponent ${label}`, start);
 
 /**
  * Class
@@ -1117,7 +1071,69 @@ class MaxiBlockComponent extends Component {
 		this.cachedDiffAttributes = undefined;
 		this.cachedBreakpointsAttributes = null;
 		this.cachedBreakpoints = null;
+		this.cachedViewportUnitAttributes = null;
+		this.cachedHasViewportUnits = null;
 		this.attributesMutated = true;
+	}
+
+	hasViewportUnitsInAttributes() {
+		if (
+			this.cachedViewportUnitAttributes === this.props.attributes &&
+			this.cachedHasViewportUnits !== null
+		) {
+			return this.cachedHasViewportUnits;
+		}
+
+		const stack = [this.props.attributes];
+		const seen = new WeakSet();
+		let hasViewportUnits = false;
+
+		while (stack.length && !hasViewportUnits) {
+			const current = stack.pop();
+
+			if (!current || typeof current !== 'object') continue;
+			if (seen.has(current)) continue;
+			seen.add(current);
+
+			Object.values(current).some(value => {
+				if (typeof value === 'string') {
+					hasViewportUnits = VIEWPORT_UNIT_VALUE_REGEX.test(value);
+					return hasViewportUnits;
+				}
+
+				if (value && typeof value === 'object') {
+					stack.push(value);
+				}
+
+				return false;
+			});
+		}
+
+		this.cachedViewportUnitAttributes = this.props.attributes;
+		this.cachedHasViewportUnits = hasViewportUnits;
+
+		return hasViewportUnits;
+	}
+
+	getCachedStyleContent(uniqueID, breakpoint) {
+		const cacheStart = getPerfStart();
+		const cssCache = select('maxiBlocks/styles').getCSSCache(uniqueID);
+		const styleContent = cssCache?.[breakpoint];
+		recordPerf(`getCSSCache ${breakpoint}`, cacheStart);
+
+		return typeof styleContent === 'string' ? styleContent : null;
+	}
+
+	applyStyleContent(uniqueID, styleContent, breakpoint) {
+		const isSiteEditor = getIsSiteEditor();
+
+		if (this.editorIframe?.contentDocument?.body) {
+			this.handleIframeStyles(this.editorIframe, breakpoint);
+		}
+
+		const target = this.getStyleTarget(isSiteEditor, this.editorIframe);
+		addBlockStyles(uniqueID, styleContent, target);
+		this.updateResponsiveClasses(this.editorIframe, breakpoint);
 	}
 
 	// eslint-disable-next-line class-methods-use-this
@@ -1556,32 +1572,32 @@ class MaxiBlockComponent extends Component {
 			this.updateDOMReferences();
 		}
 
-		// Fast path: breakpoints switch to XXL with no attribute changes
+		// Fast path: breakpoint switches with no attribute changes can reuse
+		// CSS generated from the existing style cache.
 		if (
 			attributesUnchanged &&
 			isBreakpointChange &&
 			this.props.deviceType === 'xxl' &&
 			!isBlockStyleChange &&
 			!isBaseBreakpointChange &&
-			this.xxlStyleCache &&
 			!this.isXxlStyleCacheDirty
 		) {
-			const isSiteEditor = getIsSiteEditor();
-			if (this.editorIframe?.contentDocument?.body) {
-				this.handleIframeStyles(
-					this.editorIframe,
+			const cachedStyleContent =
+				this.xxlStyleCache ||
+				this.getCachedStyleContent(uniqueID, this.props.deviceType);
+
+			if (!cachedStyleContent) {
+				// Fall through to full generation when no valid cache exists.
+			} else {
+				this.xxlStyleCache = cachedStyleContent;
+				this.applyStyleContent(
+					uniqueID,
+					cachedStyleContent,
 					this.props.deviceType
 				);
+				recordPerf('displayStyles', perfStart);
+				return;
 			}
-
-			const target = this.getStyleTarget(isSiteEditor, this.editorIframe);
-			addBlockStyles(uniqueID, this.xxlStyleCache, target);
-			this.updateResponsiveClasses(
-				this.editorIframe,
-				this.props.deviceType
-			);
-			recordPerf('displayStyles', perfStart);
-			return;
 		}
 
 		// Generate new styles if it's not a breakpoint change or if it's XXL breakpoint
@@ -1591,14 +1607,30 @@ class MaxiBlockComponent extends Component {
 			isBaseBreakpointChange ||
 			!attributesUnchanged;
 
-		let stylesForViewportCheck;
-
 		if (!shouldGenerateNewStyles && isBreakpointChange) {
-			const stylesObjStart = getPerfStart();
-			stylesForViewportCheck = this.getStylesObject || {};
-			recordPerf('getStylesObject', stylesObjStart);
+			const viewportUnitStart = getPerfStart();
+			const hasViewportUnits = this.hasViewportUnitsInAttributes();
+			if (hasViewportUnits) {
+				shouldGenerateNewStyles = true;
+			}
+			recordPerf('hasViewportUnitsInAttributes', viewportUnitStart);
 
-			if (this.hasViewportUnits(stylesForViewportCheck)) {
+			if (!hasViewportUnits) {
+				const cachedStyleContent = this.getCachedStyleContent(
+					uniqueID,
+					this.props.deviceType
+				);
+
+				if (cachedStyleContent) {
+					this.applyStyleContent(
+						uniqueID,
+						cachedStyleContent,
+						this.props.deviceType
+					);
+					recordPerf('displayStyles', perfStart);
+					return;
+				}
+
 				shouldGenerateNewStyles = true;
 			}
 		}
@@ -1647,13 +1679,13 @@ class MaxiBlockComponent extends Component {
 		let customDataRelations;
 
 		if (shouldGenerateNewStyles) {
-			if (stylesForViewportCheck) {
-				obj = stylesForViewportCheck;
-			} else {
-				const stylesObjStart = getPerfStart();
-				obj = this.getStylesObject || {};
-				recordPerf('getStylesObject', stylesObjStart);
-			}
+			const stylesObjStart = getPerfStart();
+			obj = this.getStylesObject || {};
+			recordPerf('getStylesObject', stylesObjStart);
+			recordPerf(
+				`getStylesObject ${this.props.name || 'unknown'}`,
+				stylesObjStart
+			);
 
 			// When duplicating, need to change the obj target for the new uniqueID
 			if (

--- a/src/extensions/maxi-block/withMaxiLoader.js
+++ b/src/extensions/maxi-block/withMaxiLoader.js
@@ -13,31 +13,10 @@ import { ContentLoader } from '@components';
 const SuspendedBlock = ({ onMountBlock, clientId }) => {
 	useEffect(() => onMountBlock(), [onMountBlock]);
 
-	const { getBlocks } = useSelect(select => {
-		const { getBlocks } = select('core/block-editor');
-		return { getBlocks };
-	}, []);
-
-	const getAllMaxiBlocks = blocks => {
-		return blocks.reduce((maxiBlocks, block) => {
-			if (block.name.includes('maxi-blocks')) {
-				maxiBlocks.push(block);
-			}
-
-			if (block.innerBlocks?.length) {
-				maxiBlocks.push(...getAllMaxiBlocks(block.innerBlocks));
-			}
-
-			return maxiBlocks;
-		}, []);
-	};
-
-	const allBlocks = getBlocks();
-	const maxiBlocks = getAllMaxiBlocks(allBlocks);
-
-	const shouldShowLoader = maxiBlocks.some(block => {
-		return block.clientId === clientId;
-	});
+	const shouldShowLoader = useSelect(select => {
+		const block = select('core/block-editor').getBlock(clientId);
+		return block?.name?.includes('maxi-blocks');
+	}, [clientId]);
 
 	if (shouldShowLoader) {
 		return <ContentLoader cloud={false} />;

--- a/src/extensions/maxi-block/withMaxiProps.js
+++ b/src/extensions/maxi-block/withMaxiProps.js
@@ -7,6 +7,8 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	forwardRef,
+	memo,
 	useMemo,
 	useRef,
 } from '@wordpress/element';
@@ -34,6 +36,12 @@ import {
 	getBlockPosition,
 } from '@extensions/repeater/utils';
 import RepeaterContext from '@blocks/row-maxi/repeaterContext';
+import {
+	countProfile,
+	getIsProfileEnabled,
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 /**
  * External dependencies
@@ -41,6 +49,338 @@ import RepeaterContext from '@blocks/row-maxi/repeaterContext';
 import { isEmpty, isEqual } from 'lodash';
 
 const DISABLED_BLOCKS = ['maxi-blocks/list-item-maxi'];
+
+const RESPONSIVE_BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+const MAX_DEBUG_STRING_LENGTH = 500;
+const MAX_DEBUG_OBJECT_KEYS = 80;
+const MAX_DEBUG_ARRAY_ITEMS = 40;
+const MAX_DEBUG_ELEMENT_SNAPSHOTS = 40;
+const MAX_DEBUG_LOG_KEYS = 30;
+
+const DISPLAY_DEBUG_SELECTORS = [
+	'svg',
+	'img',
+	'video',
+	'button',
+	'[class*="grid"]',
+	'[class*="container"]',
+	'[class*="row"]',
+	'[class*="column"]',
+	'[class*="wrapper"]',
+	'[class*="content"]',
+];
+
+const stringifyDebugValue = value => {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+};
+
+const getObjectChunks = (obj, chunkSize = MAX_DEBUG_LOG_KEYS) => {
+	const keys = Object.keys(obj || {}).sort();
+	const chunks = [];
+
+	for (let i = 0; i < keys.length; i += chunkSize) {
+		chunks.push(
+			Object.fromEntries(
+				keys.slice(i, i + chunkSize).map(key => [key, obj[key]])
+			)
+		);
+	}
+
+	return chunks;
+};
+
+const logDebugObject = (label, payload) => {
+	console.info(`MaxiBlocks ${label}: ${stringifyDebugValue(payload)}`);
+};
+
+const logDebugObjectChunks = (label, payload) => {
+	const chunks = getObjectChunks(payload);
+
+	chunks.forEach((chunk, index) => {
+		logDebugObject(`${label} ${index + 1}/${chunks.length}`, chunk);
+	});
+};
+
+const sanitizeDebugValue = (value, depth = 0, seen = new WeakSet()) => {
+	if (typeof value === 'string') {
+		if (value.length <= MAX_DEBUG_STRING_LENGTH) return value;
+
+		return {
+			__type: 'string',
+			length: value.length,
+			preview: `${value.slice(0, MAX_DEBUG_STRING_LENGTH)}...`,
+		};
+	}
+
+	if (
+		value === null ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	) {
+		return value;
+	}
+
+	if (typeof value === 'undefined') return '[undefined]';
+
+	if (typeof value !== 'object') return String(value);
+
+	if (seen.has(value)) return '[Circular]';
+	seen.add(value);
+
+	if (depth >= 4) {
+		return Array.isArray(value)
+			? `[Array(${value.length})]`
+			: '[Object]';
+	}
+
+	if (Array.isArray(value)) {
+		return {
+			__type: 'array',
+			length: value.length,
+			items: value
+				.slice(0, MAX_DEBUG_ARRAY_ITEMS)
+				.map(item => sanitizeDebugValue(item, depth + 1, seen)),
+			...(value.length > MAX_DEBUG_ARRAY_ITEMS && {
+				__truncatedItems: value.length - MAX_DEBUG_ARRAY_ITEMS,
+			}),
+		};
+	}
+
+	const keys = Object.keys(value).sort();
+	const response = {};
+
+	keys.slice(0, MAX_DEBUG_OBJECT_KEYS).forEach(key => {
+		response[key] = sanitizeDebugValue(value[key], depth + 1, seen);
+	});
+
+	if (keys.length > MAX_DEBUG_OBJECT_KEYS) {
+		response.__truncatedKeys = keys.length - MAX_DEBUG_OBJECT_KEYS;
+	}
+
+	return response;
+};
+
+const getBreakpointAttributeInfo = key => {
+	for (const breakpoint of RESPONSIVE_BREAKPOINTS) {
+		const hoverSuffix = `-${breakpoint}-hover`;
+		if (key.endsWith(hoverSuffix)) {
+			return {
+				breakpoint,
+				baseKey: `${key.slice(0, -hoverSuffix.length)}-hover`,
+				state: 'hover',
+			};
+		}
+
+		const suffix = `-${breakpoint}`;
+		if (key.endsWith(suffix)) {
+			return {
+				breakpoint,
+				baseKey: key.slice(0, -suffix.length),
+				state: 'normal',
+			};
+		}
+	}
+
+	return null;
+};
+
+const getResponsiveAttributeAudit = attributes => {
+	const byBreakpoint = RESPONSIVE_BREAKPOINTS.reduce((acc, breakpoint) => {
+		acc[breakpoint] = {};
+
+		return acc;
+	}, {});
+	const matrix = {};
+	const nonResponsiveAttributes = {};
+	let responsiveAttributeCount = 0;
+
+	if (!attributes) {
+		return {
+			totalAttributeCount: 0,
+			responsiveAttributeCount,
+			matrix,
+			byBreakpoint,
+			nonResponsiveAttributes,
+		};
+	}
+
+	Object.keys(attributes)
+		.sort()
+		.forEach(key => {
+			const sanitizedValue = sanitizeDebugValue(attributes[key]);
+			const breakpointInfo = getBreakpointAttributeInfo(key);
+
+			if (!breakpointInfo) {
+				nonResponsiveAttributes[key] = sanitizedValue;
+				return;
+			}
+
+			responsiveAttributeCount += 1;
+
+			const { breakpoint, baseKey, state } = breakpointInfo;
+
+			if (!matrix[baseKey]) {
+				matrix[baseKey] = {
+					state,
+				};
+			}
+
+			matrix[baseKey][breakpoint] = sanitizedValue;
+			byBreakpoint[breakpoint][key] = sanitizedValue;
+		});
+
+	return {
+		totalAttributeCount: Object.keys(attributes).length,
+		responsiveAttributeCount,
+		matrix,
+		byBreakpoint,
+		nonResponsiveAttributes,
+	};
+};
+
+const getDebugDocuments = () => {
+	if (typeof document === 'undefined') return [];
+
+	const documents = [document];
+
+	Array.from(
+		document.querySelectorAll(
+			'iframe[name="editor-canvas"], .block-editor-iframe__scale-container iframe'
+		)
+	).forEach(iframe => {
+		try {
+			if (
+				iframe.contentDocument &&
+				!documents.includes(iframe.contentDocument)
+			) {
+				documents.push(iframe.contentDocument);
+			}
+		} catch {
+			// Ignore cross-origin iframe access.
+		}
+	});
+
+	return documents;
+};
+
+const getSelectedBlockElement = (clientId, uniqueID) => {
+	for (const currentDocument of getDebugDocuments()) {
+		const blockElement = currentDocument.querySelector(
+			`[data-block="${clientId}"]`
+		);
+		if (blockElement) return blockElement;
+
+		if (uniqueID) {
+			const uniqueElement =
+				currentDocument.getElementsByClassName(uniqueID)[0];
+			if (uniqueElement) return uniqueElement;
+		}
+	}
+
+	return null;
+};
+
+const getRoundedRect = element => {
+	const rect = element.getBoundingClientRect();
+
+	return {
+		x: Number(rect.x.toFixed(1)),
+		y: Number(rect.y.toFixed(1)),
+		width: Number(rect.width.toFixed(1)),
+		height: Number(rect.height.toFixed(1)),
+		top: Number(rect.top.toFixed(1)),
+		left: Number(rect.left.toFixed(1)),
+	};
+};
+
+const getElementSnapshot = (element, label) => {
+	const view = element.ownerDocument?.defaultView || window;
+	const style = view.getComputedStyle(element);
+
+	return {
+		label,
+		tag: element.tagName.toLowerCase(),
+		className: element.getAttribute('class') || '',
+		id: element.getAttribute('id') || '',
+		inlineStyle: element.getAttribute('style') || '',
+		rect: getRoundedRect(element),
+		display: style.display,
+		position: style.position,
+		boxSizing: style.boxSizing,
+		width: style.width,
+		height: style.height,
+		minWidth: style.minWidth,
+		maxWidth: style.maxWidth,
+		minHeight: style.minHeight,
+		maxHeight: style.maxHeight,
+		margin: style.margin,
+		padding: style.padding,
+		gap: style.gap,
+		gridTemplateColumns: style.gridTemplateColumns,
+		gridTemplateRows: style.gridTemplateRows,
+		flexDirection: style.flexDirection,
+		alignItems: style.alignItems,
+		justifyContent: style.justifyContent,
+		overflow: style.overflow,
+		transform: style.transform,
+		fontSize: style.fontSize,
+		lineHeight: style.lineHeight,
+	};
+};
+
+const getDisplayDebugSnapshot = (clientId, uniqueID) => {
+	const rootElement = getSelectedBlockElement(clientId, uniqueID);
+
+	if (!rootElement) {
+		return {
+			found: false,
+			elements: [],
+		};
+	}
+
+	const elements = [getElementSnapshot(rootElement, 'selected block')];
+	const seen = new WeakSet([rootElement]);
+
+	DISPLAY_DEBUG_SELECTORS.some(selector => {
+		const matches = Array.from(rootElement.querySelectorAll(selector));
+
+		return matches.some(element => {
+			if (seen.has(element)) return false;
+
+			seen.add(element);
+			elements.push(getElementSnapshot(element, selector));
+
+			return elements.length >= MAX_DEBUG_ELEMENT_SNAPSHOTS;
+		});
+	});
+
+	return {
+		found: true,
+		elements,
+	};
+};
+
+const InterBlockInserterSlot = memo(
+	forwardRef(({ clientId, name }, ref) => {
+		const isTyping = useSelect(
+			select => select('core/block-editor').isTyping(),
+			[]
+		);
+
+		if (isTyping || DISABLED_BLOCKS.includes(name)) return null;
+
+		return (
+			<BlockInserter.InterBlockInserter ref={ref} clientId={clientId} />
+		);
+	}),
+	(oldProps, newProps) =>
+		oldProps.clientId === newProps.clientId &&
+		oldProps.name === newProps.name
+);
 
 const withMaxiProps = createHigherOrderComponent(
 	WrappedComponent =>
@@ -54,6 +394,7 @@ const withMaxiProps = createHigherOrderComponent(
 				isSelected,
 				contextLoopContext,
 			} = ownProps;
+			countProfile('withMaxiProps render');
 
 			const repeaterContext = useContext(RepeaterContext);
 
@@ -61,6 +402,7 @@ const withMaxiProps = createHigherOrderComponent(
 			const prevRelationsRef = useRef(attributes?.relations);
 			// Track if we're in the middle of a setAttributes call
 			const isSettingAttributesRef = useRef(false);
+			const responsiveDebugLogRef = useRef(null);
 
 			// Memoize selectors to prevent recreation on every render
 			const blockEditorSelectors = useMemo(() => {
@@ -68,7 +410,6 @@ const withMaxiProps = createHigherOrderComponent(
 				return {
 					getBlock: selectStore.getBlock,
 					getBlockOrder: selectStore.getBlockOrder,
-					getBlockParents: selectStore.getBlockParents,
 					getBlockParentsByBlockName:
 						selectStore.getBlockParentsByBlockName,
 				};
@@ -77,7 +418,6 @@ const withMaxiProps = createHigherOrderComponent(
 			const {
 				getBlock,
 				getBlockOrder,
-				getBlockParents,
 				getBlockParentsByBlockName,
 			} = blockEditorSelectors;
 
@@ -95,17 +435,16 @@ const withMaxiProps = createHigherOrderComponent(
 				deviceType,
 				baseBreakpoint,
 				hasSelectedChild,
-				isTyping,
 				blockIndex,
 				blockRootClientId,
 				// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 				// isLastBlock,
 			} = useSelect(select => {
+				const selectStart = getProfileStart();
 				const { receiveMaxiDeviceType, receiveBaseBreakpoint } =
 					select('maxiBlocks');
 				const {
 					hasSelectedInnerBlock,
-					isTyping,
 					getBlockIndex,
 					getBlockRootClientId,
 					// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
@@ -113,14 +452,19 @@ const withMaxiProps = createHigherOrderComponent(
 				} = select('core/block-editor');
 
 				const currentBlockIndex = getBlockIndex(clientId);
+				const currentDeviceType = receiveMaxiDeviceType();
+				const currentBaseBreakpoint = receiveBaseBreakpoint();
+				const currentHasSelectedChild = hasSelectedInnerBlock(
+					clientId,
+					true
+				);
 				// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
 				// const allBlocks = getBlocks();
 
-				return {
-					deviceType: receiveMaxiDeviceType(),
-					baseBreakpoint: receiveBaseBreakpoint(),
-					hasSelectedChild: hasSelectedInnerBlock(clientId, true),
-					isTyping: isTyping(),
+				const selection = {
+					deviceType: currentDeviceType,
+					baseBreakpoint: currentBaseBreakpoint,
+					hasSelectedChild: currentHasSelectedChild,
 					blockIndex: currentBlockIndex,
 					blockRootClientId: getBlockRootClientId(clientId),
 					// TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806
@@ -128,6 +472,9 @@ const withMaxiProps = createHigherOrderComponent(
 					// 	attributes?.isFirstOnHierarchy &&
 					// 	currentBlockIndex === allBlocks.length - 1,
 				};
+				recordProfile('withMaxiProps useSelect', selectStart);
+
+				return selection;
 			});
 
 			const parentColumnClientId = useMemo(() => {
@@ -394,6 +741,111 @@ const withMaxiProps = createHigherOrderComponent(
 				// No cleanup needed for this effect
 			}, [isSelected]);
 
+			useEffect(() => {
+				if (
+					!isSelected ||
+					typeof console === 'undefined' ||
+					!console.info ||
+					!getIsProfileEnabled()
+				)
+					return;
+
+				const responsiveAudit = getResponsiveAttributeAudit(attributes);
+				const responsiveAttributesKey = stringifyDebugValue(
+					responsiveAudit.matrix
+				);
+				const logKey = [
+					clientId,
+					attributes?.uniqueID,
+					deviceType,
+					baseBreakpoint,
+					responsiveAttributesKey,
+				].join(':');
+
+				if (responsiveDebugLogRef.current === logKey) return;
+				responsiveDebugLogRef.current = logKey;
+
+				const logSelection = () => {
+					const breakpointAttributeCounts = Object.fromEntries(
+						RESPONSIVE_BREAKPOINTS.map(breakpoint => [
+							breakpoint,
+							Object.keys(
+								responsiveAudit.byBreakpoint[breakpoint] || {}
+							).length,
+						])
+					);
+					const summary = {
+						name,
+						clientId,
+						uniqueID: attributes?.uniqueID,
+						activeBreakpoint: deviceType,
+						baseBreakpoint,
+						totalAttributeCount:
+							responsiveAudit.totalAttributeCount,
+						responsiveAttributeCount:
+							responsiveAudit.responsiveAttributeCount,
+						nonResponsiveAttributeCount: Object.keys(
+							responsiveAudit.nonResponsiveAttributes
+						).length,
+						matrixAttributeCount: Object.keys(
+							responsiveAudit.matrix
+						).length,
+						breakpointAttributeCounts,
+					};
+
+					logDebugObject('responsive audit summary', summary);
+					logDebugObject(
+						'responsive display',
+						getDisplayDebugSnapshot(clientId, attributes?.uniqueID)
+					);
+
+					RESPONSIVE_BREAKPOINTS.forEach(breakpoint => {
+						logDebugObjectChunks(
+							`responsive attrs ${breakpoint}`,
+							responsiveAudit.byBreakpoint[breakpoint]
+						);
+					});
+
+					logDebugObjectChunks(
+						'responsive matrix',
+						responsiveAudit.matrix
+					);
+					logDebugObjectChunks(
+						'nonresponsive attrs',
+						responsiveAudit.nonResponsiveAttributes
+					);
+				};
+
+				let animationFrameId;
+				let timeoutId;
+
+				if (typeof requestAnimationFrame === 'function') {
+					animationFrameId = requestAnimationFrame(() => {
+						timeoutId = setTimeout(logSelection, 0);
+					});
+				} else {
+					timeoutId = setTimeout(logSelection, 0);
+				}
+
+				return () => {
+					if (
+						animationFrameId &&
+						typeof cancelAnimationFrame === 'function'
+					) {
+						cancelAnimationFrame(animationFrameId);
+					}
+
+					if (timeoutId) clearTimeout(timeoutId);
+				};
+			}, [
+				isSelected,
+				name,
+				clientId,
+				attributes,
+				deviceType,
+				baseBreakpoint,
+			]);
+
 		// CRITICAL FIX: Detect and restore relations if they unexpectedly become empty
 		useEffect(() => {
 			const currentRelations = attributes?.relations;
@@ -484,13 +936,7 @@ const withMaxiProps = createHigherOrderComponent(
 						hasInnerBlocks={hasInnerBlocks}
 						parentColumnClientId={parentColumnClientId}
 						blockPositionFromColumn={blockPositionFromColumn}
-						isChild={
-							!isEmpty(
-								getBlockParents(clientId).filter(
-									val => val !== clientId
-								)
-							)
-						}
+						isChild={!!blockRootClientId}
 						hasSelectedChild={hasSelectedChild}
 						repeaterStatus={repeaterContext?.repeaterStatus}
 						repeaterRowClientId={
@@ -503,12 +949,11 @@ const withMaxiProps = createHigherOrderComponent(
 							repeaterContext?.updateInnerBlocksPositions
 						}
 					/>
-					{!isTyping && !DISABLED_BLOCKS.includes(ownProps.name) && (
-						<BlockInserter.InterBlockInserter
-							ref={ref}
-							{...ownProps}
-						/>
-					)}
+					<InterBlockInserterSlot
+						ref={ref}
+						clientId={clientId}
+						name={name}
+					/>
 					{/* TODO: https://github.com/maxi-blocks/maxi-blocks/issues/5806 */}
 					{/* {isLastBlock && (
 						<BlockInserter className='maxi-block-inserter maxi-block-inserter__last' />

--- a/src/extensions/performance/profiler.js
+++ b/src/extensions/performance/profiler.js
@@ -1,0 +1,194 @@
+const PROFILE_FLAGS = [
+	'__MAXI_PROFILE_MAXI_BLOCKS__',
+	'__MAXI_PROFILE__',
+	'maxiBlocksDebug',
+];
+
+const STORAGE_KEYS = ['maxiBlocks-profile', 'maxiBlocks-debug'];
+const AUTO_PROFILE_DURATION = 30000;
+const BOOST_PROFILE_DURATION = 10000;
+let cachedIsProfileEnabled = false;
+let lastProfileCheck = 0;
+let autoProfileUntil = 0;
+let autoProfileInitialized = false;
+
+const getRoot = () => {
+	if (typeof window !== 'undefined') return window;
+	if (typeof globalThis !== 'undefined') return globalThis;
+
+	return null;
+};
+
+const getNow = () => {
+	if (typeof performance !== 'undefined' && performance.now) {
+		return performance.now();
+	}
+
+	return Date.now();
+};
+
+export const getIsProfileEnabled = () => {
+	const now = Date.now();
+	if (now - lastProfileCheck < 500) return cachedIsProfileEnabled;
+
+	lastProfileCheck = now;
+	const root = getRoot();
+	if (!root) {
+		cachedIsProfileEnabled = false;
+		return cachedIsProfileEnabled;
+	}
+
+	if (!autoProfileInitialized) {
+		autoProfileInitialized = true;
+		if (typeof window !== 'undefined' && root === window) {
+			autoProfileUntil = now + AUTO_PROFILE_DURATION;
+		}
+	}
+
+	let storageProfileValue = null;
+	if (root.localStorage) {
+		try {
+			storageProfileValue = root.localStorage.getItem(
+				'maxiBlocks-profile'
+			);
+		} catch {
+			storageProfileValue = null;
+		}
+	}
+
+	if (storageProfileValue === 'false') {
+		cachedIsProfileEnabled = false;
+		return cachedIsProfileEnabled;
+	}
+
+	if (PROFILE_FLAGS.some(flag => root[flag])) {
+		cachedIsProfileEnabled = true;
+		return cachedIsProfileEnabled;
+	}
+
+	if (autoProfileUntil > now) {
+		cachedIsProfileEnabled = true;
+		return cachedIsProfileEnabled;
+	}
+
+	if (!root.localStorage) {
+		cachedIsProfileEnabled = false;
+		return cachedIsProfileEnabled;
+	}
+
+	try {
+		cachedIsProfileEnabled =
+			storageProfileValue === 'true' ||
+			STORAGE_KEYS.some(key => root.localStorage.getItem(key) === 'true');
+	} catch {
+		cachedIsProfileEnabled = false;
+	}
+
+	return cachedIsProfileEnabled;
+};
+
+export const enableProfileFor = (duration = BOOST_PROFILE_DURATION) => {
+	const root = getRoot();
+	if (!root || typeof window === 'undefined' || root !== window) return;
+
+	const now = Date.now();
+	autoProfileInitialized = true;
+	autoProfileUntil = Math.max(autoProfileUntil, now + duration);
+	cachedIsProfileEnabled = true;
+	lastProfileCheck = now;
+};
+
+const getProfileState = root => {
+	if (!root.__maxiBlocksPerfCounters__) {
+		root.__maxiBlocksPerfCounters__ = {
+			totals: {},
+			counts: {},
+			max: {},
+			counters: {},
+			logScheduled: false,
+		};
+	}
+
+	const perf = root.__maxiBlocksPerfCounters__;
+	perf.totals = perf.totals || {};
+	perf.counts = perf.counts || {};
+	perf.max = perf.max || {};
+	perf.counters = perf.counters || {};
+
+	return perf;
+};
+
+const scheduleProfileFlush = perf => {
+	if (perf.logScheduled || typeof setTimeout !== 'function') return;
+
+	perf.logScheduled = true;
+
+	setTimeout(() => {
+		perf.logScheduled = false;
+
+		const totals = perf.totals;
+		const counts = perf.counts;
+		const max = perf.max;
+		const counters = perf.counters;
+
+		perf.totals = {};
+		perf.counts = {};
+		perf.max = {};
+		perf.counters = {};
+
+		if (typeof console === 'undefined' || !console.info) return;
+
+		const timings = Object.keys(totals).map(key => {
+			const total = totals[key];
+			const count = counts[key];
+			const average = total / count;
+			const maxDuration = max[key] || total;
+
+			return `${key} ${total.toFixed(1)}ms/${count} avg ${average.toFixed(
+				1
+			)} max ${maxDuration.toFixed(1)}`;
+		});
+
+		const counterParts = Object.keys(counters).map(
+			key => `${key} ${counters[key]}`
+		);
+
+		const parts = [...timings, ...counterParts];
+
+		if (parts.length) {
+			console.info('MaxiBlocks perf (1s):', parts.join(', '));
+		}
+	}, 1000);
+};
+
+export const getProfileStart = () => {
+	if (!getIsProfileEnabled()) return null;
+
+	return getNow();
+};
+
+export const recordProfile = (label, start) => {
+	if (start === null) return;
+
+	const root = getRoot();
+	if (!root || !getIsProfileEnabled()) return;
+
+	const duration = getNow() - start;
+	const perf = getProfileState(root);
+
+	perf.totals[label] = (perf.totals[label] || 0) + duration;
+	perf.counts[label] = (perf.counts[label] || 0) + 1;
+	perf.max[label] = Math.max(perf.max[label] || 0, duration);
+
+	scheduleProfileFlush(perf);
+};
+
+export const countProfile = (label, count = 1) => {
+	const root = getRoot();
+	if (!root || !getIsProfileEnabled()) return;
+
+	const perf = getProfileState(root);
+	perf.counters[label] = (perf.counters[label] || 0) + count;
+
+	scheduleProfileFlush(perf);
+};

--- a/src/extensions/store/reducer.js
+++ b/src/extensions/store/reducer.js
@@ -13,6 +13,10 @@ import {
 } from '@extensions/fse';
 import getWinBreakpoint from '@extensions/dom/getWinBreakpoint';
 import getCurrentPreviewDeviceType from '@extensions/dom/getCurrentPreviewDeviceType';
+import {
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 /**
  * External dependencies
@@ -20,6 +24,7 @@ import getCurrentPreviewDeviceType from '@extensions/dom/getCurrentPreviewDevice
 import { omit } from 'lodash';
 
 const breakpointResizer = ({ size, breakpoints, winSize = 0 }) => {
+	const resizeStart = getProfileStart();
 	const xxlSize = breakpoints.xl + 1;
 
 	const getEditorWrapper = () => {
@@ -49,7 +54,10 @@ const breakpointResizer = ({ size, breakpoints, winSize = 0 }) => {
 	};
 	const editorWrapper = getEditorWrapper();
 
-	if (!editorWrapper) return;
+	if (!editorWrapper) {
+		recordProfile(`breakpointResizer ${size} no wrapper`, resizeStart);
+		return;
+	}
 
 	[editorWrapper, getSiteEditorIframeBody()].forEach(element => {
 		element?.setAttribute(
@@ -77,6 +85,10 @@ const breakpointResizer = ({ size, breakpoints, winSize = 0 }) => {
 			} else {
 				// Breakpoints not loaded yet, skip setting width for now
 				// This will be called again when breakpoints are loaded
+				recordProfile(
+					`breakpointResizer ${size} missing breakpoints`,
+					resizeStart
+				);
 				return;
 			}
 		} else {
@@ -128,6 +140,7 @@ const breakpointResizer = ({ size, breakpoints, winSize = 0 }) => {
 
 	// Clean prevSavedAttrs when changing the responsive stage
 	dispatch('maxiBlocks/styles').savePrevSavedAttrs([]);
+	recordProfile(`breakpointResizer ${size}`, resizeStart);
 };
 
 const reducer = (

--- a/src/extensions/styles/setScreenSize.js
+++ b/src/extensions/styles/setScreenSize.js
@@ -1,10 +1,17 @@
 import { select, dispatch } from '@wordpress/data';
+import {
+	enableProfileFor,
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 // Throttle rapid successive calls
 let lastCallTime = 0;
 let pendingCall = null;
 
 const setScreenSizeImmediate = size => {
+	enableProfileFor();
+	const start = getProfileStart();
 	const xxlSize = select('maxiBlocks').receiveXXLSize();
 	const breakpoints = select('maxiBlocks').receiveMaxiBreakpoints();
 
@@ -15,9 +22,13 @@ const setScreenSizeImmediate = size => {
 			deviceType: size,
 			width: size !== 'xxl' ? breakpoints[size] : xxlSize,
 		});
+
+	recordProfile(`setScreenSize immediate ${size}`, start);
 };
 
 const setScreenSize = size => {
+	enableProfileFor();
+	const start = getProfileStart();
 	const now = Date.now();
 
 	// Cancel any pending call
@@ -34,11 +45,13 @@ const setScreenSize = size => {
 			setScreenSizeImmediate(size);
 			pendingCall = null;
 		}, 50);
+		recordProfile(`setScreenSize ${size} throttled`, start);
 		return;
 	}
 
 	lastCallTime = now;
 	setScreenSizeImmediate(size);
+	recordProfile(`setScreenSize ${size}`, start);
 };
 
 // Export for testing

--- a/src/extensions/styles/store/reducer.js
+++ b/src/extensions/styles/store/reducer.js
@@ -5,9 +5,86 @@ import styleGenerator from '@extensions/styles/styleGenerator';
 import controls from './controls';
 import * as defaultGroupAttributes from '@extensions/styles/defaults/index';
 import { MemoCache } from '@extensions/maxi-block/memoizationHelper';
+import {
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 import { omit } from 'lodash';
 
 const BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+const estimateCacheValueSize = value => {
+	if (!value) return 0;
+
+	if (typeof value === 'string') return value.length;
+
+	if (typeof value !== 'object') return 8;
+
+	let size = 0;
+
+	Object.keys(value).forEach(key => {
+		const descriptor = Object.getOwnPropertyDescriptor(value, key);
+		size += key.length;
+
+		if (descriptor?.get) return;
+
+		const entry = descriptor?.value;
+
+		if (typeof entry === 'string') {
+			size += entry.length;
+		} else if (entry && typeof entry === 'object') {
+			Object.keys(entry).forEach(entryKey => {
+				const entryDescriptor = Object.getOwnPropertyDescriptor(
+					entry,
+					entryKey
+				);
+				if (entryDescriptor?.get) return;
+
+				const entryValue = entryDescriptor?.value;
+				size += entryKey.length;
+				size +=
+					typeof entryValue === 'string'
+						? entryValue.length
+						: String(entryValue).length;
+			});
+		} else {
+			size += String(entry).length;
+		}
+	});
+
+	return size;
+};
+
+const createLazyBreakpointStyles = (stylesObj, isIframe, isSiteEditor) => {
+	const breakpointStyles = {};
+
+	BREAKPOINTS.forEach(breakpoint => {
+		Object.defineProperty(breakpointStyles, breakpoint, {
+			configurable: true,
+			enumerable: true,
+			get() {
+				const breakpointStart = getProfileStart();
+				const styles = styleGenerator(
+					stylesObj,
+					isIframe,
+					isSiteEditor,
+					breakpoint
+				);
+				recordProfile(`styleGenerator ${breakpoint}`, breakpointStart);
+
+				Object.defineProperty(breakpointStyles, breakpoint, {
+					configurable: true,
+					enumerable: true,
+					value: styles,
+				});
+
+				return styles;
+			},
+		});
+	});
+
+	return breakpointStyles;
+};
 
 // Enhanced LRU cache for CSS with memory management
 class CSSCache extends MemoCache {
@@ -22,12 +99,16 @@ class CSSCache extends MemoCache {
 
 	set(key, value) {
 		// Estimate memory usage of the CSS content
-		const newSize = JSON.stringify(value).length;
+		const sizeStart = getProfileStart();
+		const newSize = estimateCacheValueSize(value);
+		recordProfile('cssCache estimate new value', sizeStart);
 
 		// Check for existing value and subtract its size from totalSize
 		const oldValue = this.get(key);
 		if (oldValue !== undefined) {
-			const oldSize = JSON.stringify(oldValue).length;
+			const oldSizeStart = getProfileStart();
+			const oldSize = estimateCacheValueSize(oldValue);
+			recordProfile('cssCache estimate old value', oldSizeStart);
 			this.memoryStats.totalSize -= oldSize;
 		}
 
@@ -218,30 +299,23 @@ function reducer(
 			};
 		case 'SAVE_CSS_CACHE': {
 			const { uniqueID, stylesObj, isIframe, isSiteEditor } = action;
+			const saveCacheStart = getProfileStart();
+			const hasExistingCache = !!state.cssCache.get(uniqueID);
 
-			// Check if already cached
-			const existingCache = state.cssCache.get(uniqueID);
-			if (existingCache) {
-				// Move to end (mark as recently used)
-				state.cssCache.set(uniqueID, existingCache);
-				return state;
-			}
-
-			const breakpointStyles = BREAKPOINTS.reduce(
-				(acc, breakpoint) => ({
-					...acc,
-					[breakpoint]: styleGenerator(
-						stylesObj,
-						isIframe,
-						isSiteEditor,
-						breakpoint
-					),
-				}),
-				{}
+			const breakpointStyles = createLazyBreakpointStyles(
+				stylesObj,
+				isIframe,
+				isSiteEditor
 			);
 
 			// Use LRU cache set method (automatically handles size limits)
 			state.cssCache.set(uniqueID, breakpointStyles);
+			recordProfile(
+				hasExistingCache
+					? 'styles SAVE_CSS_CACHE update'
+					: 'styles SAVE_CSS_CACHE new',
+				saveCacheStart
+			);
 
 			return { ...state };
 		}
@@ -250,10 +324,12 @@ function reducer(
 
 			// Get existing cache entry or create new one
 			const existingCache = state.cssCache.get(uniqueID) || {};
-			const updatedCache = {
-				...existingCache,
-				...stylesContent,
-			};
+			const updatedCache = {};
+			Object.defineProperties(
+				updatedCache,
+				Object.getOwnPropertyDescriptors(existingCache)
+			);
+			Object.assign(updatedCache, stylesContent);
 
 			// Update the cache entry
 			state.cssCache.set(uniqueID, updatedCache);

--- a/src/extensions/styles/store/selectors.js
+++ b/src/extensions/styles/store/selectors.js
@@ -35,6 +35,10 @@ export const getPrevSavedAttrs = state => {
 };
 
 export const getCSSCache = (state, uniqueID) => {
+	if (state.cssCache?.get && uniqueID) {
+		return state.cssCache.get(uniqueID) || false;
+	}
+
 	if (state.cssCache && state.cssCache[uniqueID])
 		return state.cssCache[uniqueID];
 

--- a/src/extensions/styles/store/test/reducer.js
+++ b/src/extensions/styles/store/test/reducer.js
@@ -200,7 +200,7 @@ describe('styles store reducer', () => {
 			expect(result.cssCache.get('block1')).toHaveProperty('general');
 		});
 
-		it('Returns existing cache if already present', () => {
+		it('Replaces existing cache when styles are regenerated', () => {
 			const state = getInitialState();
 			const existingCacheEntry = { general: { existingStyles: true } };
 
@@ -217,8 +217,9 @@ describe('styles store reducer', () => {
 
 			const result = reducer(state, action);
 
-			// Should return the existing cache entry (not generate new styles)
-			expect(result.cssCache.get('block1')).toEqual(existingCacheEntry);
+			// Regenerated block styles must invalidate old breakpoint CSS.
+			expect(result.cssCache.get('block1')).not.toBe(existingCacheEntry);
+			expect(result.cssCache.get('block1')).toHaveProperty('general');
 		});
 
 		it('Uses LRU cache behavior with size limits', () => {

--- a/src/extensions/styles/styleGenerator.js
+++ b/src/extensions/styles/styleGenerator.js
@@ -7,6 +7,10 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import viewportUnitsProcessor from './viewportUnitsProcessor';
+import {
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 const ALLOWED_BREAKPOINTS = ['xs', 's', 'm', 'l', 'xl'];
 const BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
@@ -102,17 +106,20 @@ const styleGenerator = (
 	isSiteEditor = false,
 	breakpoint
 ) => {
+	const generatorStart = getProfileStart();
 	let response = '';
 
 	const baseBreakpoint = select('maxiBlocks').receiveBaseBreakpoint();
 	const currentBreakpoint =
 		breakpoint ?? select('maxiBlocks').receiveMaxiDeviceType();
 
+	const viewportStart = getProfileStart();
 	const styles = viewportUnitsProcessor(
 		rawStyles,
 		currentBreakpoint,
 		baseBreakpoint
 	); // replacing viewport units only for the editor
+	recordProfile('styleGenerator viewportUnitsProcessor', viewportStart);
 
 	BREAKPOINTS.forEach(breakpoint => {
 		Object.entries(styles).forEach(([key, value]) => {
@@ -162,6 +169,8 @@ const styleGenerator = (
 			});
 		});
 	});
+
+	recordProfile('styleGenerator total', generatorStart);
 
 	return response;
 };

--- a/src/extensions/styles/styleResolver.js
+++ b/src/extensions/styles/styleResolver.js
@@ -12,6 +12,10 @@ import { isEmpty, isNumber, isBoolean, isObject, merge, isEqual } from 'lodash';
  * Internal dependencies
  */
 import { MemoCache } from '@extensions/maxi-block/memoizationHelper';
+import {
+	getProfileStart,
+	recordProfile,
+} from '@extensions/performance/profiler';
 
 /**
  * Styles resolver with LRU cache optimization
@@ -33,7 +37,9 @@ let cacheStats = {
 
 const cleanContent = content => {
 	// Generate cache key based on content structure
+	const cacheKeyStart = getProfileStart();
 	const cacheKey = JSON.stringify(content);
+	recordProfile('styleResolver cleanContent cache key', cacheKeyStart);
 
 	// Check cache first
 	const cached = cleanContentCache.get(cacheKey);
@@ -70,7 +76,9 @@ const cleanContent = content => {
 
 const getCleanContent = content => {
 	// Generate cache key based on content structure
+	const cacheKeyStart = getProfileStart();
 	const cacheKey = JSON.stringify(content);
+	recordProfile('styleResolver getCleanContent cache key', cacheKeyStart);
 
 	// Check cache first
 	const cached = getCleanContentCache.get(cacheKey);
@@ -101,7 +109,10 @@ const styleResolver = ({ styles, remover = false, breakpoints, uniqueID }) => {
 	if (!styles) return {};
 
 	// Generate cache key for the entire styleResolver operation
+	const resolverStart = getProfileStart();
+	const cacheKeyStart = getProfileStart();
 	const cacheKey = JSON.stringify({ styles, remover, breakpoints, uniqueID });
+	recordProfile('styleResolver root cache key', cacheKeyStart);
 	cacheStats.totalRequests += 1;
 
 	// Check cache first for non-remover operations (removers shouldn't be cached as they have side effects)
@@ -113,6 +124,7 @@ const styleResolver = ({ styles, remover = false, breakpoints, uniqueID }) => {
 			Object.entries(cached).forEach(([target]) => {
 				dispatch('maxiBlocks/styles').updateStyles(target, cached);
 			});
+			recordProfile('styleResolver total', resolverStart);
 			return cached;
 		}
 		cacheStats.misses += 1;
@@ -146,6 +158,8 @@ const styleResolver = ({ styles, remover = false, breakpoints, uniqueID }) => {
 	if (!remover) {
 		styleCache.set(cacheKey, response);
 	}
+
+	recordProfile('styleResolver total', resolverStart);
 
 	return response;
 };


### PR DESCRIPTION
## Summary

This PR improves editor responsiveness when switching MaxiBlocks breakpoints and fixes the stale breakpoint CSS cache path that could make blocks look broken after responsive changes.

The key behavior change is that breakpoint-only renders now reuse cached CSS where possible instead of forcing every selected block through full style generation. When block styles do regenerate, the CSS cache entry for that block is replaced so future breakpoint switches cannot reuse old CSS.

## Root cause

The performance issue came from breakpoint switches causing expensive style work across many blocks. The logs showed repeated `maxiBlockComponent getStylesObject` and `displayStyles` work during responsive changes, especially for rows, columns, buttons, images, and text blocks.

The correctness bug was in `SAVE_CSS_CACHE`: once a block had a cache entry for its `uniqueID`, later regenerated styles were ignored. The active breakpoint could look correct because fresh CSS was injected immediately, but switching breakpoints could pull stale CSS from the old cache entry.

## What changed

- Added a shared MaxiBlocks profiler helper for timing and render-count logs.
- Added profiling around breakpoint resizing, `setScreenSize`, style resolving, style generation, CSS cache writes, block rendering, and inserter rendering.
- Changed CSS cache generation to use lazy per-breakpoint style getters, so CSS for a breakpoint is generated only when needed.
- Changed `SAVE_CSS_CACHE` to replace an existing cache entry when styles regenerate, preventing stale breakpoint CSS.
- Preserved lazy cache descriptors when raw CSS is merged into an existing cache entry.
- Added a cache selector path that supports the `MemoCache`/LRU cache instance.
- Updated `MaxiBlockComponent` so pure breakpoint changes can inject cached breakpoint CSS directly and update responsive classes without full style generation.
- Added viewport-unit detection so blocks using viewport units still regenerate styles when breakpoint context matters.
- Memoized inserter-related components and reduced selected block render churn.
- Simplified the loader check to inspect the current block by `clientId` instead of traversing all blocks.
- Added selected-block responsive audit logs for debugging breakpoint attributes and computed display snapshots.
- Updated the reducer test so regenerated styles must replace existing CSS cache entries.

## User impact

Breakpoint switching should feel much faster in larger layouts while still rendering the correct responsive CSS after edits. The previous stale-cache case should no longer leave blocks visually out of date or broken after changing styles and switching between breakpoints.

## How to test

1. Check out this branch and install dependencies if needed.
2. Run `npm test -- src/extensions/styles/store/test/reducer.js --runInBand`.
3. Run `npm run build`.
4. Load the MaxiBlocks plugin build in a local WordPress editor.
5. Open a page or pattern with nested MaxiBlocks content, especially container, row, column, image, SVG icon, text, and button blocks.
6. Switch between `general`, `xxl`, `xl`, `l`, `m`, `s`, and `xs` breakpoints.
7. Confirm the layout updates immediately and does not show unsupported-block placeholders.
8. Select a block with responsive settings, change a visible style at one breakpoint, then switch away and back. Good examples are SVG/icon width, row gap, column sizing, container width, image width, or absolute position values.
9. Confirm the latest value is preserved visually after switching breakpoints and no old/stale CSS reappears.
10. Repeat with several selected block types and nested rows/columns.
11. Watch the browser console for `MaxiBlocks perf (1s)` logs. Breakpoint-only switches should show cached CSS paths where available and avoid large repeated full-style generation across every block.
12. Confirm there is no `Module build failed` error for `html-dom-parser`/`domhandler` after rebuilding and hard-refreshing the editor.

## Validation

- `npm test -- src/extensions/styles/store/test/reducer.js --runInBand` passed.
- `npm run build` passed with the existing asset-size warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in performance profiler and a responsive attribute audit/logging tool.

* **Performance Improvements**
  * Reduced editor re-renders via memoization of inserters and related UI.
  * Faster, cache-first responsive style handling and improved CSS cache accounting.

* **Bug Fixes**
  * Simplified maxi-block loader detection for more reliable loading behavior.

* **Tests**
  * Updated selector and style-cache tests; normalized line endings in post-content retrieval.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6257)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->