### PR TITLE
Fix Advanced CSS validation persistence

### DIFF
--- a/src/components/advanced-css-control/index.js
+++ b/src/components/advanced-css-control/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,6 +10,7 @@ import { useState } from '@wordpress/element';
 import Button from '@components/button';
 import CssCodeEditor from '@components/css-code-editor';
 import { getLastBreakpointAttribute } from '@extensions/styles';
+import { getAdvancedCssChange } from './utils';
 
 /**
  * Styles
@@ -19,35 +20,70 @@ import withRTC from '@extensions/maxi-block/withRTC';
 
 const AdvancedCssControl = ({ breakpoint, onChange, ...attributes }) => {
 	const [isExampleShown, setIsExampleShown] = useState(false);
+	const [notValidCode, setNotValidCode] = useState();
 
 	const value = getLastBreakpointAttribute({
 		target: 'advanced-css',
 		breakpoint,
 		attributes,
 	});
+	const currentAdvancedCss = attributes[`advanced-css-${breakpoint}`];
 
-	const transformCssCode = code => {
+	const transformCssCode = useCallback(code => {
 		if (!code) return '';
 
 		// Check if the code starts with a selector.
 		const selectorRegex =
-			/([a-zA-Z0-9\-_\s.,#:*[\]="'>+~()|^$!/%]*?)\s*{([^}]*)}/;
+			/([@a-zA-Z0-9\-_\s.,#:*[\]="'>+~()|^$!/%]*?)\s*{([^}]*)}/;
 		const matches = code.match(selectorRegex);
 
 		// If the code doesn't start with a selector, find the first selector and wrap everything before it with 'body'
+		if (matches?.index > 0) {
+			return `body {${code.substring(
+				0,
+				matches.index
+			)}}${code.substring(matches.index)}`;
+		}
+
 		if (!matches) {
-			const firstSelectorIndex = code.search(
-				/([a-zA-Z0-9\-_\s.,#:*[\]="'>+~()|^$!/%]*?)\s*{([^}]*)}/
-			);
-			if (firstSelectorIndex > 0) {
-				return `body {${code.substring(
-					0,
-					firstSelectorIndex
-				)}}${code.substring(firstSelectorIndex)}`;
-			}
 			return `body {${code}}`; // if there's no selector at all in the input
 		}
 		return code;
+	}, []);
+
+	useEffect(() => {
+		if (currentAdvancedCss === undefined) return;
+
+		const { isValid, valueToPersist, shouldUpdateAttribute } =
+			getAdvancedCssChange({
+				code: currentAdvancedCss,
+				currentValue: currentAdvancedCss,
+				transformCssCode,
+			});
+
+		if ((!isValid || valueToPersist === undefined) && shouldUpdateAttribute)
+			onChange(valueToPersist);
+	}, [currentAdvancedCss, onChange, transformCssCode]);
+
+	const onChangeCssCode = code => {
+		const {
+			isValid,
+			notValidCode: nextNotValidCode,
+			valueToPersist,
+			shouldUpdateAttribute,
+		} = getAdvancedCssChange({
+			code,
+			currentValue: currentAdvancedCss,
+			transformCssCode,
+		});
+
+		if (isValid) {
+			setNotValidCode();
+		} else {
+			setNotValidCode(nextNotValidCode);
+		}
+
+		if (shouldUpdateAttribute) onChange(valueToPersist);
 	};
 
 	return (
@@ -56,8 +92,8 @@ const AdvancedCssControl = ({ breakpoint, onChange, ...attributes }) => {
 				'Affects only current block, you can add selectors for inner elements.',
 				'maxi-blocks'
 			)}
-			value={value}
-			onChange={onChange}
+			value={notValidCode ?? value}
+			onChange={onChangeCssCode}
 			transformCssCode={transformCssCode}
 		>
 			<div className='maxi-advanced-css-control__example-wrapper'>

--- a/src/components/advanced-css-control/test/utils.js
+++ b/src/components/advanced-css-control/test/utils.js
@@ -1,0 +1,187 @@
+import {
+	getAdvancedCssChange,
+	isValidAdvancedCss,
+} from '@components/advanced-css-control/utils';
+
+const transformCssCode = code => {
+	if (!code) return '';
+
+	const selectorRegex =
+		/([@a-zA-Z0-9\-_\s.,#:*[\]="'>+~()|^$!/%]*?)\s*{([^}]*)}/;
+	const matches = code.match(selectorRegex);
+
+	if (matches?.index > 0) {
+		return `body {${code.substring(0, matches.index)}}${code.substring(
+			matches.index
+		)}`;
+	}
+
+	if (!matches) return `body {${code}}`;
+
+	return code;
+};
+
+describe('advanced-css-control utils', () => {
+	it('validates declaration-only CSS', () => {
+		expect(isValidAdvancedCss('background: red;', transformCssCode)).toBe(
+			true
+		);
+	});
+
+	it('validates mixed declaration and selector CSS', () => {
+		expect(
+			isValidAdvancedCss(
+				`
+					background: red;
+					.wp-block-gallery .wp-block-image {
+						outline: 2px solid blue !important;
+					}
+				`,
+				transformCssCode
+			)
+		).toBe(true);
+	});
+
+	it('validates nested at-rule CSS', () => {
+		expect(
+			isValidAdvancedCss(
+				`
+					@media (min-width: 600px) {
+						.wp-block-gallery {
+							gap: 20px;
+						}
+					}
+				`,
+				transformCssCode
+			)
+		).toBe(true);
+	});
+
+	it('rejects a missing closing brace', () => {
+		expect(
+			isValidAdvancedCss(
+				`
+					.test {
+						color: red;
+				`,
+				transformCssCode
+			)
+		).toBe(false);
+	});
+
+	it('rejects declarations without a property colon', () => {
+		expect(
+			isValidAdvancedCss(
+				`
+					.test {
+						color red;
+					}
+				`,
+				transformCssCode
+			)
+		).toBe(false);
+	});
+
+	it('allows braces and semicolons inside strings', () => {
+		expect(
+			isValidAdvancedCss(
+				`
+					.test::before {
+						content: "{;}";
+					}
+				`,
+				transformCssCode
+			)
+		).toBe(true);
+	});
+
+	it('persists valid Advanced CSS', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '.test { color: red; }',
+				currentValue: '',
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: true,
+			notValidCode: undefined,
+			valueToPersist: '.test { color: red; }',
+			shouldUpdateAttribute: true,
+		});
+	});
+
+	it('skips attribute updates when valid Advanced CSS is unchanged', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '.test { color: red; }',
+				currentValue: '.test { color: red; }',
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: true,
+			notValidCode: undefined,
+			valueToPersist: '.test { color: red; }',
+			shouldUpdateAttribute: false,
+		});
+	});
+
+	it('removes the saved attribute when Advanced CSS is empty', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '',
+				currentValue: '.test { color: blue; }',
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: true,
+			notValidCode: undefined,
+			valueToPersist: undefined,
+			shouldUpdateAttribute: true,
+		});
+	});
+
+	it('skips attribute updates when empty Advanced CSS is already unsaved', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '',
+				currentValue: undefined,
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: true,
+			notValidCode: undefined,
+			valueToPersist: undefined,
+			shouldUpdateAttribute: false,
+		});
+	});
+
+	it('keeps invalid Advanced CSS local without creating a saved attribute', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '.test { color: red;',
+				currentValue: undefined,
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: false,
+			notValidCode: '.test { color: red;',
+			valueToPersist: undefined,
+			shouldUpdateAttribute: false,
+		});
+	});
+
+	it('removes the saved attribute when an existing value becomes invalid', () => {
+		expect(
+			getAdvancedCssChange({
+				code: '.test { color: red;',
+				currentValue: '.test { color: blue; }',
+				transformCssCode,
+			})
+		).toEqual({
+			isValid: false,
+			notValidCode: '.test { color: red;',
+			valueToPersist: undefined,
+			shouldUpdateAttribute: true,
+		});
+	});
+});

--- a/src/components/advanced-css-control/utils.js
+++ b/src/components/advanced-css-control/utils.js
@@ -1,0 +1,158 @@
+const splitCssDeclarations = css => {
+	const declarations = [];
+	let quote = null;
+	let escapeNext = false;
+	let parenthesisDepth = 0;
+	let declaration = '';
+
+	for (let index = 0; index < css.length; index += 1) {
+		const char = css[index];
+
+		if (escapeNext) {
+			declaration += char;
+			escapeNext = false;
+			continue;
+		}
+
+		if (quote) {
+			declaration += char;
+			if (char === '\\') escapeNext = true;
+			else if (char === quote) quote = null;
+			continue;
+		}
+
+		if (char === '"' || char === "'") {
+			quote = char;
+			declaration += char;
+			continue;
+		}
+
+		if (char === '(') parenthesisDepth += 1;
+		else if (char === ')' && parenthesisDepth > 0) parenthesisDepth -= 1;
+
+		if (char === ';' && parenthesisDepth === 0) {
+			declarations.push(declaration);
+			declaration = '';
+			continue;
+		}
+
+		declaration += char;
+	}
+
+	if (declaration.trim()) declarations.push(declaration);
+
+	return declarations;
+};
+
+const stripCssComments = css => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+const isValidDeclarationList = css => {
+	const declarations = splitCssDeclarations(stripCssComments(css));
+
+	return declarations.every(declaration => {
+		const trimmedDeclaration = declaration.trim();
+		if (!trimmedDeclaration) return true;
+
+		const colonIndex = trimmedDeclaration.indexOf(':');
+		if (colonIndex <= 0) return false;
+
+		const propertyName = trimmedDeclaration.substring(0, colonIndex).trim();
+		return /^-{0,2}[_a-zA-Z][-_a-zA-Z0-9]*$/.test(propertyName);
+	});
+};
+
+const getInnermostDeclarationLists = css => {
+	const lists = [];
+	const stack = [];
+	let quote = null;
+	let escapeNext = false;
+	let inComment = false;
+
+	for (let index = 0; index < css.length; index += 1) {
+		const char = css[index];
+		const nextChar = css[index + 1];
+
+		if (inComment) {
+			if (char === '*' && nextChar === '/') {
+				inComment = false;
+				index += 1;
+			}
+			continue;
+		}
+
+		if (escapeNext) {
+			escapeNext = false;
+			continue;
+		}
+
+		if (quote) {
+			if (char === '\\') escapeNext = true;
+			else if (char === quote) quote = null;
+			continue;
+		}
+
+		if (char === '/' && nextChar === '*') {
+			inComment = true;
+			index += 1;
+			continue;
+		}
+
+		if (char === '"' || char === "'") {
+			quote = char;
+			continue;
+		}
+
+		if (char === '{') {
+			if (stack.length) stack[stack.length - 1].hasChildBlock = true;
+			stack.push({ start: index + 1, hasChildBlock: false });
+			continue;
+		}
+
+		if (char === '}') {
+			const block = stack.pop();
+			if (!block) return null;
+			if (!block.hasChildBlock) lists.push(css.substring(block.start, index));
+		}
+	}
+
+	if (quote || inComment || stack.length) return null;
+
+	return lists;
+};
+
+export const isValidAdvancedCss = (code, transformCssCode = value => value) => {
+	if (!code?.trim()) return true;
+
+	const transformedCode = transformCssCode(code);
+	const declarationLists = getInnermostDeclarationLists(transformedCode);
+
+	if (!declarationLists) return false;
+
+	return declarationLists.every(isValidDeclarationList);
+};
+
+export const getAdvancedCssChange = ({
+	code,
+	currentValue,
+	transformCssCode,
+}) => {
+	const nextCode = code ?? '';
+
+	if (isValidAdvancedCss(nextCode, transformCssCode)) {
+		const valueToPersist = nextCode.trim() ? nextCode : undefined;
+
+		return {
+			isValid: true,
+			notValidCode: undefined,
+			valueToPersist,
+			shouldUpdateAttribute: valueToPersist !== currentValue,
+		};
+	}
+
+	return {
+		isValid: false,
+		notValidCode: nextCode,
+		valueToPersist: undefined,
+		shouldUpdateAttribute: currentValue !== undefined,
+	};
+};


### PR DESCRIPTION
## Summary
Fixes Advanced CSS persistence so invalid or blank CSS is not saved into block attributes.

## What changed
- Added local Advanced CSS validation before persisting editor input.
- Keeps invalid CSS visible in the Advanced CSS editor so the user can correct it.
- Removes the saved Advanced CSS attribute by writing `undefined` instead of saving invalid CSS or an empty string.
- Cleans up old empty Advanced CSS attributes when the control loads.
- Added focused unit coverage for valid CSS, invalid CSS, empty CSS, nested `@media`, and string values containing braces/semicolons.

## Why / root cause
The Advanced CSS control passed editor input straight through to block attributes. That meant broken CSS, such as a missing closing brace, could be serialized into the block comment. Later style generation then tried to process that invalid saved CSS and could break page rendering.

The first cleanup attempt still left `"advanced-css-general":""` in the block comment. This update removes the attribute entirely when there is nothing valid to save.

## Testing
- `npm test -- getAdvancedCssObject src/components/advanced-css-control/test/utils.js --runInBand`
- `npm run build`
- `git diff --check`

## Closing issue link
Closes https://github.com/maxi-blocks/maxi-blocks/issues/5150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS editor validation state management and persistence of CSS updates.

* **Improvements**
  * Enhanced handling of invalid CSS input display in the editor.
  * Refined CSS code normalization for better consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6277)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->