### PR TITLE
Fix Image Maxi caption resizer layout

### DIFF
--- a/src/blocks/image-maxi/edit.js
+++ b/src/blocks/image-maxi/edit.js
@@ -35,6 +35,7 @@ import { getMaxiBlockAttributes } from '@components/maxi-block';
 import { MaxiBlockComponent, withMaxiProps } from '@extensions/maxi-block';
 import { injectImgSVG } from '@extensions/svg';
 import { copyPasteMapping } from './data';
+import { getImageResizerClassName } from './utils';
 import { TextContext, onChangeRichText } from '@extensions/text/formats';
 import { getDCValues, withMaxiContextLoopContext } from '@extensions/DC';
 import withMaxiDC from '@extensions/DC/withMaxiDC';
@@ -421,7 +422,7 @@ class edit extends MaxiBlockComponent {
 					{showImage ? (
 						<BlockResizer
 							key={uniqueID}
-							className='maxi-block__resizer maxi-image-block__resizer'
+							className={getImageResizerClassName(captionType)}
 							resizableObject={this.resizableObject}
 							isOverflowHidden={getIsOverflowHidden(
 								attributes,

--- a/src/blocks/image-maxi/editor.scss
+++ b/src/blocks/image-maxi/editor.scss
@@ -5,6 +5,12 @@ body.maxi-blocks--active .maxi-image-block {
 		height: inherit !important;
 		min-height: inherit;
 		max-height: inherit;
+
+		&--has-caption {
+			height: auto !important;
+			min-height: 0;
+			max-height: none;
+		}
 	}
 
 	&__image {
@@ -77,6 +83,13 @@ body.maxi-blocks--active .maxi-image-block {
 		height: 100%;
 		max-height: 100%;
 		margin: auto;
+	}
+
+	.maxi-image-block__resizer--has-caption {
+		.maxi-image-block-wrapper {
+			height: auto;
+			max-height: none;
+		}
 	}
 }
 .mb-hover-bg {

--- a/src/blocks/image-maxi/test/utils.js
+++ b/src/blocks/image-maxi/test/utils.js
@@ -1,0 +1,19 @@
+import { getImageResizerClassName } from '../utils';
+
+describe('image maxi utils', () => {
+	it('marks the resizer when captions are enabled', () => {
+		expect(getImageResizerClassName('custom')).toContain(
+			'maxi-image-block__resizer--has-caption'
+		);
+	});
+
+	it('does not mark the resizer when captions are disabled', () => {
+		expect(getImageResizerClassName('none')).not.toContain(
+			'maxi-image-block__resizer--has-caption'
+		);
+	});
+
+	it('does not mark the resizer when caption type is missing', () => {
+		expect(getImageResizerClassName()).toBe('maxi-image-block__resizer');
+	});
+});

--- a/src/blocks/image-maxi/utils.js
+++ b/src/blocks/image-maxi/utils.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+export const getImageResizerClassName = captionType =>
+	classnames(
+		'maxi-image-block__resizer',
+		captionType &&
+			captionType !== 'none' &&
+			'maxi-image-block__resizer--has-caption'
+	);


### PR DESCRIPTION
## Summary
Fixes Image Maxi caption positioning in the editor so top and bottom captions stay inside the selected image block frame.

## What changed
- Added a caption-aware Image Maxi resizer class.
- Applied editor-only layout rules when captions are enabled so the resizer/image wrapper can grow with the caption.
- Added focused unit coverage for enabled, disabled, and missing caption states.

## Why / root cause
Image Maxi always forced the editor resizer and image wrapper to inherit/fill the image height. When a caption was rendered inside that resizer, the caption took extra vertical space but the wrapper still consumed the full available height, causing top captions to push the image down and bottom captions to overflow outside the selected frame.

## Testing
- Confirmed the original issue locally on WAMP after enabling captions.
- Confirmed the fix locally on WAMP at `http://localhost/maxi-blocks-local/wp-admin/post.php?post=9&action=edit`.
- Ran `npm test -- src/blocks/image-maxi/test/utils.js --runInBand`.
- Ran `npm run build`.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5103