### PR TITLE
Fix SVG fit-height first toggle

### DIFF
--- a/src/blocks/svg-icon-maxi/edit.js
+++ b/src/blocks/svg-icon-maxi/edit.js
@@ -199,7 +199,8 @@ class edit extends MaxiBlockComponent {
 			getSVGWidthHeightRatio(
 				this.blockRef?.current?.querySelector(
 					'.maxi-svg-icon-block__icon svg'
-				)
+				),
+				this.props.attributes.content
 			)
 		);
 	}

--- a/src/extensions/svg/getSVGWidthHeightRatio.js
+++ b/src/extensions/svg/getSVGWidthHeightRatio.js
@@ -7,10 +7,12 @@ import { round } from 'lodash';
  * Calculates the width to height ratio of an SVG element.
  *
  * @param {SVGElement|null} svg - The SVG element to calculate the ratio for.
+ * @param {string|null}     fallbackSvg - Raw SVG markup to measure if the rendered
+ * SVG is not available.
  * @returns {number} The width to height ratio, rounded to 2 decimal places. Returns 1 if the SVG is invalid.
  */
-const getSVGWidthHeightRatio = svg => {
-	if (!svg) return 1;
+const getRatioFromElement = svg => {
+	if (!svg) return null;
 
 	const svgWindow = svg.ownerDocument?.defaultView;
 	const SvgElementCtor = svgWindow?.SVGElement;
@@ -18,14 +20,45 @@ const getSVGWidthHeightRatio = svg => {
 		? svg instanceof SvgElementCtor
 		: svg?.nodeName?.toLowerCase?.() === 'svg';
 
-	if (!isSvgElement || typeof svg.getBBox !== 'function') return 1;
+	if (!isSvgElement || typeof svg.getBBox !== 'function') return null;
 
 	try {
 		const { width, height } = svg.getBBox();
-		return height > 0 ? round(width / height, 2) : 1;
+		return height > 0 ? round(width / height, 2) : null;
 	} catch (error) {
-		return 1;
+		return null;
 	}
 };
+
+const getRatioFromMarkup = svgMarkup => {
+	if (
+		typeof svgMarkup !== 'string' ||
+		typeof document === 'undefined' ||
+		!svgMarkup
+	)
+		return null;
+
+	const wrapper = document.createElement('div');
+	wrapper.style.cssText =
+		'position:absolute;visibility:hidden;pointer-events:none;left:-9999px;top:-9999px;';
+	wrapper.innerHTML = svgMarkup.trim();
+
+	const svg = wrapper.querySelector('svg');
+	if (!svg) return null;
+
+	if (document.body) document.body.appendChild(wrapper);
+
+	try {
+		return getRatioFromElement(svg);
+	} finally {
+		wrapper.remove();
+	}
+};
+
+const getSVGWidthHeightRatio = (svg, fallbackSvg = null) =>
+	getRatioFromElement(svg) ??
+	getRatioFromMarkup(fallbackSvg) ??
+	getRatioFromMarkup(svg) ??
+	1;
 
 export default getSVGWidthHeightRatio;

--- a/src/extensions/svg/test/getSVGWidthHeightRatio.js
+++ b/src/extensions/svg/test/getSVGWidthHeightRatio.js
@@ -44,4 +44,26 @@ describe('getSVGWidthHeightRatio', () => {
 
 		expect(getSVGWidthHeightRatio(svg)).toBe(3.03);
 	});
+
+	it('Calculates ratio from fallback SVG markup when no rendered SVG is available', () => {
+		const originalGetBBox = window.SVGElement.prototype.getBBox;
+		window.SVGElement.prototype.getBBox = jest
+			.fn()
+			.mockReturnValue({ width: 36, height: 9 });
+
+		try {
+			expect(
+				getSVGWidthHeightRatio(
+					null,
+					'<svg viewBox="0 0 36 36"><path d="M0 13h36v9H0z" /></svg>'
+				)
+			).toBe(4);
+		} finally {
+			if (originalGetBBox) {
+				window.SVGElement.prototype.getBBox = originalGetBBox;
+			} else {
+				delete window.SVGElement.prototype.getBBox;
+			}
+		}
+	});
 });


### PR DESCRIPTION
## Summary
Fixes SVG Maxi fit-height so it works immediately on the first toggle for SVG shapes/dividers.

## What changed
- Added a fallback path in `getSVGWidthHeightRatio` that can measure raw SVG markup when the rendered SVG node is not available yet.
- Passed the SVG block content into the ratio helper from `svg-icon-maxi/edit.js`.
- Added focused unit coverage for the no-rendered-node fallback path.

## Why / root cause
The SVG fit-height CSS depends on the SVG width/height ratio. On the first fit-height toggle, and in duplicate or copy/paste flows, style generation can run before the SVG element is measurable in the editor DOM. The helper then returned the default ratio of `1`, producing square `height`/`width` CSS until a later width change forced another style pass. Measuring the saved SVG markup as a fallback gives the style generator the correct ratio during that first pass.

## Testing
- `npm test -- src/extensions/svg/test/getSVGWidthHeightRatio.js src/extensions/styles/helpers/test/getSVGStyles.js --runInBand`
- `git diff --check HEAD^ HEAD`
- `npm run build`
- Manual check on local `localhost:8888`: enabling SVG fit-height worked on the first click.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5261