### PR TITLE
Hide background image size controls for parallax

### DIFF
--- a/src/components/background-control/imageLayer.js
+++ b/src/components/background-control/imageLayer.js
@@ -648,6 +648,7 @@ const ImageLayerSettings = props => {
 				isHover={isHover}
 				isLayer={isLayer}
 				breakpoint={breakpoint}
+				hideSize={parallaxStatus}
 			/>
 		</>
 	);

--- a/src/components/background-control/sizeAndPositionLayerControl.js
+++ b/src/components/background-control/sizeAndPositionLayerControl.js
@@ -203,6 +203,7 @@ const SizeAndPositionLayerControl = ({
 	isLayer = false,
 	breakpoint,
 	onlyWidth = false,
+	hideSize = false,
 }) => {
 	const { type } = options;
 	const prefix = `${rawPrefix}background-${
@@ -241,12 +242,14 @@ const SizeAndPositionLayerControl = ({
 
 	return (
 		<>
-			<Size
-				{...equivalentProps}
-				options={options}
-				isLayer={isLayer}
-				onlyWidth={onlyWidth}
-			/>
+			{!hideSize && (
+				<Size
+					{...equivalentProps}
+					options={options}
+					isLayer={isLayer}
+					onlyWidth={onlyWidth}
+				/>
+			)}
 			<PositionControl
 				{...options}
 				{...equivalentProps}

--- a/src/components/background-control/sizeAndPositionLayerControl.js
+++ b/src/components/background-control/sizeAndPositionLayerControl.js
@@ -250,18 +250,21 @@ const SizeAndPositionLayerControl = ({
 					onlyWidth={onlyWidth}
 				/>
 			)}
-			<PositionControl
-				{...options}
-				{...equivalentProps}
-				className='maxi-background-control__position'
-				disablePosition
-				defaultAttributes={getDefaultLayerWithBreakpoint(
-					`${type === 'shape' ? 'SVG' : type}Options`,
-					'general',
-					isHover
-				)}
-				disableRTC
-			/>
+			{!hideSize && (
+				<PositionControl
+					{...options}
+					{...equivalentProps}
+					className='maxi-background-control__position'
+					label={__('Position', 'maxi-blocks')}
+					disablePosition
+					defaultAttributes={getDefaultLayerWithBreakpoint(
+						`${type === 'shape' ? 'SVG' : type}Options`,
+						'general',
+						isHover
+					)}
+					disableRTC
+				/>
+			)}
 		</>
 	);
 };


### PR DESCRIPTION
## Summary

Hides the background image Height / Width controls when parallax is enabled.

## Why

When parallax is active, changing the background image Height / Width values does not affect the rendered background. Leaving those controls visible makes the Settings tab look editable in a way that can confuse users.

## What Changed

- Passes the current background image parallax state into `SizeAndPositionLayerControl`.
- Adds a `hideSize` option so the size controls can be hidden while keeping the position controls visible.
- Applies `hideSize` only for image layers when `background-image-parallax-status` is enabled.

## Validation

- `git diff --check`
- `npm run build`

Closes #6265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background image layer controls now hide size and position controls when the parallax effect is enabled, simplifying the interface and reducing visual clutter for parallax-enabled layers. This makes configuring parallax backgrounds more focused and prevents irrelevant size/position options from being shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6268)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->