### PR TITLE
Fix typography italic toggle

### DIFF
--- a/src/components/typography-control/index.js
+++ b/src/components/typography-control/index.js
@@ -32,7 +32,11 @@ import {
 } from '@extensions/styles';
 import { getListTypographyAttributes } from '@extensions/text/lists';
 import { getDefaultSCValue } from '@extensions/style-cards';
-import { getClosestAvailableFontWeight, getWeightOptions } from './utils';
+import {
+	getClosestAvailableFontWeight,
+	getToggledFontStyle,
+	getWeightOptions,
+} from './utils';
 import onChangeFontWeight from '@components/font-weight-control/utils';
 
 /**
@@ -1076,11 +1080,8 @@ const TypographyControl = props => {
 									onClick={() => {
 										const currentStyle =
 											getValue('font-style');
-										const isActive =
-											currentStyle === 'italic';
-										const targetStyle = isActive
-											? undefined
-											: 'italic';
+										const targetStyle =
+											getToggledFontStyle(currentStyle);
 										const fontName =
 											getValue('font-family') ??
 											getDefault('font-family');

--- a/src/components/typography-control/test/utils.spec.js
+++ b/src/components/typography-control/test/utils.spec.js
@@ -1,4 +1,7 @@
-import { getClosestAvailableFontWeight } from '@components/typography-control/utils';
+import {
+	getClosestAvailableFontWeight,
+	getToggledFontStyle,
+} from '@components/typography-control/utils';
 import { select } from '@wordpress/data';
 
 jest.mock('@wordpress/data', () => {
@@ -50,5 +53,16 @@ describe('getClosestAvailableFontWeight', () => {
 		const result = getClosestAvailableFontWeight(font, targetWeight);
 
 		expect(result).toBe(900);
+	});
+});
+
+describe('getToggledFontStyle', () => {
+	it('returns italic when the current style is not italic', () => {
+		expect(getToggledFontStyle('normal')).toBe('italic');
+		expect(getToggledFontStyle(undefined)).toBe('italic');
+	});
+
+	it('returns normal when the current style is italic', () => {
+		expect(getToggledFontStyle('italic')).toBe('normal');
 	});
 });

--- a/src/components/typography-control/utils.js
+++ b/src/components/typography-control/utils.js
@@ -91,3 +91,6 @@ export const getClosestAvailableFontWeight = (font, targetWeight) =>
 			Math.abs(Number(targetWeight) - Number(prevValue)) -
 			Math.abs(Number(targetWeight) - Number(currValue))
 	)[0].value;
+
+export const getToggledFontStyle = fontStyle =>
+	fontStyle === 'italic' ? 'normal' : 'italic';


### PR DESCRIPTION
## Summary
Fixes the typography italic toggle so clicking italic a second time reliably removes italic styling across text controls.

## What changed
- Added a small `getToggledFontStyle` helper that toggles `italic` to `normal` and non-italic values to `italic`.
- Updated the typography italic button to use the helper instead of writing `undefined` when disabling italic.
- Added unit coverage for both italic enable and disable behavior.

## Why / root cause
The italic button previously set `font-style` to `undefined` when turning italic off. The typography update path filters out undefined values, so the remove-italic update could be dropped and the text could remain italic. Writing the explicit CSS value `normal` keeps the update in the attribute/style flow.

## Testing
- `npm test -- src/components/typography-control/test/utils.spec.js --runInBand`
- `git diff --check`
- `npm run build` passed with the existing webpack size warnings.

## Closing issue link
Closes https://github.com/maxi-blocks/maxi-blocks/issues/6212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored italic formatting logic in the typography control component to use a dedicated utility function for toggling font styles.

* **Tests**
  * Added unit tests for font style toggling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6274)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->