### PR TITLE
Fix advanced number unit control widths

### DIFF
--- a/src/components/advanced-number-control/editor.scss
+++ b/src/components/advanced-number-control/editor.scss
@@ -34,7 +34,7 @@
 	&__input-wrapper {
 		position: relative;
 		flex: none;
-		width: 70px !important;
+		width: 72px !important;
 
 		// Focus state (Keyboard Accessibility)
 		&:focus-within {
@@ -44,10 +44,12 @@
 	}
 
 	&__value {
+		box-sizing: border-box;
+		width: 100%;
 		height: 36px;
-		padding: 0 5px 0 4px !important;
+		padding: 0 21px 0 6px !important;
 		z-index: 0;
-		max-width: 55px;
+		max-width: none;
 
 		// Browser Spinner Hides
 		&::-webkit-outer-spin-button,
@@ -71,23 +73,31 @@
 	/*--- Spinner Controls ---*/
 	&__spinner-container {
 		position: absolute;
-		right: 2px;
+		right: 0;
 		top: 50%;
 		transform: translateY(-48%);
 		flex-direction: column;
 		z-index: 1;
 
-		// Divider line
-		&::before {
+		// Divider lines
+		&::before,
+		&::after {
 			content: '';
 			position: absolute;
-			left: -3px;
 			top: 50%;
 			transform: translateY(-50%);
 			width: 1px;
 			height: 18px;
 			background-color: var(--maxi-grey-light);
 			pointer-events: none;
+		}
+
+		&::before {
+			left: -3px;
+		}
+
+		&::after {
+			right: -4px;
 		}
 	}
 
@@ -192,10 +202,31 @@
 	}
 
 	// Dimensions Control Units
+	.maxi-dimensions-control__units {
+		flex: 0 0 51px !important;
+		width: 51px !important;
+		min-width: 51px !important;
+		max-width: 51px !important;
+		margin-bottom: 0 !important;
+	}
+
+	.maxi-dimensions-control__units .maxi-base-control__field {
+		width: 100%;
+		margin-bottom: 0;
+	}
+
 	.maxi-dimensions-control__units .maxi-select-control__input {
+		background-color: var(--maxi-white) !important;
+		border-left: none !important;
+		border-right: none !important;
+		box-sizing: border-box;
+		flex: 0 0 auto !important;
+		width: 51px !important;
+		min-width: 51px !important;
+		max-width: 51px !important;
 		height: 36px !important;
 		min-height: 36px !important;
-		padding-right: 6px !important;
+		padding: 8px 6px !important;
 	}
 }
 

--- a/src/components/typography-control/editor.scss
+++ b/src/components/typography-control/editor.scss
@@ -419,6 +419,6 @@
 
 .maxi-typography-control:not([class*='maxi-style-cards-control']) {
 	.maxi-advanced-number-control__input-wrapper {
-		width: 50px !important;
+		width: 60px !important;
 	}
 }

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -400,24 +400,6 @@ body .toolbar-item__popover {
 	}
 }
 
-// Tighten unit select spacing inside AdvancedNumberControl only
-body.maxi-blocks--active {
-	.maxi-advanced-number-control
-		.maxi-dimensions-control__units
-		select.maxi-select-control__input {
-		/* Prevent stretching and tighten internal spacing */
-		flex: 0 0 auto !important;
-		width: auto !important;
-		max-width: 60px !important;
-		min-width: 55px !important;
-		padding: 8px 6px !important;
-		background-color: var(--maxi-white) !important;
-		/* Ensure native borders are not shown */
-		border-left: none !important;
-		border-right: none !important;
-	}
-}
-
 /*******************************
 * Style Card Editor Boat Icon and Cloud library Icon
 *******************************/


### PR DESCRIPTION
## Summary

Fixes issue #6118, where AdvancedNumberControl numeric fields were too narrow in the editor UI. The original problem showed up in controls like typography spacing: the numeric value, spinner arrows, unit selector, and reset icon all had to share a compact two-column layout, leaving too little room for the value text.

This PR widens the numeric input area while keeping the control usable when two AdvancedNumberControl fields sit next to each other.

## Original Issue

Issue #6118 reported that input fields in the editor did not have enough width for readable numeric values. The first pass widened the value input, but that exposed a related layout problem: in two-column controls, the unit selector could still consume too much horizontal space and squeeze the value field again.

The final fix handles both parts of the issue:

- the numeric value field has more usable text space;
- the spinner arrows stay visually separated with divider lines;
- the unit selector is constrained so longer labels like `REM` fit without taking extra width from the value field;
- the two-column typography layout remains compact enough for paired controls such as Line height and Bottom gap.

## Root Cause

The unit select width was being controlled in two places. The component stylesheet had the newer 51px values, but `src/css/editor.scss` still included an older AdvancedNumberControl-specific global override with `min-width: 55px` and `max-width: 60px`. That higher-specificity global rule could win in the cascade, so changing the component rule alone did not reliably tighten the unit selector.

The select also sits inside a nested `SelectControl` / `BaseControl` wrapper. Constraining only the `<select>` allowed the wrapper around it to continue taking extra flex space.

## Changes

- Moved the AdvancedNumberControl unit sizing source of truth into `src/components/advanced-number-control/editor.scss`.
- Fixed both the unit wrapper and the select to 51px so the wrapper cannot flex wider than the select.
- Removed the stale global AdvancedNumberControl unit override from `src/css/editor.scss`.
- Kept the typography AdvancedNumberControl input width at 60px to preserve enough value text space when controls sit side by side.
- Kept the spinner divider treatment so the arrows remain visually separated while leaving more room for the numeric value.

## Validation

- `git diff --cached --check`
- `npm run build`

Closes https://github.com/maxi-blocks/maxi-blocks/issues/6118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and layout adjustments for the advanced number control component's input fields and spinner positioning.
  * Increased control width in typography styling for improved alignment.
  * Optimized styling rules for consistent spacing and visual appearance across number and typography control components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6267)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->