### PR TITLE
Fix callout arrow background hover transition

### DIFF
--- a/src/blocks/container-maxi/styles.js
+++ b/src/blocks/container-maxi/styles.js
@@ -211,6 +211,7 @@ const getStyles = props => {
 						'boxShadow',
 					]),
 					blockStyle: props.blockStyle,
+					transition: props.transition,
 				}),
 				...getArrowStyles({
 					...getGroupAttributes(
@@ -228,6 +229,7 @@ const getStyles = props => {
 					...getGroupAttributes(props, ['arrow']),
 					blockStyle: props.blockStyle,
 					isHover: true,
+					transition: props.transition,
 				}),
 				...(props['cl-pagination'] && {
 					' .maxi-pagination': getPaginationStyles(props),

--- a/src/blocks/container-maxi/test/styles.js
+++ b/src/blocks/container-maxi/test/styles.js
@@ -1,0 +1,88 @@
+jest.mock('@extensions/styles', () => ({
+	getGroupAttributes: jest.requireActual('@extensions/styles/getGroupAttributes')
+		.default,
+	styleProcessor: jest.fn(styles => styles),
+}));
+
+jest.mock('@extensions/relations', () => ({
+	getCanvasSettings: jest.fn(() => ({})),
+	getAdvancedSettings: jest.fn(() => ({})),
+}));
+
+jest.mock('src/extensions/styles/getDefaultAttribute.js', () =>
+	jest.fn(() => 0)
+);
+
+jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () => {
+	return jest.fn(() => {
+		return {
+			value: {
+				name: 'Maxi (Default)',
+				status: 'active',
+				light: {
+					styleCard: {},
+					defaultStyleCard: {
+						color: {
+							1: '255,255,255',
+							2: '242,249,253',
+							3: '155,155,155',
+							4: '255,74,23',
+							5: '0,0,0',
+							6: '201,52,10',
+							7: '8,18,25',
+							8: '150,176,203',
+						},
+					},
+				},
+			},
+		};
+	});
+});
+
+import getStyles from '../styles';
+
+describe('container-maxi styles', () => {
+	it('passes background transition settings to callout arrow color elements', () => {
+		const uniqueID = 'container-maxi-arrow-transition-test-u';
+		const result = getStyles({
+			uniqueID,
+			blockStyle: 'light',
+			'arrow-status-general': true,
+			'arrow-side-general': 'bottom',
+			'arrow-position-general': 50,
+			'arrow-width-general': 24,
+			'block-background-status-hover': true,
+			'background-layers': [
+				{
+					type: 'color',
+					'display-general': 'block',
+					'background-palette-status-general': false,
+					'background-color-general': 'rgba(150,200,90)',
+					'background-palette-status-general-hover': false,
+					'background-color-general-hover': 'rgba(61,133,209)',
+					order: 0,
+				},
+			],
+			transition: {
+				canvas: {
+					'background / layer': {
+						'transition-duration-general': 0.3,
+						'transition-delay-general': 0,
+						'easing-general': 'ease',
+						'transition-status-general': true,
+					},
+				},
+			},
+		});
+
+		expect(
+			result[uniqueID][' .maxi-container-arrow:before'].transition
+				.general.transition
+		).toBe('background-color 0.3s 0s ease');
+		expect(
+			result[uniqueID][
+				' .maxi-container-arrow .maxi-container-arrow--content:after'
+			].transition.general.transition
+		).toBe('background-color 0.3s 0s ease');
+	});
+});

--- a/src/extensions/styles/helpers/getArrowStyles.js
+++ b/src/extensions/styles/helpers/getArrowStyles.js
@@ -6,11 +6,13 @@ import getColorRGBAString from '@extensions/styles/getColorRGBAString';
 import getGroupAttributes from '@extensions/styles/getGroupAttributes';
 import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttribute';
 import getPaletteAttributes from '@extensions/styles/getPaletteAttributes';
+import getTransitionStyles from './getTransitionStyles';
+import transitionDefault from '@extensions/styles/transitions/transitionDefault';
 
 /**
  * External dependencies
  */
-import { isNil, isEmpty, isNumber } from 'lodash';
+import { isNil, isEmpty, isNumber, merge } from 'lodash';
 import { __ } from '@wordpress/i18n';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
@@ -274,7 +276,20 @@ const getArrowStyles = props => {
 		}),
 	};
 
-	return response;
+	const arrowBackgroundTransition = getTransitionStyles(props, {
+		canvas: {
+			'background / layer': {
+				...transitionDefault.canvas['background / layer'],
+				target: [
+					`${target} .maxi-container-arrow:before`,
+					`${target} .maxi-container-arrow .maxi-container-arrow--content:after`,
+				],
+				property: 'background-color',
+			},
+		},
+	});
+
+	return merge(response, arrowBackgroundTransition || {});
 };
 
 export default getArrowStyles;

--- a/src/extensions/styles/helpers/test/getArrowStyles.js
+++ b/src/extensions/styles/helpers/test/getArrowStyles.js
@@ -250,6 +250,46 @@ describe('getArrowStyles', () => {
 		expect(result).toMatchSnapshot();
 	});
 
+	it('adds background transitions to callout arrow color elements', () => {
+		const object = {
+			target: '',
+			blockStyle: 'light',
+			'arrow-status-general': true,
+			'block-background-status-hover': true,
+			'background-layers': [
+				{
+					type: 'color',
+					'display-general': 'block',
+					'background-palette-status-general': false,
+					'background-color-general': 'rgba(150,200,90)',
+					order: 0,
+				},
+			],
+			transition: {
+				canvas: {
+					'background / layer': {
+						'transition-duration-general': 0.3,
+						'transition-delay-general': 0,
+						'easing-general': 'ease',
+						'transition-status-general': true,
+					},
+				},
+			},
+		};
+
+		const result = getArrowStyles(object);
+
+		expect(
+			result[' .maxi-container-arrow:before'].transition.general
+				.transition
+		).toBe('background-color 0.3s 0s ease');
+		expect(
+			result[
+				' .maxi-container-arrow .maxi-container-arrow--content:after'
+			].transition.general.transition
+		).toBe('background-color 0.3s 0s ease');
+	});
+
 	it('Return empty arrow styles when arrow status is off', () => {
 		const object = {
 			target: '',


### PR DESCRIPTION
## Summary
Fixes the callout arrow background hover transition for Container Maxi blocks.

## What changed
- Pass the container transition settings into `getArrowStyles()` for both normal and hover arrow style generation.
- Added a container-level unit regression test that covers the real `getStyles()` path and asserts both arrow color pseudo-elements receive the background-color transition.

## Why / root cause
The earlier helper-level fix added transition support inside `getArrowStyles()`, but the Container Maxi style builder was not passing `props.transition` into that helper. As a result, the actual generated container styles still had hover arrow color changes without the configured Background / Layer transition.

## Testing
- Confirmed the new container-level test failed before the fix because `transition.general` was missing on the arrow pseudo-element styles.
- `npm test -- src/blocks/container-maxi/test/styles.js --runInBand`
- `npm test -- src/extensions/styles/helpers/test/getArrowStyles.js src/blocks/container-maxi/test/styles.js --runInBand`
- `git diff --check`
- `npm run build` passed with existing asset-size warnings.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/4528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added smooth transition animations to arrow elements in container components with enhanced background color transitions for improved visual polish.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->