### PR TITLE
Fix avatar background image size default

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -1274,6 +1274,9 @@ class MaxiBlocks_DynamicContent
         if (empty($dc_relation)) {
             $dc_relation = 'by-id';
         }
+        if (empty($dc_media_size)) {
+            $dc_media_size = 512;
+        }
 
         $media_alt = '';
         $media_caption = '';

--- a/src/extensions/DC/constants.js
+++ b/src/extensions/DC/constants.js
@@ -737,5 +737,6 @@ export const attributeDefaults = {
 		return dictionary[relation];
 	},
 	accumulator: 0,
+	'media-size': 512,
 	'limit-by-archive': null,
 };

--- a/src/extensions/DC/test/getDCValues.js
+++ b/src/extensions/DC/test/getDCValues.js
@@ -9,6 +9,7 @@ jest.mock('@extensions/DC/constants', () => ({
 		relation: 'current',
 		author: '',
 		content: props => props.testProperty || 'default content',
+		'media-size': 512,
 	},
 }));
 
@@ -95,6 +96,22 @@ describe('getDCValues', () => {
 			source: 'wp', // default
 			relation: 'current', // default
 			author: '', // default
+		});
+	});
+
+	it('should default avatar media size when dynamic content does not provide one', () => {
+		const dynamicContent = {
+			'dc-status': true,
+			'dc-field': 'author_avatar',
+			'dc-media-size': undefined,
+		};
+
+		const result = getDCValues(dynamicContent, null);
+
+		expect(result).toEqual({
+			status: true,
+			field: 'author_avatar',
+			mediaSize: 512,
 		});
 	});
 


### PR DESCRIPTION
## Summary
Fixes avatar dynamic-content background images defaulting to a zero or missing media size.

## What changed
- Added the missing dynamic content default for `dc-media-size` so avatar image lookups default to `512`.
- Added the same fallback in the PHP dynamic-content image renderer for frontend/server rendering.
- Added a focused unit test covering an avatar background image layer without an explicit media size.

## Why / root cause
Background image layers use nested dynamic-content attributes and can reach the avatar image path without a populated `dc-media-size`. The shared dynamic-content defaults did not include `media-size`, and the PHP renderer also did not normalize a missing media size, so avatar background images could resolve as size `0`/empty instead of the expected `512px` default used by image blocks.

## Testing
- `npm test -- src/extensions/DC/test/getDCValues.js --runInBand`
- `npm test -- src/extensions/DC/test/getDCValues.js src/extensions/DC/test/getDCMedia.js src/extensions/DC/test/fetchAndUpdateDCData.js --runInBand`
- `git diff --check`
- `npm run build`

PHP lint was not run because `php` is not available on PATH in this environment.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic content images and avatars now default to a size of 512 pixels when no specific size is specified, ensuring consistent rendering across the application.

* **Tests**
  * Added test coverage to verify the default media size behavior for dynamic content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->