### PR TITLE
Fix background layer width with horizontal scroll

### DIFF
--- a/core/blocks/class-group-maxi-block.php
+++ b/core/blocks/class-group-maxi-block.php
@@ -82,6 +82,7 @@ if (!class_exists('MaxiBlocks_Group_Maxi_Block')):
                         'border',
                         'borderWidth',
                         'borderRadius',
+                        'scroll',
                     ]),
                     [ 'block_style' => $block_style,]
                 )

--- a/core/blocks/style-helpers/get_background_styles.php
+++ b/core/blocks/style-helpers/get_background_styles.php
@@ -618,14 +618,41 @@ function get_horizontal_scroll_background_sizing_object($args)
         'is_hover' => $is_hover,
     ]);
 
-    return $horizontal_scroll_status
-        ? [
+    $direct_horizontal_scroll_status_key = 'scroll-horizontal-status-' . $breakpoint . ($is_hover ? '-hover' : '');
+    $direct_horizontal_scroll_status = array_key_exists($direct_horizontal_scroll_status_key, $args)
+        ? $args[$direct_horizontal_scroll_status_key]
+        : null;
+    $breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+    $breakpoint_index = array_search($breakpoint, $breakpoints, true);
+    $previous_breakpoint = $breakpoint_index > 0 ? $breakpoints[$breakpoint_index - 1] : null;
+    $previous_horizontal_scroll_status = $previous_breakpoint
+        ? get_last_breakpoint_attribute([
+            'target' => 'scroll-horizontal-status',
+            'breakpoint' => $previous_breakpoint,
+            'attributes' => $args,
+            'is_hover' => $is_hover,
+        ])
+        : false;
+
+    if (!$horizontal_scroll_status) {
+        if ($direct_horizontal_scroll_status === false && $previous_horizontal_scroll_status) {
+            return [
+                'label' => 'Background layer horizontal scroll sizing',
+                $breakpoint => [
+                    'min-width' => 'initial',
+                ],
+            ];
+        }
+
+        return [];
+    }
+
+    return [
             'label' => 'Background layer horizontal scroll sizing',
             $breakpoint => [
                 'min-width' => 'max-content',
             ],
-        ]
-        : [];
+        ];
 }
 
 

--- a/core/blocks/style-helpers/get_background_styles.php
+++ b/core/blocks/style-helpers/get_background_styles.php
@@ -602,6 +602,32 @@ function get_wrapper_object($args)
     return !empty($response[$breakpoint]) ? $response : [];
 }
 
+function get_horizontal_scroll_background_sizing_object($args)
+{
+    $breakpoint = $args['breakpoint'] ?? 'general';
+    $is_hover = $args['is_hover'] ?? false;
+
+    if ($is_hover) {
+        return [];
+    }
+
+    $horizontal_scroll_status = get_last_breakpoint_attribute([
+        'target' => 'scroll-horizontal-status',
+        'breakpoint' => $breakpoint,
+        'attributes' => $args,
+        'is_hover' => $is_hover,
+    ]);
+
+    return $horizontal_scroll_status
+        ? [
+            'label' => 'Background layer horizontal scroll sizing',
+            $breakpoint => [
+                'min-width' => 'max-content',
+            ],
+        ]
+        : [];
+}
+
 
 function get_svg_background_object($options)
 {
@@ -1106,6 +1132,23 @@ function get_block_background_styles($args)
         $breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
         foreach ($breakpoints as $breakpoint) {
+            $horizontal_scroll_background_sizing = get_horizontal_scroll_background_sizing_object(array_merge(
+                $args,
+                [
+                    'breakpoint' => $breakpoint,
+                    'is_hover' => $is_hover,
+                ]
+            ));
+
+            if (!empty($horizontal_scroll_background_sizing)) {
+                $response[$target]['horizontalScrollBackgroundSizing'] = array_replace_recursive(
+                    isset($response[$target]['horizontalScrollBackgroundSizing'])
+                        ? $response[$target]['horizontalScrollBackgroundSizing']
+                        : [],
+                    $horizontal_scroll_background_sizing
+                );
+            }
+
             $response =  get_background_layers([
                     'response' => $response,
                     'layers' => $layers,

--- a/src/blocks/group-maxi/styles.js
+++ b/src/blocks/group-maxi/styles.js
@@ -109,20 +109,30 @@ const getHoverObject = props => {
 const getStyles = props => {
 	const { uniqueID } = props;
 
+	const blockBackgroundStyles = getBlockBackgroundStyles({
+		...getGroupAttributes(props, [
+			'blockBackground',
+			'border',
+			'borderWidth',
+			'borderRadius',
+			'scroll',
+		]),
+		blockStyle: props.blockStyle,
+	});
+	const {
+		'': blockBackgroundRootStyles = {},
+		...blockBackgroundTargetStyles
+	} = blockBackgroundStyles;
+
 	const response = {
 		[uniqueID]: styleProcessor(
 			{
-				'': getNormalObject(props),
+				'': {
+					...getNormalObject(props),
+					...blockBackgroundRootStyles,
+				},
 				':hover': getHoverObject(props),
-				...getBlockBackgroundStyles({
-					...getGroupAttributes(props, [
-						'blockBackground',
-						'border',
-						'borderWidth',
-						'borderRadius',
-					]),
-					blockStyle: props.blockStyle,
-				}),
+				...blockBackgroundTargetStyles,
 				...getBlockBackgroundStyles({
 					...getGroupAttributes(
 						props,

--- a/src/extensions/styles/helpers/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/getBackgroundStyles.js
@@ -678,6 +678,37 @@ const getWrapperObject = ({
 };
 
 /**
+ * Get background layer sizing object for horizontal scroll effects
+ *
+ * @param {string}  breakpoint The breakpoint
+ * @param {boolean} isHover    Whether the styles are for a hover state
+ * @param {Object}  props      The attributes
+ */
+const getHorizontalScrollBackgroundSizingObject = ({
+	breakpoint,
+	isHover = false,
+	...props
+}) => {
+	if (isHover) return {};
+
+	const horizontalScrollStatus = getLastBreakpointAttribute({
+		target: 'scroll-horizontal-status',
+		breakpoint,
+		attributes: props,
+		isHover,
+	});
+
+	return horizontalScrollStatus
+		? {
+				label: 'Background layer horizontal scroll sizing',
+				[breakpoint]: {
+					'min-width': 'max-content',
+				},
+		  }
+		: {};
+};
+
+/**
  * Get SVG background object
  *
  * @param {'light'|'dark'} blockStyle The block style
@@ -1341,6 +1372,24 @@ export const getBlockBackgroundStyles = ({
 
 	if (layers.length > 0) {
 		BREAKPOINTS.forEach(breakpoint => {
+			const horizontalScrollBackgroundSizing =
+				getHorizontalScrollBackgroundSizingObject({
+					...props,
+					breakpoint,
+					isHover,
+				});
+
+			if (!isEmpty(horizontalScrollBackgroundSizing)) {
+				response[target] = {
+					...response[target],
+					horizontalScrollBackgroundSizing: merge(
+						{},
+						response?.[target]?.horizontalScrollBackgroundSizing,
+						horizontalScrollBackgroundSizing
+					),
+				};
+			}
+
 			const backgroundLayers = getBackgroundLayers({
 				response,
 				layers,

--- a/src/extensions/styles/helpers/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/getBackgroundStyles.js
@@ -697,15 +697,46 @@ const getHorizontalScrollBackgroundSizingObject = ({
 		attributes: props,
 		isHover,
 	});
+	const directHorizontalScrollStatus = getAttributeValue({
+		target: 'scroll-horizontal-status',
+		props,
+		breakpoint,
+		isHover,
+		returnValueWithoutBreakpoint: false,
+	});
+	const breakpointIndex = BREAKPOINTS.indexOf(breakpoint);
+	const previousBreakpoint = BREAKPOINTS[breakpointIndex - 1];
+	const previousHorizontalScrollStatus =
+		previousBreakpoint &&
+		getLastBreakpointAttribute({
+			target: 'scroll-horizontal-status',
+			breakpoint: previousBreakpoint,
+			attributes: props,
+			isHover,
+		});
 
-	return horizontalScrollStatus
-		? {
+	if (!horizontalScrollStatus) {
+		if (
+			directHorizontalScrollStatus === false &&
+			previousHorizontalScrollStatus
+		) {
+			return {
 				label: 'Background layer horizontal scroll sizing',
 				[breakpoint]: {
-					'min-width': 'max-content',
+					'min-width': 'initial',
 				},
-		  }
-		: {};
+			};
+		}
+
+		return {};
+	}
+
+	return {
+		label: 'Background layer horizontal scroll sizing',
+		[breakpoint]: {
+			'min-width': 'max-content',
+		},
+	};
 };
 
 /**

--- a/src/extensions/styles/helpers/test/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/test/getBackgroundStyles.js
@@ -1579,6 +1579,37 @@ describe('getBackgroundStyles', () => {
 		expect(result).toMatchSnapshot();
 	});
 
+	it('Adds max-content min width when a background layer uses horizontal scroll', () => {
+		const result = getBlockBackgroundStyles({
+			target,
+			isHover: false,
+			blockStyle: 'light',
+			'scroll-horizontal-status-general': true,
+			'background-layers': [
+				{
+					type: 'color',
+					'display-general': 'block',
+					'background-palette-status-general': true,
+					'background-palette-color-general': 1,
+					'background-palette-opacity-general': 1,
+					'background-color-clip-path-status-general': false,
+					'background-color-wrapper-width-general': 100,
+					'background-color-wrapper-width-unit-general': '%',
+					'background-color-wrapper-height-general': 100,
+					'background-color-wrapper-height-unit-general': '%',
+					order: 1,
+					id: 1,
+				},
+			],
+		});
+
+		expect(
+			result[target].horizontalScrollBackgroundSizing.general[
+				'min-width'
+			]
+		).toBe('max-content');
+	});
+
 	it('Should work for button background', () => {
 		const object = {
 			'button-background-active-media-general': 'color',

--- a/src/extensions/styles/helpers/test/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/test/getBackgroundStyles.js
@@ -1579,12 +1579,13 @@ describe('getBackgroundStyles', () => {
 		expect(result).toMatchSnapshot();
 	});
 
-	it('Adds max-content min width when a background layer uses horizontal scroll', () => {
+	it('Adds and resets min width when a background layer uses horizontal scroll', () => {
 		const result = getBlockBackgroundStyles({
 			target,
 			isHover: false,
 			blockStyle: 'light',
 			'scroll-horizontal-status-general': true,
+			'scroll-horizontal-status-m': false,
 			'background-layers': [
 				{
 					type: 'color',
@@ -1608,6 +1609,9 @@ describe('getBackgroundStyles', () => {
 				'min-width'
 			]
 		).toBe('max-content');
+		expect(
+			result[target].horizontalScrollBackgroundSizing.m['min-width']
+		).toBe('initial');
 	});
 
 	it('Should work for button background', () => {


### PR DESCRIPTION
## Summary
Fixes background layers on wide Group Maxi blocks with horizontal scroll/translate enabled so the background continues across the full scrolling content instead of stopping at the viewport edge.

## What changed
- Added horizontal-scroll-aware sizing to the shared background-layer style helper.
- Passed Group Maxi scroll attributes into background style generation in both JS and PHP style paths.
- Merged root background sizing into the Group Maxi root style object so existing group styles are preserved.
- Added a focused unit test for the generated `min-width: max-content` background sizing.

## Why / root cause
The background layer used `width: 100%`, but the group's normal root width could stay constrained to the viewport while horizontal scroll/translate made the visual content extend beyond it. Because the background layer is absolutely positioned inside that root box, it ended at the viewport-width boundary instead of covering the wider scrolled group content.

## Testing
- `npm test -- src/extensions/styles/helpers/test/getBackgroundStyles.js --runInBand`
- `git diff --check`
- `npm run build`

Notes:
- `npm run build` passed with the existing webpack asset-size warnings.
- `npm run lint:js -- src/blocks/group-maxi/styles.js src/extensions/styles/helpers/getBackgroundStyles.js src/extensions/styles/helpers/test/getBackgroundStyles.js` could not run because the repo has ESLint v9 but no `eslint.config.js`.
- `php -l core/blocks/style-helpers/get_background_styles.php` could not run because `php` is not on PATH in this environment.

## Closing issue link
Closes https://github.com/maxi-blocks/maxi-blocks/issues/5431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced group-maxi block backgrounds with proper horizontal-scroll sizing support. Background layers now correctly adapt to scrollable content across all breakpoints and responsive sizes.

* **Tests**
  * Added test coverage for horizontal-scroll background sizing functionality to ensure proper behavior across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->