### PR TITLE
Fix button quick style icon background state

### DIFF
--- a/src/blocks/button-maxi/getPresetAttributes.js
+++ b/src/blocks/button-maxi/getPresetAttributes.js
@@ -12,13 +12,18 @@ import * as defaultPresets from './defaults';
 const preserveExistingIconAttribute = attr =>
 	/^icon-(width|height)(-unit|-fit-content)?-/.test(attr);
 
+const shouldPreserveExistingIconAttributes = svgType =>
+	['Fill', 'Filled', 'Shape'].includes(svgType);
+
 export const getPresetInlineStyleTargets = ({
 	inlineStylesTargets = {},
 	presetAttributes = {},
 }) => {
 	const shouldCleanIcon = Object.entries(presetAttributes).some(
 		([key, value]) =>
-			key.startsWith('icon-background-active-media') && value === 'none'
+			key.startsWith('icon-background-active-media') &&
+			!key.includes('-hover') &&
+			value === 'none'
 	);
 
 	return shouldCleanIcon && inlineStylesTargets.icon
@@ -42,11 +47,13 @@ const getPresetAttributes = ({
 	if (type === 'icon' && !isEmpty(attributes['icon-content'])) {
 		preset['icon-content'] = attributes['icon-content'];
 
-		if (!isNil(attributes.svgType)) preset.svgType = attributes.svgType;
+		if (shouldPreserveExistingIconAttributes(attributes.svgType)) {
+			if (!isNil(attributes.svgType)) preset.svgType = attributes.svgType;
 
-		Object.entries(attributes).forEach(([key, value]) => {
-			if (preserveExistingIconAttribute(key)) preset[key] = value;
-		});
+			Object.entries(attributes).forEach(([key, value]) => {
+				if (preserveExistingIconAttribute(key)) preset[key] = value;
+			});
+		}
 	}
 
 	if (

--- a/src/blocks/button-maxi/getPresetAttributes.js
+++ b/src/blocks/button-maxi/getPresetAttributes.js
@@ -67,18 +67,8 @@ const getPresetAttributes = ({
 			'icon-'
 		);
 
-		const nonHoverAttr = getGroupAttributes(
-			{ ...preset },
-			['border', 'borderWidth', 'borderRadius'],
-			false,
-			'icon-'
-		);
-
 		Object.keys(hoverAttr).forEach(h => {
 			if (!h.includes('hover')) delete hoverAttr[h];
-		});
-		Object.keys(nonHoverAttr).forEach(h => {
-			if (h.includes('hover')) delete nonHoverAttr[h];
 		});
 
 		newDefaultPresets[presetKey] = {

--- a/src/blocks/button-maxi/getPresetAttributes.js
+++ b/src/blocks/button-maxi/getPresetAttributes.js
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep, isEmpty, isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getGroupAttributes from '@extensions/styles/getGroupAttributes';
+import * as defaultPresets from './defaults';
+
+const preserveExistingIconAttribute = attr =>
+	/^icon-(width|height)(-unit|-fit-content)?-/.test(attr);
+
+export const getPresetInlineStyleTargets = ({
+	inlineStylesTargets = {},
+	presetAttributes = {},
+}) => {
+	const shouldCleanIcon = Object.entries(presetAttributes).some(
+		([key, value]) =>
+			key.startsWith('icon-background-active-media') && value === 'none'
+	);
+
+	return shouldCleanIcon && inlineStylesTargets.icon
+		? [inlineStylesTargets.icon]
+		: [];
+};
+
+const getPresetAttributes = ({
+	attributes,
+	getIconWithColor,
+	number,
+	presets = defaultPresets,
+	type = 'normal',
+}) => {
+	const presetKey = `preset${number}`;
+	const newDefaultPresets = cloneDeep({ ...presets });
+	const preset = newDefaultPresets[presetKey];
+
+	if (!preset) return {};
+
+	if (type === 'icon' && !isEmpty(attributes['icon-content'])) {
+		preset['icon-content'] = attributes['icon-content'];
+
+		if (!isNil(attributes.svgType)) preset.svgType = attributes.svgType;
+
+		Object.entries(attributes).forEach(([key, value]) => {
+			if (preserveExistingIconAttribute(key)) preset[key] = value;
+		});
+	}
+
+	if (
+		!isNil(presets[presetKey]['icon-border-style-general-hover']) &&
+		presets[presetKey]['icon-border-style-general-hover'] !== 'none'
+	) {
+		const hoverAttr = getGroupAttributes(
+			{ ...preset },
+			['border', 'borderWidth', 'borderRadius'],
+			true,
+			'icon-'
+		);
+
+		const nonHoverAttr = getGroupAttributes(
+			{ ...preset },
+			['border', 'borderWidth', 'borderRadius'],
+			false,
+			'icon-'
+		);
+
+		Object.keys(hoverAttr).forEach(h => {
+			if (!h.includes('hover')) delete hoverAttr[h];
+		});
+		Object.keys(nonHoverAttr).forEach(h => {
+			if (h.includes('hover')) delete nonHoverAttr[h];
+		});
+
+		newDefaultPresets[presetKey] = {
+			...preset,
+			...hoverAttr,
+		};
+	}
+
+	const {
+		'icon-stroke-palette-status': strokePaletteStatus,
+		'icon-stroke-palette-status-hover': strokePaletteHoverStatus,
+		'icon-content': rawIcon,
+	} = newDefaultPresets[presetKey];
+
+	let icon = null;
+
+	if (
+		rawIcon &&
+		getIconWithColor &&
+		(strokePaletteStatus || strokePaletteHoverStatus)
+	) {
+		const {
+			'icon-stroke-palette-color': strokePaletteColor,
+			'icon-stroke-palette-color-hover': strokePaletteHoverColor,
+			'icon-inherit': rawIconInherit,
+			'icon-only': rawIconOnly,
+		} = newDefaultPresets[presetKey];
+
+		icon = getIconWithColor(attributes, {
+			paletteStatus: strokePaletteStatus,
+			paletteColor: strokePaletteColor,
+			rawIcon,
+			isInherit: rawIconInherit,
+			isIconOnly: rawIconOnly,
+		});
+
+		icon = getIconWithColor(attributes, {
+			paletteStatus: strokePaletteHoverStatus,
+			paletteColor: strokePaletteHoverColor,
+			isHover: true,
+			rawIcon: icon,
+			isInherit: rawIconInherit,
+			isIconOnly: rawIconOnly,
+		});
+	}
+
+	return {
+		...newDefaultPresets[presetKey],
+		...(icon && { 'icon-content': icon }),
+	};
+};
+
+export default getPresetAttributes;

--- a/src/blocks/button-maxi/inspector.js
+++ b/src/blocks/button-maxi/inspector.js
@@ -8,7 +8,7 @@ import { useCallback, useEffect } from '@wordpress/element';
 /**
  * External dependencies
  */
-import { isEmpty, isNil, cloneDeep, without } from 'lodash';
+import { isEmpty, without } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,8 +17,10 @@ import AccordionControl from '@components/accordion-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import DefaultStylesControl from '@components/default-styles-control';
 import Icon from '@components/icon';
-import * as defaultPresets from './defaults';
-import { getGroupAttributes, getIconWithColor } from '@extensions/styles';
+import getPresetAttributes, {
+	getPresetInlineStyleTargets,
+} from './getPresetAttributes';
+import { getIconWithColor } from '@extensions/styles';
 import { ariaLabelsCategories, customCss } from './data';
 import * as inspectorTabs from '@components/inspector-tabs';
 import { withMaxiInspector } from '@extensions/inspector';
@@ -32,8 +34,13 @@ import * as iconPresets from '@maxi-icons/button-presets/index';
  * Inspector
  */
 const Inspector = props => {
-	const { attributes, deviceType, maxiSetAttributes, inlineStylesTargets } =
-		props;
+	const {
+		attributes,
+		cleanInlineStyles,
+		deviceType,
+		inlineStylesTargets,
+		maxiSetAttributes,
+	} = props;
 	const {
 		'icon-only': iconOnly,
 		'icon-content': icon,
@@ -60,92 +67,19 @@ const Inspector = props => {
 	);
 
 	const onChangePreset = (number, type = 'normal') => {
-		const newDefaultPresets = cloneDeep({ ...defaultPresets });
-
-		if (
-			type === 'icon' &&
-			!isEmpty(attributes['icon-content']) &&
-			attributes['icon-content'] !==
-				defaultPresets[`preset${number}`]['icon-content']
-		)
-			newDefaultPresets[`preset${number}`]['icon-content'] =
-				attributes['icon-content'];
-
-		if (
-			!isNil(
-				defaultPresets[`preset${number}`][
-					'icon-border-style-general-hover'
-				]
-			) &&
-			defaultPresets[`preset${number}`][
-				'icon-border-style-general-hover'
-			] !== 'none'
-		) {
-			const hoverAttr = getGroupAttributes(
-				{ ...newDefaultPresets[`preset${number}`] },
-				['border', 'borderWidth', 'borderRadius'],
-				true,
-				'icon-'
-			);
-
-			const nonHoverAttr = getGroupAttributes(
-				{ ...newDefaultPresets[`preset${number}`] },
-				['border', 'borderWidth', 'borderRadius'],
-				false,
-				'icon-'
-			);
-
-			Object.keys(hoverAttr).forEach(h => {
-				if (!h.includes('hover')) delete hoverAttr[h];
-			});
-			Object.keys(nonHoverAttr).forEach(h => {
-				if (h.includes('hover')) delete nonHoverAttr[h];
-			});
-
-			newDefaultPresets[`preset${number}`] = {
-				...newDefaultPresets[`preset${number}`],
-				...hoverAttr,
-			};
-		}
-
-		const {
-			'icon-stroke-palette-status': strokePaletteStatus,
-			'icon-stroke-palette-status-hover': strokePaletteHoverStatus,
-			'icon-content': rawIcon,
-		} = newDefaultPresets[`preset${number}`];
-
-		let icon = null;
-
-		if (rawIcon && (strokePaletteStatus || strokePaletteHoverStatus)) {
-			const {
-				'icon-stroke-palette-color': strokePaletteColor,
-				'icon-stroke-palette-color-hover': strokePaletteHoverColor,
-				'icon-inherit': rawIconInherit,
-				'icon-only': rawIconOnly,
-			} = newDefaultPresets[`preset${number}`];
-
-			icon = getIconWithColor(attributes, {
-				paletteStatus: strokePaletteStatus,
-				paletteColor: strokePaletteColor,
-				rawIcon,
-				isInherit: rawIconInherit,
-				isIconOnly: rawIconOnly,
-			});
-
-			icon = getIconWithColor(attributes, {
-				paletteStatus: strokePaletteHoverStatus,
-				paletteColor: strokePaletteHoverColor,
-				isHover: true,
-				rawIcon: icon,
-				isInherit: rawIconInherit,
-				isIconOnly: rawIconOnly,
-			});
-		}
-
-		maxiSetAttributes({
-			...newDefaultPresets[`preset${number}`],
-			...(icon && { 'icon-content': icon }),
+		const presetAttributes = getPresetAttributes({
+			attributes,
+			getIconWithColor,
+			number,
+			type,
 		});
+
+		maxiSetAttributes(presetAttributes);
+
+		getPresetInlineStyleTargets({
+			inlineStylesTargets,
+			presetAttributes,
+		}).forEach(target => cleanInlineStyles?.(target));
 	};
 
 	const getCategoriesCss = () => {

--- a/src/blocks/button-maxi/test/getPresetAttributes.js
+++ b/src/blocks/button-maxi/test/getPresetAttributes.js
@@ -1,0 +1,63 @@
+import getPresetAttributes, {
+	getPresetInlineStyleTargets,
+} from '../getPresetAttributes';
+
+describe('button maxi getPresetAttributes', () => {
+	const iconContent =
+		'<svg class="phone-36-fill-maxi-svg" viewBox="0 0 24 24"><path data-fill fill="#081219" d="M0 0h24v24H0z" /></svg>';
+	const getIconWithColor = jest.fn((attributes, { rawIcon }) => rawIcon);
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it.each(['Filled', 'Shape'])(
+		'preserves an existing %s icon type when applying an icon quick style',
+		svgType => {
+			const result = getPresetAttributes({
+				attributes: {
+					'icon-content': iconContent,
+					svgType,
+				},
+				getIconWithColor,
+				number: 4,
+				type: 'icon',
+			});
+
+			expect(result['icon-content']).toBe(iconContent);
+			expect(result.svgType).toBe(svgType);
+		}
+	);
+
+	it('preserves an existing icon width when applying an icon quick style', () => {
+		const result = getPresetAttributes({
+			attributes: {
+				'icon-content': iconContent,
+				'icon-width-general': '96',
+				'icon-width-unit-general': 'px',
+				'icon-width-xxl': '140',
+				svgType: 'Shape',
+			},
+			getIconWithColor,
+			number: 4,
+			type: 'icon',
+		});
+
+		expect(result['icon-width-general']).toBe('96');
+		expect(result['icon-width-unit-general']).toBe('px');
+		expect(result['icon-width-xxl']).toBe('140');
+	});
+
+	it('marks icon inline styles for cleanup when a quick style turns icon background off', () => {
+		const targets = getPresetInlineStyleTargets({
+			inlineStylesTargets: {
+				icon: ' .maxi-button-block__icon',
+			},
+			presetAttributes: {
+				'icon-background-active-media-general': 'none',
+			},
+		});
+
+		expect(targets).toEqual([' .maxi-button-block__icon']);
+	});
+});

--- a/src/blocks/button-maxi/test/getPresetAttributes.js
+++ b/src/blocks/button-maxi/test/getPresetAttributes.js
@@ -48,6 +48,26 @@ describe('button maxi getPresetAttributes', () => {
 		expect(result['icon-width-xxl']).toBe('140');
 	});
 
+	it('uses preset icon widths when switching between line icon quick styles', () => {
+		const result = getPresetAttributes({
+			attributes: {
+				'icon-content': iconContent,
+				'icon-width-general': '14',
+				'icon-width-unit-general': 'px',
+				'icon-width-xxl': '18',
+				'icon-width-l': '14',
+				svgType: 'Line',
+			},
+			getIconWithColor,
+			number: 7,
+			type: 'icon',
+		});
+
+		expect(result['icon-width-general']).toBe('23');
+		expect(result['icon-width-xxl']).toBe('35');
+		expect(result['icon-width-l']).toBeUndefined();
+	});
+
 	it('marks icon inline styles for cleanup when a quick style turns icon background off', () => {
 		const targets = getPresetInlineStyleTargets({
 			inlineStylesTargets: {
@@ -59,5 +79,19 @@ describe('button maxi getPresetAttributes', () => {
 		});
 
 		expect(targets).toEqual([' .maxi-button-block__icon']);
+	});
+
+	it('does not mark icon inline styles for cleanup when only hover icon background is off', () => {
+		const targets = getPresetInlineStyleTargets({
+			inlineStylesTargets: {
+				icon: ' .maxi-button-block__icon',
+			},
+			presetAttributes: {
+				'icon-background-active-media-general': 'color',
+				'icon-background-active-media-general-hover': 'none',
+			},
+		});
+
+		expect(targets).toEqual([]);
 	});
 });

--- a/src/components/icon-control/index.js
+++ b/src/components/icon-control/index.js
@@ -216,6 +216,10 @@ const IconControlResponsiveSettings = withRTC(props => {
 		iconBackgroundActiveMedia || 'none'
 	);
 
+	useEffect(() => {
+		setIconBgActive(iconBackgroundActiveMedia || 'none');
+	}, [iconBackgroundActiveMedia]);
+
 	return (
 		<>
 			{/* Icon-only toggle: Only show on general breakpoint, not in hover state or image blocks */}

--- a/src/components/icon-control/test/index.js
+++ b/src/components/icon-control/test/index.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+import IconControl from '../index';
+
+const mockSettingTabsControl = jest.fn(() => null);
+
+jest.mock('@wordpress/i18n', () => ({
+	__: text => text,
+}));
+
+jest.mock('@components/advanced-number-control', () => () => null);
+jest.mock('@components/axis-control', () => () => null);
+jest.mock('@components/axis-position-control', () => () => null);
+jest.mock('@components/border-control', () => () => null);
+jest.mock('@components/color-control', () => () => null);
+jest.mock('@components/gradient-control', () => () => null);
+jest.mock('@components/icon', () => () => null);
+jest.mock('@components/info-box', () => () => null);
+jest.mock('@components/svg-stroke-width-control', () => () => null);
+jest.mock('@components/svg-width-control', () => () => null);
+jest.mock('@components/toggle-switch', () => () => null);
+jest.mock('@editor/library/modal', () => () => null);
+jest.mock('@extensions/maxi-block/withRTC', () => Component => Component);
+jest.mock('@extensions/svg', () => ({
+	setSVGAriaLabel: jest.fn((ariaLabel, getIcon) => getIcon()),
+	shouldSetPreserveAspectRatio: jest.fn(() => false),
+	togglePreserveAspectRatio: jest.fn(icon => icon),
+}));
+jest.mock('@editor/library/util', () => ({
+	svgAttributesReplacer: jest.fn(icon => icon),
+}));
+
+jest.mock('@components/setting-tabs-control', () => props =>
+	mockSettingTabsControl(props)
+);
+
+jest.mock('@extensions/styles', () => ({
+	getAttributeKey: (target, isHover, prefix = '', breakpoint = 'general') =>
+		`${prefix}${target}-${breakpoint}${isHover ? '-hover' : ''}`,
+	getAttributeValue: jest.fn(() => ''),
+	getDefaultAttribute: jest.fn(() => ''),
+	getGroupAttributes: props => props,
+	getLastBreakpointAttribute: ({
+		target,
+		breakpoint = 'general',
+		attributes,
+		isHover = false,
+	}) => attributes?.[`${target}-${breakpoint}${isHover ? '-hover' : ''}`],
+}));
+
+describe('IconControl', () => {
+	let container;
+	let root;
+
+	const defaultProps = {
+		breakpoint: 'general',
+		getIconWithColor: jest.fn(() => '<svg />'),
+		onChange: jest.fn(),
+		svgType: 'Shape',
+		'icon-content': '<svg />',
+		'icon-inherit': false,
+		'icon-only': true,
+	};
+
+	const getBackgroundTabsProps = () =>
+		mockSettingTabsControl.mock.calls
+			.map(([props]) => props)
+			.filter(
+				props =>
+					props.items
+						?.map(item => item?.label || item?.value)
+						.filter(Boolean)
+						.join('|') === 'None|Solid|Gradient'
+			)
+			.pop();
+
+	beforeEach(() => {
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		document.body.removeChild(container);
+		jest.clearAllMocks();
+	});
+
+	it('syncs the background selector when preset attributes change', () => {
+		act(() => {
+			root.render(
+				<IconControl
+					{...defaultProps}
+					// Starts from the default "None" icon background state.
+					icon-background-active-media-general='none'
+				/>
+			);
+		});
+
+		expect(getBackgroundTabsProps().selected).toBe('none');
+
+		act(() => {
+			root.render(
+				<IconControl
+					{...defaultProps}
+					// Button quick-style presets can switch this to a fill.
+					icon-background-active-media-general='color'
+				/>
+			);
+		});
+
+		expect(getBackgroundTabsProps().selected).toBe('color');
+	});
+});

--- a/src/components/inspector-tabs/inspector-icon.js
+++ b/src/components/inspector-tabs/inspector-icon.js
@@ -75,6 +75,7 @@ const icon = ({
 
 	const groupAttributes = [
 		'icon',
+		'iconBackground',
 		'iconBackgroundGradient',
 		'iconBackgroundColor',
 		'iconBorder',

--- a/src/components/inspector-tabs/test/inspector-icon.js
+++ b/src/components/inspector-tabs/test/inspector-icon.js
@@ -1,0 +1,73 @@
+import icon from '../inspector-icon';
+
+jest.mock('@wordpress/i18n', () => ({
+	__: text => text,
+}));
+
+jest.mock('@components/icon-control', () => 'IconControl');
+jest.mock('@components/manage-hover-transitions', () => 'ManageHoverTransitions');
+jest.mock('@components/setting-tabs-control', () => 'SettingTabsControl');
+jest.mock('@components/toggle-switch', () => 'ToggleSwitch');
+
+jest.mock('@extensions/styles', () => ({
+	getIconWithColor: jest.fn(() => '<svg />'),
+	getGroupAttributes: (attributes, groups, isHover = false, prefix = '') => {
+		const groupKeys = {
+			icon: [`${prefix}icon-content`, `${prefix}svgType`],
+			iconBackground: [
+				`${prefix}icon-background-active-media-general${
+					isHover ? '-hover' : ''
+				}`,
+			],
+			iconBackgroundColor: [
+				`${prefix}icon-background-palette-color-general${
+					isHover ? '-hover' : ''
+				}`,
+			],
+			iconBackgroundGradient: [
+				`${prefix}icon-background-gradient-general${
+					isHover ? '-hover' : ''
+				}`,
+			],
+			iconBorder: [],
+			iconBorderWidth: [],
+			iconBorderRadius: [],
+			iconPadding: [],
+		};
+
+		return (Array.isArray(groups) ? groups : [groups]).reduce(
+			(acc, group) => {
+				groupKeys[group]?.forEach(key => {
+					if (attributes[key] !== undefined) acc[key] = attributes[key];
+				});
+
+				return acc;
+			},
+			{}
+		);
+	},
+}));
+
+describe('inspector icon tab', () => {
+	it('passes icon background active media to IconControl', () => {
+		const result = icon({
+			props: {
+				attributes: {
+					'icon-content': '<svg />',
+					'icon-background-active-media-general': 'color',
+				},
+				cleanInlineStyles: jest.fn(),
+				clientId: 'client-id',
+				deviceType: 'general',
+				insertInlineStyles: jest.fn(),
+				maxiSetAttributes: jest.fn(),
+			},
+		});
+
+		const normalTab = result.content.props.items[0];
+
+		expect(
+			normalTab.content.props['icon-background-active-media-general']
+		).toBe('color');
+	});
+});


### PR DESCRIPTION
## Summary
Fixes Button Maxi quick-style presets for filled/shape icons so preset application preserves the existing icon details and the icon background UI reflects the actual applied state.

## What changed
- Extracted Button Maxi quick-style preset attribute handling into a focused helper.
- Preserved the existing filled/shape icon content, SVG type, and icon size attributes when applying icon presets.
- Kept line-icon quick-style switching on each preset's own icon sizing so the existing preset snapshots stay stable.
- Restricted icon inline-style cleanup to normal icon background resets so hover-only background `none` does not clear the normal icon background state.
- Removed an unused non-hover preset helper computation flagged by CodeRabbit.
- Passed icon background active-media attributes into the icon inspector panel.
- Synced the icon background selector state when preset attributes change.
- Added focused unit tests for preset behavior, icon background selector syncing, and the inspector prop path.

## Why / root cause
Icon quick-style presets were updating the block attributes and visible icon background, but the icon inspector did not pass `icon-background-active-media-*` through to `IconControl`. That made the `None / Solid / Gradient` control fall back to `None` even while the preset-rendered background was visible. The same preset path could also overwrite existing filled/shape icon type and sizing.

The follow-up CI failure showed the size-preservation logic was too broad for built-in line-icon presets: after preset 4, preset 7 kept the previous `14/18/14` widths instead of using preset 7's `23/35/23` sizing. The bot review also caught that hover-only icon background resets were triggering normal icon inline-style cleanup.

## Testing
- `npm test -- src/blocks/button-maxi/test/getPresetAttributes.js src/components/icon-control/test/index.js src/components/inspector-tabs/test/inspector-icon.js --runInBand`
- `npm test -- src/blocks/button-maxi/test/getPresetAttributes.js --runInBand`
- `git diff --check`
- `npm run build`

## Closing issue link
Closes https://github.com/maxi-blocks/maxi-blocks/issues/4599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized preset handling for buttons and improved icon background behavior across normal/hover states.
  * Visual separators and reordered controls for list options; enhanced custom list-marker support (URL or SVG) with refined sizing.

* **Bug Fixes**
  * Reliable inline-style cleanup when switching presets to prevent stale icon styles; icon background updates synchronize correctly.

* **Tests**
  * New suites covering preset logic, icon control sync, inspector icon integration, and list/options styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->