### PR TITLE
Fix responsive box shadow opacity

### DIFF
--- a/src/extensions/styles/helpers/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/getBoxShadowStyles.js
@@ -128,6 +128,17 @@ const getBoxShadowStyles = ({
 
 		const { value: paletteOpacity, defaultValue: defaultPaletteOpacity } =
 			getValue('palette-opacity');
+		const paletteOpacityChanged =
+			paletteStatus &&
+			isNumber(paletteOpacity) &&
+			paletteOpacity !== defaultPaletteOpacity;
+		const resolvedPaletteColor = isNil(paletteColor)
+			? defaultPaletteColor
+			: paletteColor;
+		const resolvedPaletteOpacity =
+			isNil(paletteOpacity) && breakpoint !== 'general'
+				? defaultPaletteOpacity
+				: paletteOpacity;
 
 		const defaultColor = getCachedColor(
 			defaultPaletteColor,
@@ -136,8 +147,8 @@ const getBoxShadowStyles = ({
 		);
 
 		const color = getCachedColor(
-			paletteColor,
-			paletteOpacity,
+			resolvedPaletteColor,
+			resolvedPaletteOpacity,
 			paletteStatus
 		);
 
@@ -173,6 +184,7 @@ const getBoxShadowStyles = ({
 			(!isNil(values['spread-unit']?.value) &&
 				values['spread-unit']?.value !==
 					values['spread-unit']?.defaultValue) ||
+			paletteOpacityChanged ||
 			(!isNil(color) && color !== defaultColor);
 
 		if (!isNotDefault) return;

--- a/src/extensions/styles/helpers/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/getBoxShadowStyles.js
@@ -132,7 +132,7 @@ const getBoxShadowStyles = ({
 			paletteStatus &&
 			isNumber(paletteOpacity) &&
 			paletteOpacity !== defaultPaletteOpacity;
-		const resolvedPaletteColor = isNil(paletteColor)
+		const resolvedPaletteColor = isNil(paletteColor) && paletteOpacityChanged
 			? defaultPaletteColor
 			: paletteColor;
 		const resolvedPaletteOpacity =

--- a/src/extensions/styles/helpers/test/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/test/getBoxShadowStyles.js
@@ -138,6 +138,39 @@ describe('getBoxShadowStyles', () => {
 		expect(result).toMatchSnapshot();
 	});
 
+	it('Returns responsive box-shadow when only palette opacity changes for the same palette color', () => {
+		const object = {
+			'box-shadow-palette-status-general': true,
+			'box-shadow-palette-color-general': 4,
+			'box-shadow-palette-opacity-general': 1,
+			'box-shadow-palette-opacity-l': 0.2,
+			'box-shadow-horizontal-general': 1,
+			'box-shadow-vertical-general': 2,
+			'box-shadow-blur-general': 3,
+			'box-shadow-spread-general': 4,
+			'box-shadow-blur-unit-general': 'px',
+			'box-shadow-horizontal-unit-general': 'px',
+			'box-shadow-vertical-unit-general': 'px',
+			'box-shadow-spread-unit-general': 'px',
+		};
+
+		const result = getBoxShadowStyles({
+			obj: object,
+			blockStyle: 'light',
+		});
+
+		expect(result).toEqual({
+			general: {
+				'box-shadow':
+					'1px 2px 3px 4px rgba(var(--maxi-light-color-4,255,74,23),1)',
+			},
+			l: {
+				'box-shadow':
+					'1px 2px 3px 4px rgba(var(--maxi-light-color-4,255,74,23),0.2)',
+			},
+		});
+	});
+
 	it('Returns box-shadow default styles for IB', () => {
 		const object = {
 			'box-shadow-palette-status-general': true,


### PR DESCRIPTION
## Summary
Fixes responsive box-shadow opacity changes when the box shadow keeps the same palette color across breakpoints.

## What changed
- Updated `getBoxShadowStyles` so responsive-only palette opacity changes are treated as real box-shadow style changes.
- Reused the inherited palette color only for explicit responsive palette-opacity changes so custom hover shadow colors do not emit duplicated responsive rules.
- Added a focused unit test covering same palette color with breakpoint-specific opacity.

## Why / root cause
The style helper compared generated color output against the default color, but opacity-only responsive changes could be skipped because the palette color itself had not changed. When the responsive breakpoint did not explicitly store a palette color, the helper needed to resolve the inherited palette color for that opacity-only palette case, while leaving custom-color hover shadows scoped to their explicit breakpoint output.

## Testing
- `npm test -- src/extensions/styles/helpers/test/getBoxShadowStyles.js --runInBand`
- `npm test -- src/extensions/styles/helpers/test/getBoxShadowStyles.js src/extensions/styles/helpers/test/getArrowStyles.js --runInBand`
- `git diff --check`
- `npm run build` passed with existing webpack asset-size warnings.
- Manual editor check by user: responsive box-shadow opacity now appears fixed.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/4591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved box-shadow rendering with correct palette opacity resolution across responsive breakpoints.

* **Tests**
  * Added test coverage for responsive box-shadow styling with varying palette opacity values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->