### PR TITLE
Add spacing to accordion line controls

### DIFF
--- a/src/blocks/accordion-maxi/components/accordion-line-control/index.js
+++ b/src/blocks/accordion-maxi/components/accordion-line-control/index.js
@@ -68,7 +68,11 @@ const AccordionLineControl = props => {
 				items={[
 					{
 						label: __('Normal', 'maxi-blocks'),
-						content: <DividerControl {...props} disableRTC />,
+						content: (
+							<div className='maxi-accordion-line-control__normal-state'>
+								<DividerControl {...props} disableRTC />
+							</div>
+						),
 					},
 					{
 						label: __('Hover', 'maxi-blocks'),

--- a/src/blocks/accordion-maxi/editor.scss
+++ b/src/blocks/accordion-maxi/editor.scss
@@ -9,6 +9,10 @@
 	margin-bottom: 5px !important;
 }
 
+.maxi-accordion-line-control__normal-state {
+	margin-top: 10px !important;
+}
+
 .maxi-skin-control__reveal-action-tabs {
 	.components-button {
 		background: var(--maxi-white);


### PR DESCRIPTION
## Summary

Adds the missing spacing for the Accordion block's Line settings normal state.

## What changed

- Wrapped the normal Line settings `DividerControl` with a scoped accordion line control class.
- Added a small top margin for that normal state so the controls have the same breathing room expected in the inspector UI.

## Why

The Accordion Line settings panel had spacing for hover and active controls, but the normal state rendered the divider controls directly without a spacing hook. This made the normal state feel cramped compared with the rest of the accordion settings UI.

## Testing

- `git diff --check`
- `npm run build` passed with the existing webpack asset-size warnings

Closes https://github.com/maxi-blocks/maxi-blocks/issues/6185