### PR TITLE
Fix first-load backend style state

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -109,6 +109,39 @@ function ensureBlockMoveStyleSheet() {
  */
 let pendingStyleDisplays = [];
 let styleDisplayScheduled = false;
+let backendStyleFirstLoadCompat = null;
+
+function getWordPressCoreVersion() {
+	if (typeof window !== 'undefined') {
+		try {
+			return (
+				window.maxiSettings?.core?.version ??
+				window.parent?.maxiSettings?.core?.version
+			);
+		} catch (e) {
+			return window.maxiSettings?.core?.version;
+		}
+	}
+
+	return select('maxiBlocks')?.receiveMaxiSettings?.()?.core?.version;
+}
+
+function shouldRunBackendStyleFirstLoadCompat() {
+	if (backendStyleFirstLoadCompat !== null) {
+		return backendStyleFirstLoadCompat;
+	}
+
+	const coreVersion = getWordPressCoreVersion();
+
+	if (!coreVersion) {
+		return true;
+	}
+
+	backendStyleFirstLoadCompat =
+		compareVersions(String(coreVersion), '7.0') < 0;
+
+	return backendStyleFirstLoadCompat;
+}
 
 function flushStyleDisplays() {
 	if (pendingStyleDisplays.length === 0) return;
@@ -1029,10 +1062,9 @@ class MaxiBlockComponent extends Component {
 				body: null,
 				breakpoint: null,
 			});
-		const hasExpectedEditorState = this.hasResponsiveEditorState(
-			editorWrapper,
-			currentBreakpoint
-		);
+		const hasExpectedEditorState =
+			!this.shouldRunBackendStyleFirstLoadCompat() ||
+			this.hasResponsiveEditorState(editorWrapper, currentBreakpoint);
 
 		if (
 			cache.doc === iframeDocument &&
@@ -1858,9 +1890,14 @@ class MaxiBlockComponent extends Component {
 		// Update responsive classes for non-XXL breakpoint changes, or when in general mode
 		// with a valid base breakpoint (handles first load with iframe canvas where the
 		// maxi-blocks-responsive attribute is not set by breakpointResizer)
+		const shouldSyncFirstLoadResponsiveState =
+			this.shouldRunBackendStyleFirstLoadCompat() &&
+			this.props.deviceType === 'general' &&
+			this.props.baseBreakpoint;
+
 		if (
 			(isBreakpointChange && this.props.deviceType !== 'xxl') ||
-			(this.props.deviceType === 'general' && this.props.baseBreakpoint)
+			shouldSyncFirstLoadResponsiveState
 		) {
 			this.updateResponsiveClasses(
 				this.editorIframe,
@@ -2083,7 +2120,7 @@ class MaxiBlockComponent extends Component {
 			this.copyMaxiVariablesToIframe(iframeDocument, iframe);
 			this.ensureMaxiStylesLoaded(iframeDocument, iframe);
 		}
-		if (iframe) {
+		if (iframe && this.shouldRunBackendStyleFirstLoadCompat()) {
 			this.ensureIframeEditorState(iframeDocument, currentBreakpoint);
 			this.setupEditorCanvasStateObserver(iframeDocument);
 		}
@@ -2102,6 +2139,24 @@ class MaxiBlockComponent extends Component {
 
 	addMaxiClassesToIframe(iframeDocument, editorWrapper, currentBreakpoint) {
 		iframeDocument.body.classList.add('maxi-blocks--active');
+
+		if (!this.shouldRunBackendStyleFirstLoadCompat()) {
+			const { isPreview } = this.getPreviewElements(
+				editorWrapper,
+				currentBreakpoint
+			);
+
+			if (!isPreview) {
+				return;
+			}
+
+			editorWrapper.setAttribute(
+				'maxi-blocks-responsive',
+				currentBreakpoint
+			);
+			return;
+		}
+
 		this.ensureResponsiveEditorState(editorWrapper, currentBreakpoint);
 	}
 
@@ -2498,6 +2553,11 @@ class MaxiBlockComponent extends Component {
 		this.ensureResponsiveEditorState(target, currentBreakpoint);
 	}
 
+	// eslint-disable-next-line class-methods-use-this
+	shouldRunBackendStyleFirstLoadCompat() {
+		return shouldRunBackendStyleFirstLoadCompat();
+	}
+
 	getResolvedResponsiveBreakpoint(currentBreakpoint) {
 		const maxiBlocksStore = select('maxiBlocks');
 		const deviceType =
@@ -2589,6 +2649,8 @@ class MaxiBlockComponent extends Component {
 			});
 			bodyObserver.observe(observedBody, {
 				attributes: true,
+				childList: true,
+				subtree: true,
 				attributeFilter: ['class', 'maxi-blocks-responsive'],
 			});
 		};

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -850,7 +850,6 @@ class MaxiBlockComponent extends Component {
 		this.editorIframe = null;
 		this.templateModal = null;
 		this.previousIframeContent = null;
-		this.blockRef = null;
 
 		// Clear font cache references
 		if (this.fontCache) {
@@ -2439,7 +2438,7 @@ class MaxiBlockComponent extends Component {
 	 */
 	// eslint-disable-next-line class-methods-use-this
 	hasParentWithClass(ref, className) {
-		let parent = ref.current ? ref.current.parentNode : null;
+		let parent = ref?.current ? ref.current.parentNode : null;
 		while (parent) {
 			if (parent.classList && parent.classList.contains(className)) {
 				return true;

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -88,6 +88,7 @@ let blockMoveStyleSheet = null;
  */
 let fseSingletonObserver = null;
 let fseSingletonObserverTimeout = null;
+const editorCanvasStateObservers = new WeakMap();
 
 function ensureBlockMoveStyleSheet() {
 	if (blockMoveStyleSheet) return;
@@ -1026,12 +1027,20 @@ class MaxiBlockComponent extends Component {
 			MaxiBlockComponent.iframeStylesCache ||
 			(MaxiBlockComponent.iframeStylesCache = {
 				doc: null,
+				body: null,
 				breakpoint: null,
 			});
+		const hasExpectedEditorState = this.hasResponsiveEditorState(
+			editorWrapper,
+			currentBreakpoint
+		);
 
 		if (
 			cache.doc === iframeDocument &&
-			cache.breakpoint === currentBreakpoint
+			cache.body === editorWrapper &&
+			cache.breakpoint === currentBreakpoint &&
+			editorWrapper.classList.contains('maxi-blocks--active') &&
+			hasExpectedEditorState
 		) {
 			recordProfile('maxiBlockComponent handleIframeStyles', perfStart);
 			return;
@@ -1056,6 +1065,7 @@ class MaxiBlockComponent extends Component {
 		}
 
 		cache.doc = iframeDocument;
+		cache.body = editorWrapper;
 		cache.breakpoint = currentBreakpoint;
 		recordProfile('maxiBlockComponent handleIframeStyles', perfStart);
 	}
@@ -1748,12 +1758,20 @@ class MaxiBlockComponent extends Component {
 				MaxiBlockComponent.breakpointSwitchCache ||
 				(MaxiBlockComponent.breakpointSwitchCache = {
 					doc: null,
+					body: null,
 					breakpoint: null,
 				});
+			const iframeBody = iframeDoc?.body || null;
 
 			const cacheHit =
 				cache.doc === iframeDoc &&
-				cache.breakpoint === this.props.deviceType;
+				cache.body === iframeBody &&
+				cache.breakpoint === this.props.deviceType &&
+				iframeBody?.classList.contains('maxi-blocks--active') &&
+				this.hasResponsiveEditorState(
+					iframeBody,
+					this.props.deviceType
+				);
 
 			if (!cacheHit) {
 				this.handleIframeStyles(
@@ -1765,6 +1783,7 @@ class MaxiBlockComponent extends Component {
 					this.props.deviceType
 				);
 				cache.doc = iframeDoc;
+				cache.body = iframeBody;
 				cache.breakpoint = this.props.deviceType;
 			}
 
@@ -2065,6 +2084,10 @@ class MaxiBlockComponent extends Component {
 			this.copyMaxiVariablesToIframe(iframeDocument, iframe);
 			this.ensureMaxiStylesLoaded(iframeDocument, iframe);
 		}
+		if (iframe) {
+			this.ensureIframeEditorState(iframeDocument, currentBreakpoint);
+			this.setupEditorCanvasStateObserver(iframeDocument);
+		}
 
 		// Clear previous iframe references
 		if (this.previousIframeContent) {
@@ -2080,16 +2103,7 @@ class MaxiBlockComponent extends Component {
 
 	addMaxiClassesToIframe(iframeDocument, editorWrapper, currentBreakpoint) {
 		iframeDocument.body.classList.add('maxi-blocks--active');
-		const { isPreview } = this.getPreviewElements(
-			editorWrapper,
-			currentBreakpoint
-		);
-
-		if (!isPreview) {
-			return;
-		}
-
-		editorWrapper.setAttribute('maxi-blocks-responsive', currentBreakpoint);
+		this.ensureResponsiveEditorState(editorWrapper, currentBreakpoint);
 	}
 
 	copyFontsToIframe(iframeDocument, iframe) {
@@ -2478,39 +2492,121 @@ class MaxiBlockComponent extends Component {
 		const target = iframe?.contentDocument?.body || document.body;
 		if (!target) return;
 
-		// Resolve 'general' to the actual window breakpoint so the attribute
-		// matches what breakpointResizer writes (e.g. 'xl' not 'general').
-		// This ensures CSS rules like [maxi-blocks-responsive="xl"] match.
-		const resolvedBreakpoint =
-			currentBreakpoint === 'general'
-				? this.props.baseBreakpoint || currentBreakpoint
-				: currentBreakpoint;
-
-		const cache =
-			MaxiBlockComponent.responsiveClassCache ||
-			(MaxiBlockComponent.responsiveClassCache = {
-				target: null,
-				breakpoint: null,
-			});
-
-		if (
-			cache.target === target &&
-			cache.breakpoint === resolvedBreakpoint
-		) {
+		if (this.hasResponsiveEditorState(target, currentBreakpoint)) {
 			return;
 		}
 
-		const editorWrapper = target.classList.contains('editor-styles-wrapper')
+		this.ensureResponsiveEditorState(target, currentBreakpoint);
+	}
+
+	getResolvedResponsiveBreakpoint(currentBreakpoint) {
+		const maxiBlocksStore = select('maxiBlocks');
+		const deviceType =
+			currentBreakpoint ??
+			maxiBlocksStore?.receiveMaxiDeviceType?.() ??
+			this.props.deviceType;
+
+		if (deviceType !== 'general') return deviceType;
+
+		return (
+			maxiBlocksStore?.receiveBaseBreakpoint?.() ??
+			this.props.baseBreakpoint ??
+			deviceType
+		);
+	}
+
+	getResponsiveEditorWrapper(target) {
+		if (!target) return null;
+
+		return target.classList?.contains('editor-styles-wrapper')
 			? target
-			: target.querySelector('.editor-styles-wrapper');
-		if (editorWrapper) {
+			: target.querySelector?.('.editor-styles-wrapper');
+	}
+
+	hasResponsiveEditorState(target, currentBreakpoint) {
+		const editorWrapper = this.getResponsiveEditorWrapper(target);
+		if (!editorWrapper) return false;
+
+		return (
+			editorWrapper.getAttribute('maxi-blocks-responsive') ===
+			this.getResolvedResponsiveBreakpoint(currentBreakpoint)
+		);
+	}
+
+	ensureResponsiveEditorState(target, currentBreakpoint) {
+		const editorWrapper = this.getResponsiveEditorWrapper(target);
+		if (!editorWrapper) return;
+
+		const resolvedBreakpoint =
+			this.getResolvedResponsiveBreakpoint(currentBreakpoint);
+
+		if (
+			editorWrapper.getAttribute('maxi-blocks-responsive') !==
+			resolvedBreakpoint
+		) {
 			editorWrapper.setAttribute(
 				'maxi-blocks-responsive',
 				resolvedBreakpoint
 			);
-			cache.target = target;
-			cache.breakpoint = resolvedBreakpoint;
 		}
+	}
+
+	ensureIframeEditorState(iframeDocument, currentBreakpoint) {
+		const editorWrapper = iframeDocument?.body;
+		if (!editorWrapper) return;
+
+		editorWrapper.classList.add('maxi-blocks--active');
+		this.ensureResponsiveEditorState(editorWrapper, currentBreakpoint);
+	}
+
+	setupEditorCanvasStateObserver(iframeDocument) {
+		if (
+			!iframeDocument?.documentElement ||
+			editorCanvasStateObservers.has(iframeDocument) ||
+			typeof MutationObserver === 'undefined'
+		) {
+			return;
+		}
+
+		let observedBody = null;
+		let bodyObserver = null;
+		const schedule =
+			typeof requestAnimationFrame === 'function'
+				? requestAnimationFrame
+				: callback => setTimeout(callback, 0);
+
+		const applyEditorState = () => {
+			this.ensureIframeEditorState(iframeDocument);
+
+			if (observedBody === iframeDocument.body) return;
+
+			if (bodyObserver) bodyObserver.disconnect();
+
+			observedBody = iframeDocument.body;
+			if (!observedBody) return;
+
+			bodyObserver = new MutationObserver(() => {
+				schedule(() => this.ensureIframeEditorState(iframeDocument));
+			});
+			bodyObserver.observe(observedBody, {
+				attributes: true,
+				attributeFilter: ['class', 'maxi-blocks-responsive'],
+			});
+		};
+
+		const documentObserver = new MutationObserver(() => {
+			schedule(applyEditorState);
+		});
+		documentObserver.observe(iframeDocument.documentElement, {
+			childList: true,
+		});
+		applyEditorState();
+		editorCanvasStateObservers.set(iframeDocument, {
+			documentObserver,
+			get bodyObserver() {
+				return bodyObserver;
+			},
+		});
 	}
 
 	copyGeneralToXL(obj) {


### PR DESCRIPTION
## Summary

Fixes the backend/editor style break that could happen once on first editor load and then repair itself when a responsive breakpoint was clicked.

The first-load compatibility path is now limited to WordPress versions before `7.0`, because the original bug reproduces on WordPress 6 but the extra observer/state sync is not needed on WordPress 7 and can slow editor load there.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/6275

## What changed

- Tightened the editor iframe style cache so it no longer treats the iframe document and breakpoint as sufficient proof that the editor canvas is ready.
- Added the iframe body to the cache identity check, because WordPress can mutate or replace the first-load editor canvas body while the document object and breakpoint remain the same.
- Required the cached iframe path to still have the expected Maxi editor state before skipping setup:
  - `maxi-blocks--active` on the iframe body.
  - the correct `maxi-blocks-responsive` value on the editor styles wrapper.
- Ensured the editor iframe can get the correct responsive state, including `general` resolving to the current base breakpoint.
- Added a focused iframe canvas observer for the WordPress 6 first-load compatibility path.
- Updated that observer from CodeRabbit feedback so it also watches wrapper insertion and subtree mutations, not only body attributes.
- Added a WordPress core version gate using the localized `maxiSettings.core.version` value:
  - WordPress `< 7.0`: run the first-load backend style compatibility path.
  - WordPress `>= 7.0`: skip that compatibility path and keep the normal editor styling flow.
- Cached the resolved compatibility decision after the WordPress version is available to avoid repeated version reads in hot style paths.

## Why / root cause

The recent merge scan showed this was not caused by PR #6157 alone.

The direct break came from the interaction of the breakpoint/style optimization work in:

- https://github.com/maxi-blocks/maxi-blocks/pull/6262
- https://github.com/maxi-blocks/maxi-blocks/pull/6217

Those changes introduced cached breakpoint CSS reuse, iframe document/breakpoint reuse, and deferred initial `displayStyles()` work through `scheduleDisplayStyles(... requestAnimationFrame ...)`.

PR #6157 also mattered, but mainly because it exposed the timing gap. It added the store-index readiness path in `getAllStylesAreSaved`, so first editor load became more sensitive to whether the Maxi block store and iframe canvas state had fully caught up.

The debug log matched that sequence:

- WordPress had `194` Maxi client IDs.
- The Maxi block store was still incomplete at `123` blocks.
- `allStylesAreSaved` became `true` before the final `71`-block batch flush completed.
- After the final flush, the store reached `194/194` and the fast path was correct.

Clicking a responsive breakpoint fixed the page because it forced the responsive/style path to run again after the iframe body was stable. The stale assumption was that matching iframe document + breakpoint meant the iframe editor state was still valid. That is not always true on first load.

This fix makes the cached path verify the actual iframe body and responsive attribute before skipping setup, and it re-applies the editor state if WordPress 6 mutates the canvas during first load. WordPress 7 does not need that compatibility path, so it is skipped there for editor-load performance.

## Testing

- `git diff --check`
- `git diff --check origin/fix/backend-style-first-load..HEAD`
- `npm test -- src/extensions/styles/test/setScreenSize.js --runInBand`
- `npm run build`

`npm run build` completed successfully with the existing webpack asset-size warnings for the large MaxiBlocks bundles.

Local environment smoke checks:

- WordPress 6.4.3 on `http://localhost:8888` responds.
- WordPress 7.0-RC4 on `http://localhost:8890` responds.
- Editor route loaded on both local sites.

## Manual testing

WordPress 6:

1. Open `http://localhost:8888/wp-admin/post-new.php?post_type=page`.
2. Open or create a page with MaxiBlocks content.
3. Hard refresh the editor.
4. Do not click any responsive breakpoint after load.
5. Wait 1-2 minutes.
6. Confirm backend styles remain applied and do not disappear or degrade.
7. Click through responsive breakpoints and confirm the view still updates normally.
8. Reload once more and confirm the issue does not only repair after the first breakpoint click.

WordPress 7:

1. Open `http://localhost:8890/wp-admin/post-new.php?post_type=page`.
2. Confirm editor load feels normal/fast.
3. Confirm Style Cards and Cloud Library still open.
4. Click through responsive breakpoints and confirm the view still updates normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of per-iframe responsive editor state and responsive attributes to prevent visual drift during DOM changes and breakpoint switches.
  * Ensured responsive classes re-apply reliably when iframe content mutates.

* **Performance Improvements**
  * Smarter caching to skip unnecessary style/class updates during breakpoint transitions.
  * Faster, more stable breakpoint switching with reduced redundant DOM/styling work.

* **Compatibility**
  * Added first-load compatibility handling for older environments to ensure correct responsive state on initial load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6276)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->