### PR TITLE
Fix Text Maxi custom URL marker sizing

### DIFF
--- a/e2e-tests/blocks/text-maxi/list.spec.js
+++ b/e2e-tests/blocks/text-maxi/list.spec.js
@@ -134,7 +134,7 @@ describe('List in Text-maxi', () => {
 
 		// Text Position
 		const textPosition = await page.$(
-			'.maxi-text-inspector__list-style select'
+			'.maxi-text-inspector__list-text-position select'
 		);
 		await textPosition.select('sub');
 
@@ -315,7 +315,7 @@ describe('List in Text-maxi', () => {
 
 		// Text Position
 		const textPosition = await page.$(
-			'.maxi-text-inspector__list-style select'
+			'.maxi-text-inspector__list-text-position select'
 		);
 		await textPosition.select('sub');
 
@@ -339,8 +339,8 @@ describe('List in Text-maxi', () => {
 		expect(await getAttributes('listStart')).toStrictEqual(-23);
 
 		// Style
-		const style = await page.$$('.maxi-text-inspector__list-style select');
-		await style[1].select('armenian');
+		const style = await page.$('.maxi-text-inspector__list-style select');
+		await style.select('armenian');
 
 		expect(await getAttributes('listStyle')).toStrictEqual('armenian');
 		expect(await getAttributes('listStart')).toStrictEqual(0);
@@ -404,22 +404,22 @@ describe('List in Text-maxi', () => {
 		expect(await getAttributes('typeOfList')).toStrictEqual('ul');
 
 		// style default
-		const style = await page.$$('.maxi-text-inspector__list-style select');
-		await style[1].select('circle');
+		const style = await page.$('.maxi-text-inspector__list-style select');
+		await style.select('circle');
 
 		await page.waitForTimeout(500);
 
 		expect(await getBlockStyle(page)).toMatchSnapshot();
 
 		// Style custom
-		const styleCustom = await page.$$(
+		const styleCustom = await page.$(
 			'.maxi-text-inspector__list-style select'
 		);
-		await styleCustom[1].select('custom');
+		await styleCustom.select('custom');
 
 		await page.waitForTimeout(150);
 
-		const source = await page.$(
+		const source = await page.waitForSelector(
 			'.maxi-text-inspector__list-source-selector select'
 		);
 
@@ -555,16 +555,16 @@ describe('List in Text-maxi', () => {
 		await openSidebarTab(page, 'style', 'list options');
 
 		// Style custom
-		const styleCustom = await page.$$(
+		const styleCustom = await page.$(
 			'.maxi-text-inspector__list-style select'
 		);
 		await page.waitForTimeout(700);
 
-		await styleCustom[1].select('custom');
+		await styleCustom.select('custom');
 
 		await page.waitForTimeout(150);
 
-		const source = await page.$(
+		const source = await page.waitForSelector(
 			'.maxi-text-inspector__list-source-selector select'
 		);
 
@@ -725,10 +725,10 @@ describe('List in Text-maxi', () => {
 		await openSidebarTab(page, 'style', 'list options');
 
 		// Style none
-		const styleNone = await page.$$(
+		const styleNone = await page.$(
 			'.maxi-text-inspector__list-style select'
 		);
-		await styleNone[1].select('none');
+		await styleNone.select('none');
 
 		expect(await getBlockStyle(page)).toMatchSnapshot();
 

--- a/src/blocks/text-maxi/components/list-options-control/index.js
+++ b/src/blocks/text-maxi/components/list-options-control/index.js
@@ -137,6 +137,221 @@ const ListOptionsControl = props => {
 
 	return (
 		<>
+			{deviceType === 'general' && (
+				<SelectControl
+					__nextHasNoMarginBottom
+					label={__('Type of list', 'maxi-blocks')}
+					className='maxi-text-inspector__list-type'
+					value={typeOfList}
+					defaultValue={getDefaultAttribute('typeOfList')}
+					onReset={() =>
+						maxiSetAttributes({
+							typeOfList: getDefaultAttribute('typeOfList'),
+							listStyle: getListStyleOptions(
+								getDefaultAttribute('typeOfList')
+							)[0].value,
+							isReset: true,
+						})
+					}
+					options={[
+						{
+							label: __('Unordered', 'maxi-blocks'),
+							value: 'ul',
+						},
+						{
+							label: __('Ordered', 'maxi-blocks'),
+							value: 'ol',
+						},
+					]}
+					onChange={typeOfList =>
+						maxiSetAttributes({
+							typeOfList,
+							listStyle: getListStyleOptions(typeOfList)[0].value,
+						})
+					}
+				/>
+			)}
+			{deviceType === 'general' && (
+				<>
+					<SelectControl
+						__nextHasNoMarginBottom
+						label={__('Style', 'maxi-blocks')}
+						className='maxi-text-inspector__list-style'
+						value={listStyle || 'disc'}
+						defaultValue={getDefaultAttribute('listStyle')}
+						onReset={() =>
+							maxiSetAttributes({
+								listStyle: getDefaultAttribute('listStyle'),
+								isReset: true,
+							})
+						}
+						options={getListStyleOptions(typeOfList)}
+						onChange={listStyle => {
+							maxiSetAttributes({
+								listStyle,
+							});
+							if (
+								!(
+									['decimal', 'details'].includes(
+										typeOfList
+									) || !listStyle
+								) &&
+								listStart < 0
+							) {
+								maxiSetAttributes({ listStart: 0 });
+							}
+						}}
+					/>
+					{typeOfList === 'ol' && (
+						<>
+							<AdvancedNumberControl
+								label={__('Start from', 'maxi-blocks')}
+								className='maxi-text-inspector__list-start'
+								value={listStart}
+								onChangeValue={val => {
+									maxiSetAttributes({
+										listStart:
+											val !== undefined && val !== ''
+												? val
+												: '',
+									});
+								}}
+								min={
+									['decimal', 'details'].includes(
+										listStyle
+									) || !listStyle
+										? -99
+										: 0
+								}
+								max={99}
+								onReset={() =>
+									maxiSetAttributes({
+										listStart: '',
+										isReset: true,
+									})
+								}
+							/>
+							<ToggleSwitch
+								label={__('Reverse order', 'maxi-blocks')}
+								className='maxi-text-inspector__list-reverse'
+								selected={listReversed}
+								onChange={val => {
+									maxiSetAttributes({
+										listReversed: val,
+									});
+								}}
+							/>
+						</>
+					)}
+					{typeOfList === 'ul' && listStyle === 'custom' && (
+						<>
+							<SelectControl
+								__nextHasNoMarginBottom
+								label={__('Source', 'maxi-blocks')}
+								className='maxi-text-inspector__list-source-selector'
+								value={listStyleSource}
+								defaultValue={defaultListStyleSource}
+								options={[
+									{
+										label: __('Text', 'maxi-blocks'),
+										value: 'text',
+									},
+									{
+										label: __('URL', 'maxi-blocks'),
+										value: 'url',
+									},
+									{
+										label: __('Icon', 'maxi-blocks'),
+										value: 'icon',
+									},
+								]}
+								onChange={listStyleSource => {
+									setListStyleSource(listStyleSource);
+
+									if (listStyleCustoms[listStyleSource])
+										maxiSetAttributes({
+											listStyleCustom:
+												listStyleCustoms[
+													listStyleSource
+												],
+										});
+								}}
+							/>
+							{listStyleSource !== 'icon' && (
+								<TextControl
+									className='maxi-text-inspector__list-source-text'
+									value={
+										listStyleCustoms[listStyleSource] ?? ''
+									}
+									onChange={listStyleCustom => {
+										maxiSetAttributes({
+											listStyleCustom,
+										});
+
+										setListStyleCustoms({
+											...listStyleCustoms,
+											[listStyleSource]: listStyleCustom,
+										});
+									}}
+								/>
+							)}
+							{listStyleSource === 'icon' && (
+								<MaxiModal
+									type='image-shape'
+									style={blockStyle || 'light'}
+									onSelect={obj => {
+										const {
+											paletteStatus,
+											paletteColor,
+											paletteOpacity,
+											color,
+										} = getPaletteAttributes({
+											obj: attributes,
+											prefix: 'list-',
+										});
+
+										const colorStr = paletteStatus
+											? getColorRGBAString({
+													firstVar: `color-${paletteColor}`,
+													opacity: paletteOpacity,
+													blockStyle,
+											  })
+											: color;
+
+										const SVGElement = setSVGColor({
+											svg: obj.SVGElement,
+											color: colorStr,
+											type: 'fill',
+										});
+
+										maxiSetAttributes({
+											listStyleCustom: SVGElement,
+										});
+										setListStyleCustoms({
+											...listStyleCustoms,
+											[listStyleSource]: SVGElement,
+										});
+									}}
+									onRemove={() => {
+										maxiSetAttributes({
+											listStyleCustom: '',
+										});
+										setListStyleCustoms({
+											...listStyleCustoms,
+											[listStyleSource]: '',
+										});
+									}}
+									icon={
+										listStyleCustom?.includes('<svg ')
+											? listStyleCustom
+											: false
+									}
+								/>
+							)}
+						</>
+					)}
+				</>
+			)}
 			<SelectControl
 				__nextHasNoMarginBottom
 				label={__('List style position', 'maxi-blocks')}
@@ -721,221 +936,6 @@ const ListOptionsControl = props => {
 					})
 				}
 			/>
-			{deviceType === 'general' && (
-				<SelectControl
-					__nextHasNoMarginBottom
-					label={__('Type of list', 'maxi-blocks')}
-					className='maxi-text-inspector__list-type'
-					value={typeOfList}
-					defaultValue={getDefaultAttribute('typeOfList')}
-					onReset={() =>
-						maxiSetAttributes({
-							typeOfList: getDefaultAttribute('typeOfList'),
-							listStyle: getListStyleOptions(
-								getDefaultAttribute('typeOfList')
-							)[0].value,
-							isReset: true,
-						})
-					}
-					options={[
-						{
-							label: __('Unordered', 'maxi-blocks'),
-							value: 'ul',
-						},
-						{
-							label: __('Ordered', 'maxi-blocks'),
-							value: 'ol',
-						},
-					]}
-					onChange={typeOfList =>
-						maxiSetAttributes({
-							typeOfList,
-							listStyle: getListStyleOptions(typeOfList)[0].value,
-						})
-					}
-				/>
-			)}
-			{deviceType === 'general' && (
-				<>
-					<SelectControl
-						__nextHasNoMarginBottom
-						label={__('Style', 'maxi-blocks')}
-						className='maxi-text-inspector__list-style'
-						value={listStyle || 'disc'}
-						defaultValue={getDefaultAttribute('listStyle')}
-						onReset={() =>
-							maxiSetAttributes({
-								listStyle: getDefaultAttribute('listStyle'),
-								isReset: true,
-							})
-						}
-						options={getListStyleOptions(typeOfList)}
-						onChange={listStyle => {
-							maxiSetAttributes({
-								listStyle,
-							});
-							if (
-								!(
-									['decimal', 'details'].includes(
-										typeOfList
-									) || !listStyle
-								) &&
-								listStart < 0
-							) {
-								maxiSetAttributes({ listStart: 0 });
-							}
-						}}
-					/>
-					{typeOfList === 'ol' && (
-						<>
-							<AdvancedNumberControl
-								label={__('Start from', 'maxi-blocks')}
-								className='maxi-text-inspector__list-start'
-								value={listStart}
-								onChangeValue={val => {
-									maxiSetAttributes({
-										listStart:
-											val !== undefined && val !== ''
-												? val
-												: '',
-									});
-								}}
-								min={
-									['decimal', 'details'].includes(
-										listStyle
-									) || !listStyle
-										? -99
-										: 0
-								}
-								max={99}
-								onReset={() =>
-									maxiSetAttributes({
-										listStart: '',
-										isReset: true,
-									})
-								}
-							/>
-							<ToggleSwitch
-								label={__('Reverse order', 'maxi-blocks')}
-								className='maxi-text-inspector__list-reverse'
-								selected={listReversed}
-								onChange={val => {
-									maxiSetAttributes({
-										listReversed: val,
-									});
-								}}
-							/>
-						</>
-					)}
-					{typeOfList === 'ul' && listStyle === 'custom' && (
-						<>
-							<SelectControl
-								__nextHasNoMarginBottom
-								label={__('Source', 'maxi-blocks')}
-								className='maxi-text-inspector__list-source-selector'
-								value={listStyleSource}
-								defaultValue={defaultListStyleSource}
-								options={[
-									{
-										label: __('Text', 'maxi-blocks'),
-										value: 'text',
-									},
-									{
-										label: __('URL', 'maxi-blocks'),
-										value: 'url',
-									},
-									{
-										label: __('Icon', 'maxi-blocks'),
-										value: 'icon',
-									},
-								]}
-								onChange={listStyleSource => {
-									setListStyleSource(listStyleSource);
-
-									if (listStyleCustoms[listStyleSource])
-										maxiSetAttributes({
-											listStyleCustom:
-												listStyleCustoms[
-													listStyleSource
-												],
-										});
-								}}
-							/>
-							{listStyleSource !== 'icon' && (
-								<TextControl
-									className='maxi-text-inspector__list-source-text'
-									value={
-										listStyleCustoms[listStyleSource] ?? ''
-									}
-									onChange={listStyleCustom => {
-										maxiSetAttributes({
-											listStyleCustom,
-										});
-
-										setListStyleCustoms({
-											...listStyleCustoms,
-											[listStyleSource]: listStyleCustom,
-										});
-									}}
-								/>
-							)}
-							{listStyleSource === 'icon' && (
-								<MaxiModal
-									type='image-shape'
-									style={blockStyle || 'light'}
-									onSelect={obj => {
-										const {
-											paletteStatus,
-											paletteColor,
-											paletteOpacity,
-											color,
-										} = getPaletteAttributes({
-											obj: attributes,
-											prefix: 'list-',
-										});
-
-										const colorStr = paletteStatus
-											? getColorRGBAString({
-													firstVar: `color-${paletteColor}`,
-													opacity: paletteOpacity,
-													blockStyle,
-											  })
-											: color;
-
-										const SVGElement = setSVGColor({
-											svg: obj.SVGElement,
-											color: colorStr,
-											type: 'fill',
-										});
-
-										maxiSetAttributes({
-											listStyleCustom: SVGElement,
-										});
-										setListStyleCustoms({
-											...listStyleCustoms,
-											[listStyleSource]: SVGElement,
-										});
-									}}
-									onRemove={() => {
-										maxiSetAttributes({
-											listStyleCustom: '',
-										});
-										setListStyleCustoms({
-											...listStyleCustoms,
-											[listStyleSource]: '',
-										});
-									}}
-									icon={
-										listStyleCustom?.includes('<svg ')
-											? listStyleCustom
-											: false
-									}
-								/>
-							)}
-						</>
-					)}
-				</>
-			)}
 		</>
 	);
 };

--- a/src/blocks/text-maxi/components/list-options-control/index.js
+++ b/src/blocks/text-maxi/components/list-options-control/index.js
@@ -715,7 +715,7 @@ const ListOptionsControl = props => {
 			<SelectControl
 				__nextHasNoMarginBottom
 				label={__('Text position', 'maxi-blocks')}
-				className='maxi-text-inspector__list-style'
+				className='maxi-text-inspector__list-text-position'
 				value={getLastBreakpointAttribute({
 					target: 'list-text-position',
 					breakpoint: deviceType,

--- a/src/blocks/text-maxi/components/list-options-control/index.js
+++ b/src/blocks/text-maxi/components/list-options-control/index.js
@@ -28,6 +28,13 @@ import {
 } from '@extensions/styles';
 import { setSVGColor } from '@extensions/svg';
 
+const ListOptionsSeparator = () => (
+	<hr
+		aria-hidden='true'
+		className='maxi-text-inspector__list-options-separator'
+	/>
+);
+
 const ListOptionsControl = props => {
 	const {
 		attributes,
@@ -352,6 +359,164 @@ const ListOptionsControl = props => {
 					)}
 				</>
 			)}
+			{deviceType === 'general' && <ListOptionsSeparator />}
+			{deviceType === 'general' && (
+				<ColorControl
+					label={__('Marker', 'maxi-blocks')}
+					color={attributes['list-color']}
+					paletteStatus={attributes['list-palette-status']}
+					paletteSCStatus={attributes['list-palette-sc-status']}
+					paletteColor={attributes['list-palette-color']}
+					paletteOpacity={attributes['list-palette-opacity']}
+					prefix='list-'
+					avoidBreakpointForDefault
+					onChangeInline={({ color }) =>
+						insertInlineStyles({
+							obj: { color },
+							target: 'li',
+							isMultiplySelector: false,
+							pseudoElement: '::before',
+						})
+					}
+					onChange={({
+						paletteStatus,
+						paletteSCStatus,
+						paletteColor,
+						paletteOpacity,
+						color,
+					}) => {
+						const colorStr = paletteStatus
+							? getColorRGBAString({
+									firstVar: `color-${paletteColor}`,
+									opacity: paletteOpacity,
+									blockStyle,
+							  })
+							: color;
+
+						maxiSetAttributes({
+							'list-palette-status': paletteStatus,
+							'list-palette-sc-status': paletteSCStatus,
+							'list-palette-color': paletteColor,
+							'list-palette-opacity': paletteOpacity,
+							'list-color': color,
+							...(listStyleCustom?.includes('<svg ') && {
+								listStyleCustom: setSVGColor({
+									svg: listStyleCustom,
+									color: colorStr,
+									type: 'fill',
+								}),
+							}),
+						});
+						cleanInlineStyles('li', '::before');
+					}}
+				/>
+			)}
+			<AdvancedNumberControl
+				label={
+					isSVGMarker
+						? __('Marker width', 'maxi-blocks')
+						: __('Marker size', 'maxi-blocks')
+				}
+				className='maxi-text-inspector__list-marker-size'
+				value={getLastBreakpointAttribute({
+					target: 'list-marker-size',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				onChangeValue={(val, meta) => {
+					maxiSetAttributes({
+						[`list-marker-size-${deviceType}`]:
+							val !== undefined && val !== '' ? val : '',
+						meta,
+					});
+				}}
+				enableUnit
+				unit={getLastBreakpointAttribute({
+					target: 'list-marker-size-unit',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				onChangeUnit={val => {
+					maxiSetAttributes({
+						[`list-marker-size-unit-${deviceType}`]: val,
+					});
+				}}
+				breakpoint={deviceType}
+				minMaxSettings={{
+					px: {
+						min: 0,
+						max: 999,
+					},
+					em: {
+						min: 0,
+						max: 99,
+					},
+					vw: {
+						min: 0,
+						max: 99,
+					},
+					'%': {
+						min: 0,
+						max: 999,
+					},
+				}}
+				onReset={() => {
+					maxiSetAttributes({
+						[`list-marker-size-${deviceType}`]: getDefaultAttribute(
+							`list-marker-size-${deviceType}`
+						),
+						[`list-marker-size-unit-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-size-unit-${deviceType}`
+							),
+						isReset: true,
+					});
+				}}
+			/>
+			{isSVGMarker && (
+				<AdvancedNumberControl
+					label={__('Marker height', 'maxi-blocks')}
+					className='maxi-text-inspector__list-marker-height'
+					placeholder={getLastBreakpointAttribute({
+						target: 'list-marker-height',
+						breakpoint: deviceType,
+						attributes,
+					})}
+					value={attributes[`list-marker-height-${deviceType}`]}
+					onChangeValue={(val, meta) =>
+						maxiSetAttributes({
+							[`list-marker-height-${deviceType}`]: val,
+							meta,
+						})
+					}
+					enableUnit
+					unit={getLastBreakpointAttribute({
+						target: 'list-marker-height-unit',
+						breakpoint: deviceType,
+						attributes,
+					})}
+					onChangeUnit={val =>
+						maxiSetAttributes({
+							[`list-marker-height-unit-${deviceType}`]: val,
+						})
+					}
+					onReset={() => {
+						maxiSetAttributes({
+							[`list-marker-height-${deviceType}`]:
+								getDefaultAttribute(
+									`list-marker-height-${deviceType}`
+								),
+							[`list-marker-height-unit-${deviceType}`]:
+								getDefaultAttribute(
+									`list-marker-height-unit-${deviceType}`
+								),
+							isReset: true,
+						});
+					}}
+					allowedUnits={['px', 'em', 'vw', '%']}
+				/>
+			)}
+			<ListOptionsSeparator />
 			<SelectControl
 				__nextHasNoMarginBottom
 				label={__('List style position', 'maxi-blocks')}
@@ -389,6 +554,220 @@ const ListOptionsControl = props => {
 					})
 				}
 			/>
+			<AdvancedNumberControl
+				label={__('Marker indent', 'maxi-blocks')}
+				className='maxi-text-inspector__list-marker-indent'
+				placeholder={getLastBreakpointAttribute({
+					target: 'list-marker-indent',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				value={attributes[`list-marker-indent-${deviceType}`]}
+				onChangeValue={(val, meta) =>
+					maxiSetAttributes({
+						[`list-marker-indent-${deviceType}`]: val,
+						meta,
+					})
+				}
+				enableUnit
+				unit={getLastBreakpointAttribute({
+					target: 'list-marker-indent-unit',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				onChangeUnit={val =>
+					maxiSetAttributes({
+						[`list-marker-indent-unit-${deviceType}`]: val,
+					})
+				}
+				breakpoint={deviceType}
+				minMaxSettings={{
+					px: {
+						min: -999,
+						max: 999,
+					},
+					em: {
+						min: -99,
+						max: 99,
+					},
+					vw: {
+						min: -99,
+						max: 99,
+					},
+					'%': {
+						min: -100,
+						max: 100,
+					},
+				}}
+				onReset={() => {
+					maxiSetAttributes({
+						[`list-marker-indent-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-indent-${deviceType}`
+							),
+						[`list-marker-indent-unit-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-indent-unit-${deviceType}`
+							),
+						isReset: true,
+					});
+				}}
+			/>
+			<AdvancedNumberControl
+				label={__('Marker vertical offset', 'maxi-blocks')}
+				className='maxi-text-inspector__list-marker-offset'
+				placeholder={getLastBreakpointAttribute({
+					target: 'list-marker-vertical-offset',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				value={attributes[`list-marker-vertical-offset-${deviceType}`]}
+				onChangeValue={(val, meta) =>
+					maxiSetAttributes({
+						[`list-marker-vertical-offset-${deviceType}`]: val,
+						meta,
+					})
+				}
+				enableUnit
+				unit={getLastBreakpointAttribute({
+					target: 'list-marker-vertical-offset-unit',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				onChangeUnit={val =>
+					maxiSetAttributes({
+						[`list-marker-vertical-offset-unit-${deviceType}`]: val,
+					})
+				}
+				onReset={() => {
+					maxiSetAttributes({
+						[`list-marker-vertical-offset-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-vertical-offset-${deviceType}`
+							),
+						[`list-marker-vertical-offset-unit-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-vertical-offset-unit-${deviceType}`
+							),
+						isReset: true,
+					});
+				}}
+				minMaxSettings={{
+					px: {
+						min: -999,
+						max: 999,
+					},
+					em: {
+						min: -99,
+						max: 99,
+					},
+					vw: {
+						min: -99,
+						max: 99,
+					},
+					'%': {
+						min: -100,
+						max: 100,
+					},
+				}}
+			/>
+			<AdvancedNumberControl
+				label={__('Marker line-height', 'maxi-blocks')}
+				className='maxi-text-inspector__list-marker-line-height'
+				placeholder={getLastBreakpointAttribute({
+					target: 'list-marker-line-height',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				value={attributes[`list-marker-line-height-${deviceType}`]}
+				onChangeValue={(val, meta) =>
+					maxiSetAttributes({
+						[`list-marker-line-height-${deviceType}`]: val,
+						meta,
+					})
+				}
+				enableUnit
+				unit={getLastBreakpointAttribute({
+					target: 'list-marker-line-height-unit',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				onChangeUnit={val =>
+					maxiSetAttributes({
+						[`list-marker-line-height-unit-${deviceType}`]: val,
+					})
+				}
+				onReset={() => {
+					maxiSetAttributes({
+						[`list-marker-line-height-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-line-height-${deviceType}`
+							),
+						[`list-marker-line-height-unit-${deviceType}`]:
+							getDefaultAttribute(
+								`list-marker-line-height-unit-${deviceType}`
+							),
+						isReset: true,
+					});
+				}}
+				allowedUnits={['px', 'em', 'vw', '%', '-']}
+			/>
+			<SelectControl
+				__nextHasNoMarginBottom
+				label={__('Text position', 'maxi-blocks')}
+				className='maxi-text-inspector__list-style'
+				value={getLastBreakpointAttribute({
+					target: 'list-text-position',
+					breakpoint: deviceType,
+					attributes,
+				})}
+				defaultValue={getDefaultAttribute(
+					`list-text-position-${deviceType}`
+				)}
+				onReset={() =>
+					maxiSetAttributes({
+						[`list-text-position-${deviceType}`]:
+							getDefaultAttribute(
+								`list-text-position-${deviceType}`
+							),
+						isReset: true,
+					})
+				}
+				options={[
+					{
+						label: __('Baseline', 'maxi-blocks'),
+						value: 'baseline',
+					},
+					{ label: __('Sub', 'maxi-blocks'), value: 'sub' },
+					{
+						label: __('Super', 'maxi-blocks'),
+						value: 'super',
+					},
+					{ label: __('Top', 'maxi-blocks'), value: 'top' },
+					{
+						label: __('Text-top', 'maxi-blocks'),
+						value: 'text-top',
+					},
+					{
+						label: __('Middle', 'maxi-blocks'),
+						value: 'middle',
+					},
+					{
+						label: __('Bottom', 'maxi-blocks'),
+						value: 'bottom',
+					},
+					{
+						label: __('Text-bottom', 'maxi-blocks'),
+						value: 'text-bottom',
+					},
+				]}
+				onChange={val =>
+					maxiSetAttributes({
+						[`list-text-position-${deviceType}`]: val,
+					})
+				}
+			/>
+			<ListOptionsSeparator />
 			<AdvancedNumberControl
 				label={__('Text indent', 'maxi-blocks')}
 				className='maxi-text-inspector__list-indent'
@@ -566,375 +945,6 @@ const ListOptionsControl = props => {
 						isReset: true,
 					});
 				}}
-			/>
-			<AdvancedNumberControl
-				label={
-					isSVGMarker
-						? __('Marker width', 'maxi-blocks')
-						: __('Marker size', 'maxi-blocks')
-				}
-				className='maxi-text-inspector__list-marker-size'
-				value={getLastBreakpointAttribute({
-					target: 'list-marker-size',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				onChangeValue={(val, meta) => {
-					maxiSetAttributes({
-						[`list-marker-size-${deviceType}`]:
-							val !== undefined && val !== '' ? val : '',
-						meta,
-					});
-				}}
-				enableUnit
-				unit={getLastBreakpointAttribute({
-					target: 'list-marker-size-unit',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				onChangeUnit={val => {
-					maxiSetAttributes({
-						[`list-marker-size-unit-${deviceType}`]: val,
-					});
-				}}
-				breakpoint={deviceType}
-				minMaxSettings={{
-					px: {
-						min: 0,
-						max: 999,
-					},
-					em: {
-						min: 0,
-						max: 99,
-					},
-					vw: {
-						min: 0,
-						max: 99,
-					},
-					'%': {
-						min: 0,
-						max: 999,
-					},
-				}}
-				onReset={() => {
-					maxiSetAttributes({
-						[`list-marker-size-${deviceType}`]: getDefaultAttribute(
-							`list-marker-size-${deviceType}`
-						),
-						[`list-marker-size-unit-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-size-unit-${deviceType}`
-							),
-						isReset: true,
-					});
-				}}
-			/>
-			{isSVGMarker && (
-				<AdvancedNumberControl
-					label={__('Marker height', 'maxi-blocks')}
-					className='maxi-text-inspector__list-marker-height'
-					placeholder={getLastBreakpointAttribute({
-						target: 'list-marker-height',
-						breakpoint: deviceType,
-						attributes,
-					})}
-					value={attributes[`list-marker-height-${deviceType}`]}
-					onChangeValue={(val, meta) =>
-						maxiSetAttributes({
-							[`list-marker-height-${deviceType}`]: val,
-							meta,
-						})
-					}
-					enableUnit
-					unit={getLastBreakpointAttribute({
-						target: 'list-marker-height-unit',
-						breakpoint: deviceType,
-						attributes,
-					})}
-					onChangeUnit={val =>
-						maxiSetAttributes({
-							[`list-marker-height-unit-${deviceType}`]: val,
-						})
-					}
-					onReset={() => {
-						maxiSetAttributes({
-							[`list-marker-height-${deviceType}`]:
-								getDefaultAttribute(
-									`list-marker-height-${deviceType}`
-								),
-							[`list-marker-height-unit-${deviceType}`]:
-								getDefaultAttribute(
-									`list-marker-height-unit-${deviceType}`
-								),
-							isReset: true,
-						});
-					}}
-					allowedUnits={['px', 'em', 'vw', '%']}
-				/>
-			)}
-			<AdvancedNumberControl
-				label={__('Marker line-height', 'maxi-blocks')}
-				className='maxi-text-inspector__list-marker-line-height'
-				placeholder={getLastBreakpointAttribute({
-					target: 'list-marker-line-height',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				value={attributes[`list-marker-line-height-${deviceType}`]}
-				onChangeValue={(val, meta) =>
-					maxiSetAttributes({
-						[`list-marker-line-height-${deviceType}`]: val,
-						meta,
-					})
-				}
-				enableUnit
-				unit={getLastBreakpointAttribute({
-					target: 'list-marker-line-height-unit',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				onChangeUnit={val =>
-					maxiSetAttributes({
-						[`list-marker-line-height-unit-${deviceType}`]: val,
-					})
-				}
-				onReset={() => {
-					maxiSetAttributes({
-						[`list-marker-line-height-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-line-height-${deviceType}`
-							),
-						[`list-marker-line-height-unit-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-line-height-unit-${deviceType}`
-							),
-						isReset: true,
-					});
-				}}
-				allowedUnits={['px', 'em', 'vw', '%', '-']}
-			/>
-			<AdvancedNumberControl
-				label={__('Marker vertical offset', 'maxi-blocks')}
-				className='maxi-text-inspector__list-marker-offset'
-				placeholder={getLastBreakpointAttribute({
-					target: 'list-marker-vertical-offset',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				value={attributes[`list-marker-vertical-offset-${deviceType}`]}
-				onChangeValue={(val, meta) =>
-					maxiSetAttributes({
-						[`list-marker-vertical-offset-${deviceType}`]: val,
-						meta,
-					})
-				}
-				enableUnit
-				unit={getLastBreakpointAttribute({
-					target: 'list-marker-vertical-offset-unit',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				onChangeUnit={val =>
-					maxiSetAttributes({
-						[`list-marker-vertical-offset-unit-${deviceType}`]: val,
-					})
-				}
-				onReset={() => {
-					maxiSetAttributes({
-						[`list-marker-vertical-offset-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-vertical-offset-${deviceType}`
-							),
-						[`list-marker-vertical-offset-unit-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-vertical-offset-unit-${deviceType}`
-							),
-						isReset: true,
-					});
-				}}
-				minMaxSettings={{
-					px: {
-						min: -999,
-						max: 999,
-					},
-					em: {
-						min: -99,
-						max: 99,
-					},
-					vw: {
-						min: -99,
-						max: 99,
-					},
-					'%': {
-						min: -100,
-						max: 100,
-					},
-				}}
-			/>
-			<AdvancedNumberControl
-				label={__('Marker indent', 'maxi-blocks')}
-				className='maxi-text-inspector__list-marker-indent'
-				placeholder={getLastBreakpointAttribute({
-					target: 'list-marker-indent',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				value={attributes[`list-marker-indent-${deviceType}`]}
-				onChangeValue={(val, meta) =>
-					maxiSetAttributes({
-						[`list-marker-indent-${deviceType}`]: val,
-						meta,
-					})
-				}
-				enableUnit
-				unit={getLastBreakpointAttribute({
-					target: 'list-marker-indent-unit',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				onChangeUnit={val =>
-					maxiSetAttributes({
-						[`list-marker-indent-unit-${deviceType}`]: val,
-					})
-				}
-				breakpoint={deviceType}
-				minMaxSettings={{
-					px: {
-						min: -999,
-						max: 999,
-					},
-					em: {
-						min: -99,
-						max: 99,
-					},
-					vw: {
-						min: -99,
-						max: 99,
-					},
-					'%': {
-						min: -100,
-						max: 100,
-					},
-				}}
-				onReset={() => {
-					maxiSetAttributes({
-						[`list-marker-indent-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-indent-${deviceType}`
-							),
-						[`list-marker-indent-unit-${deviceType}`]:
-							getDefaultAttribute(
-								`list-marker-indent-unit-${deviceType}`
-							),
-						isReset: true,
-					});
-				}}
-			/>
-			{deviceType === 'general' && (
-				<ColorControl
-					label={__('Marker', 'maxi-blocks')}
-					color={attributes['list-color']}
-					paletteStatus={attributes['list-palette-status']}
-					paletteSCStatus={attributes['list-palette-sc-status']}
-					paletteColor={attributes['list-palette-color']}
-					paletteOpacity={attributes['list-palette-opacity']}
-					prefix='list-'
-					avoidBreakpointForDefault
-					onChangeInline={({ color }) =>
-						insertInlineStyles({
-							obj: { color },
-							target: 'li',
-							isMultiplySelector: false,
-							pseudoElement: '::before',
-						})
-					}
-					onChange={({
-						paletteStatus,
-						paletteSCStatus,
-						paletteColor,
-						paletteOpacity,
-						color,
-					}) => {
-						const colorStr = paletteStatus
-							? getColorRGBAString({
-									firstVar: `color-${paletteColor}`,
-									opacity: paletteOpacity,
-									blockStyle,
-							  })
-							: color;
-
-						maxiSetAttributes({
-							'list-palette-status': paletteStatus,
-							'list-palette-sc-status': paletteSCStatus,
-							'list-palette-color': paletteColor,
-							'list-palette-opacity': paletteOpacity,
-							'list-color': color,
-							...(listStyleCustom?.includes('<svg ') && {
-								listStyleCustom: setSVGColor({
-									svg: listStyleCustom,
-									color: colorStr,
-									type: 'fill',
-								}),
-							}),
-						});
-						cleanInlineStyles('li', '::before');
-					}}
-				/>
-			)}
-			<SelectControl
-				__nextHasNoMarginBottom
-				label={__('Text position', 'maxi-blocks')}
-				className='maxi-text-inspector__list-style'
-				value={getLastBreakpointAttribute({
-					target: 'list-text-position',
-					breakpoint: deviceType,
-					attributes,
-				})}
-				defaultValue={getDefaultAttribute(
-					`list-text-position-${deviceType}`
-				)}
-				onReset={() =>
-					maxiSetAttributes({
-						[`list-text-position-${deviceType}`]:
-							getDefaultAttribute(
-								`list-text-position-${deviceType}`
-							),
-						isReset: true,
-					})
-				}
-				options={[
-					{
-						label: __('Baseline', 'maxi-blocks'),
-						value: 'baseline',
-					},
-					{ label: __('Sub', 'maxi-blocks'), value: 'sub' },
-					{
-						label: __('Super', 'maxi-blocks'),
-						value: 'super',
-					},
-					{ label: __('Top', 'maxi-blocks'), value: 'top' },
-					{
-						label: __('Text-top', 'maxi-blocks'),
-						value: 'text-top',
-					},
-					{
-						label: __('Middle', 'maxi-blocks'),
-						value: 'middle',
-					},
-					{
-						label: __('Bottom', 'maxi-blocks'),
-						value: 'bottom',
-					},
-					{
-						label: __('Text-bottom', 'maxi-blocks'),
-						value: 'text-bottom',
-					},
-				]}
-				onChange={val =>
-					maxiSetAttributes({
-						[`list-text-position-${deviceType}`]: val,
-					})
-				}
 			/>
 		</>
 	);

--- a/src/blocks/text-maxi/components/list-options-control/test/order.js
+++ b/src/blocks/text-maxi/components/list-options-control/test/order.js
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('ListOptionsControl control order', () => {
+	it('shows list type and custom marker source controls before sizing controls', () => {
+		const source = fs.readFileSync(
+			path.join(__dirname, '..', 'index.js'),
+			'utf8'
+		);
+
+		const typeControl = source.indexOf(
+			"label={__('Type of list', 'maxi-blocks')}"
+		);
+		const styleControl = source.indexOf(
+			"label={__('Style', 'maxi-blocks')}"
+		);
+		const sourceControl = source.indexOf(
+			"label={__('Source', 'maxi-blocks')}"
+		);
+		const sourceInput = source.indexOf(
+			"className='maxi-text-inspector__list-source-text'"
+		);
+		const stylePositionControl = source.indexOf(
+			"label={__('List style position', 'maxi-blocks')}"
+		);
+		const markerSizeControl = source.indexOf(
+			"className='maxi-text-inspector__list-marker-size'"
+		);
+
+		expect(typeControl).toBeGreaterThanOrEqual(0);
+		expect(styleControl).toBeGreaterThan(typeControl);
+		expect(sourceControl).toBeGreaterThan(styleControl);
+		expect(sourceInput).toBeGreaterThan(sourceControl);
+		expect(stylePositionControl).toBeGreaterThan(sourceInput);
+		expect(markerSizeControl).toBeGreaterThan(sourceInput);
+	});
+});

--- a/src/blocks/text-maxi/components/list-options-control/test/order.js
+++ b/src/blocks/text-maxi/components/list-options-control/test/order.js
@@ -18,6 +18,7 @@ const expectedControlOrder = [
 	"label={__('Marker vertical offset', 'maxi-blocks')}",
 	"label={__('Marker line-height', 'maxi-blocks')}",
 	"label={__('Text position', 'maxi-blocks')}",
+	"className='maxi-text-inspector__list-text-position'",
 	'<ListOptionsSeparator />',
 	"label={__('Text indent', 'maxi-blocks')}",
 	"label={__('List gap', 'maxi-blocks')}",

--- a/src/blocks/text-maxi/components/list-options-control/test/order.js
+++ b/src/blocks/text-maxi/components/list-options-control/test/order.js
@@ -1,37 +1,120 @@
 import fs from 'fs';
 import path from 'path';
 
+const getIndex = (source, search) => {
+	const index = source.indexOf(search);
+	expect(index).toBeGreaterThanOrEqual(0);
+
+	return index;
+};
+
 describe('ListOptionsControl control order', () => {
-	it('shows list type and custom marker source controls before sizing controls', () => {
+	it('groups list options by setup, marker appearance, placement, and spacing', () => {
 		const source = fs.readFileSync(
 			path.join(__dirname, '..', 'index.js'),
 			'utf8'
 		);
 
-		const typeControl = source.indexOf(
+		const typeControl = getIndex(
+			source,
 			"label={__('Type of list', 'maxi-blocks')}"
 		);
-		const styleControl = source.indexOf(
+		const styleControl = getIndex(
+			source,
 			"label={__('Style', 'maxi-blocks')}"
 		);
-		const sourceControl = source.indexOf(
+		const startControl = getIndex(
+			source,
+			"label={__('Start from', 'maxi-blocks')}"
+		);
+		const reverseControl = getIndex(
+			source,
+			"label={__('Reverse order', 'maxi-blocks')}"
+		);
+		const sourceControl = getIndex(
+			source,
 			"label={__('Source', 'maxi-blocks')}"
 		);
-		const sourceInput = source.indexOf(
+		const sourceInput = getIndex(
+			source,
 			"className='maxi-text-inspector__list-source-text'"
 		);
-		const stylePositionControl = source.indexOf(
-			"label={__('List style position', 'maxi-blocks')}"
+		const firstSeparator = source.indexOf('<ListOptionsSeparator />');
+		const markerColorControl = getIndex(
+			source,
+			"label={__('Marker', 'maxi-blocks')}"
 		);
-		const markerSizeControl = source.indexOf(
+		const markerSizeControl = getIndex(
+			source,
 			"className='maxi-text-inspector__list-marker-size'"
 		);
+		const markerHeightControl = getIndex(
+			source,
+			"label={__('Marker height', 'maxi-blocks')}"
+		);
+		const secondSeparator = source.indexOf(
+			'<ListOptionsSeparator />',
+			firstSeparator + 1
+		);
+		const stylePositionControl = getIndex(
+			source,
+			"label={__('List style position', 'maxi-blocks')}"
+		);
+		const markerIndentControl = getIndex(
+			source,
+			"label={__('Marker indent', 'maxi-blocks')}"
+		);
+		const markerOffsetControl = getIndex(
+			source,
+			"label={__('Marker vertical offset', 'maxi-blocks')}"
+		);
+		const markerLineHeightControl = getIndex(
+			source,
+			"label={__('Marker line-height', 'maxi-blocks')}"
+		);
+		const textPositionControl = getIndex(
+			source,
+			"label={__('Text position', 'maxi-blocks')}"
+		);
+		const thirdSeparator = source.indexOf(
+			'<ListOptionsSeparator />',
+			secondSeparator + 1
+		);
+		const textIndentControl = getIndex(
+			source,
+			"label={__('Text indent', 'maxi-blocks')}"
+		);
+		const listGapControl = getIndex(
+			source,
+			"label={__('List gap', 'maxi-blocks')}"
+		);
+		const paragraphSpacingControl = getIndex(
+			source,
+			"label={__('Paragraph spacing', 'maxi-blocks')}"
+		);
 
-		expect(typeControl).toBeGreaterThanOrEqual(0);
 		expect(styleControl).toBeGreaterThan(typeControl);
+		expect(startControl).toBeGreaterThan(styleControl);
+		expect(reverseControl).toBeGreaterThan(startControl);
 		expect(sourceControl).toBeGreaterThan(styleControl);
 		expect(sourceInput).toBeGreaterThan(sourceControl);
-		expect(stylePositionControl).toBeGreaterThan(sourceInput);
-		expect(markerSizeControl).toBeGreaterThan(sourceInput);
+
+		expect(firstSeparator).toBeGreaterThan(sourceInput);
+		expect(markerColorControl).toBeGreaterThan(firstSeparator);
+		expect(markerSizeControl).toBeGreaterThan(markerColorControl);
+		expect(markerHeightControl).toBeGreaterThan(markerSizeControl);
+
+		expect(secondSeparator).toBeGreaterThan(markerHeightControl);
+		expect(stylePositionControl).toBeGreaterThan(secondSeparator);
+		expect(markerIndentControl).toBeGreaterThan(stylePositionControl);
+		expect(markerOffsetControl).toBeGreaterThan(markerIndentControl);
+		expect(markerLineHeightControl).toBeGreaterThan(markerOffsetControl);
+		expect(textPositionControl).toBeGreaterThan(markerLineHeightControl);
+
+		expect(thirdSeparator).toBeGreaterThan(textPositionControl);
+		expect(textIndentControl).toBeGreaterThan(thirdSeparator);
+		expect(listGapControl).toBeGreaterThan(textIndentControl);
+		expect(paragraphSpacingControl).toBeGreaterThan(listGapControl);
+		expect(source.match(/<ListOptionsSeparator \/>/g)).toHaveLength(3);
 	});
 });

--- a/src/blocks/text-maxi/components/list-options-control/test/order.js
+++ b/src/blocks/text-maxi/components/list-options-control/test/order.js
@@ -1,12 +1,28 @@
 import fs from 'fs';
 import path from 'path';
 
-const getIndex = (source, search) => {
-	const index = source.indexOf(search);
-	expect(index).toBeGreaterThanOrEqual(0);
-
-	return index;
-};
+const expectedControlOrder = [
+	"label={__('Type of list', 'maxi-blocks')}",
+	"label={__('Style', 'maxi-blocks')}",
+	"label={__('Start from', 'maxi-blocks')}",
+	"label={__('Reverse order', 'maxi-blocks')}",
+	"label={__('Source', 'maxi-blocks')}",
+	"className='maxi-text-inspector__list-source-text'",
+	'<ListOptionsSeparator />',
+	"label={__('Marker', 'maxi-blocks')}",
+	"className='maxi-text-inspector__list-marker-size'",
+	"label={__('Marker height', 'maxi-blocks')}",
+	'<ListOptionsSeparator />',
+	"label={__('List style position', 'maxi-blocks')}",
+	"label={__('Marker indent', 'maxi-blocks')}",
+	"label={__('Marker vertical offset', 'maxi-blocks')}",
+	"label={__('Marker line-height', 'maxi-blocks')}",
+	"label={__('Text position', 'maxi-blocks')}",
+	'<ListOptionsSeparator />',
+	"label={__('Text indent', 'maxi-blocks')}",
+	"label={__('List gap', 'maxi-blocks')}",
+	"label={__('Paragraph spacing', 'maxi-blocks')}",
+];
 
 describe('ListOptionsControl control order', () => {
 	it('groups list options by setup, marker appearance, placement, and spacing', () => {
@@ -15,106 +31,14 @@ describe('ListOptionsControl control order', () => {
 			'utf8'
 		);
 
-		const typeControl = getIndex(
-			source,
-			"label={__('Type of list', 'maxi-blocks')}"
-		);
-		const styleControl = getIndex(
-			source,
-			"label={__('Style', 'maxi-blocks')}"
-		);
-		const startControl = getIndex(
-			source,
-			"label={__('Start from', 'maxi-blocks')}"
-		);
-		const reverseControl = getIndex(
-			source,
-			"label={__('Reverse order', 'maxi-blocks')}"
-		);
-		const sourceControl = getIndex(
-			source,
-			"label={__('Source', 'maxi-blocks')}"
-		);
-		const sourceInput = getIndex(
-			source,
-			"className='maxi-text-inspector__list-source-text'"
-		);
-		const firstSeparator = source.indexOf('<ListOptionsSeparator />');
-		const markerColorControl = getIndex(
-			source,
-			"label={__('Marker', 'maxi-blocks')}"
-		);
-		const markerSizeControl = getIndex(
-			source,
-			"className='maxi-text-inspector__list-marker-size'"
-		);
-		const markerHeightControl = getIndex(
-			source,
-			"label={__('Marker height', 'maxi-blocks')}"
-		);
-		const secondSeparator = source.indexOf(
-			'<ListOptionsSeparator />',
-			firstSeparator + 1
-		);
-		const stylePositionControl = getIndex(
-			source,
-			"label={__('List style position', 'maxi-blocks')}"
-		);
-		const markerIndentControl = getIndex(
-			source,
-			"label={__('Marker indent', 'maxi-blocks')}"
-		);
-		const markerOffsetControl = getIndex(
-			source,
-			"label={__('Marker vertical offset', 'maxi-blocks')}"
-		);
-		const markerLineHeightControl = getIndex(
-			source,
-			"label={__('Marker line-height', 'maxi-blocks')}"
-		);
-		const textPositionControl = getIndex(
-			source,
-			"label={__('Text position', 'maxi-blocks')}"
-		);
-		const thirdSeparator = source.indexOf(
-			'<ListOptionsSeparator />',
-			secondSeparator + 1
-		);
-		const textIndentControl = getIndex(
-			source,
-			"label={__('Text indent', 'maxi-blocks')}"
-		);
-		const listGapControl = getIndex(
-			source,
-			"label={__('List gap', 'maxi-blocks')}"
-		);
-		const paragraphSpacingControl = getIndex(
-			source,
-			"label={__('Paragraph spacing', 'maxi-blocks')}"
-		);
+		let previousIndex = -1;
+		expectedControlOrder.forEach(search => {
+			const index = source.indexOf(search, previousIndex + 1);
 
-		expect(styleControl).toBeGreaterThan(typeControl);
-		expect(startControl).toBeGreaterThan(styleControl);
-		expect(reverseControl).toBeGreaterThan(startControl);
-		expect(sourceControl).toBeGreaterThan(styleControl);
-		expect(sourceInput).toBeGreaterThan(sourceControl);
+			expect(index).toBeGreaterThan(previousIndex);
+			previousIndex = index;
+		});
 
-		expect(firstSeparator).toBeGreaterThan(sourceInput);
-		expect(markerColorControl).toBeGreaterThan(firstSeparator);
-		expect(markerSizeControl).toBeGreaterThan(markerColorControl);
-		expect(markerHeightControl).toBeGreaterThan(markerSizeControl);
-
-		expect(secondSeparator).toBeGreaterThan(markerHeightControl);
-		expect(stylePositionControl).toBeGreaterThan(secondSeparator);
-		expect(markerIndentControl).toBeGreaterThan(stylePositionControl);
-		expect(markerOffsetControl).toBeGreaterThan(markerIndentControl);
-		expect(markerLineHeightControl).toBeGreaterThan(markerOffsetControl);
-		expect(textPositionControl).toBeGreaterThan(markerLineHeightControl);
-
-		expect(thirdSeparator).toBeGreaterThan(textPositionControl);
-		expect(textIndentControl).toBeGreaterThan(thirdSeparator);
-		expect(listGapControl).toBeGreaterThan(textIndentControl);
-		expect(paragraphSpacingControl).toBeGreaterThan(listGapControl);
 		expect(source.match(/<ListOptionsSeparator \/>/g)).toHaveLength(3);
 	});
 });

--- a/src/blocks/text-maxi/editor.scss
+++ b/src/blocks/text-maxi/editor.scss
@@ -47,6 +47,13 @@
 		display: none;
 	}
 }
+
+.maxi-text-inspector__list-options-separator {
+	border: 0;
+	border-top: 1px solid var(--maxi-grey-light);
+	margin: 14px 0;
+}
+
 /*******************************
 * RTL
 *******************************/

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -570,7 +570,7 @@ const getMarkerObject = props => {
 				const customImageMarkerSize = {
 					width: markerSize,
 					...(isCustomURLMarker && {
-						height: !isNil(heightNum) ? markerHeight : markerSize,
+						height: markerSize,
 					}),
 					...(isCustomSVGMarker &&
 						!isNil(heightNum) && {

--- a/src/blocks/text-maxi/styles.js
+++ b/src/blocks/text-maxi/styles.js
@@ -378,6 +378,16 @@ const getListParagraphObject = props => {
 
 const getMarkerObject = props => {
 	const { typeOfList, listStyle, listStyleCustom, blockStyle } = props;
+	const isCustomURLMarker =
+		typeOfList === 'ul' &&
+		listStyle === 'custom' &&
+		listStyleCustom &&
+		isURL(listStyleCustom);
+	const isCustomSVGMarker =
+		typeOfList === 'ul' &&
+		listStyle === 'custom' &&
+		listStyleCustom &&
+		listStyleCustom.includes('</svg>');
 
 	const { paletteStatus, paletteColor, paletteOpacity, color } =
 		getPaletteAttributes({
@@ -431,16 +441,20 @@ const getMarkerObject = props => {
 					general: {
 						...(listStyle === 'custom' &&
 							listStyleCustom && {
-								...(isURL(listStyleCustom) && {
-									content: `url('${listStyleCustom}')`,
+								...(isCustomURLMarker && {
+									content: '""',
+									'background-image': `url('${listStyleCustom}')`,
+									'background-position': 'center',
+									'background-repeat': 'no-repeat',
+									'background-size': 'contain',
 								}),
-								...(listStyleCustom.includes('</svg>') && {
+								...(isCustomSVGMarker && {
 									content: `url("data:image/svg+xml,${getSVGListStyle(
 										listStyleCustom
 									)}")`,
 								}),
-								...(!isURL(listStyleCustom) &&
-									!listStyleCustom.includes('</svg>') && {
+								...(!isCustomURLMarker &&
+									!isCustomSVGMarker && {
 										content: `"${listStyleCustom}"`,
 									}),
 							}),
@@ -549,25 +563,32 @@ const getMarkerObject = props => {
 						attributes: props,
 					}) || 'px';
 
+				const markerSize = sizeNum + sizeUnit;
+				const markerHeight = !isNil(heightNum)
+					? heightNum + heightUnit
+					: undefined;
+				const customImageMarkerSize = {
+					width: markerSize,
+					...(isCustomURLMarker && {
+						height: !isNil(heightNum) ? markerHeight : markerSize,
+					}),
+					...(isCustomSVGMarker &&
+						!isNil(heightNum) && {
+							height: markerHeight,
+							// Vertically center the SVG marker content if the height is set
+							...(textPosition === 'middle' && {
+								top: `calc(${heightNum / 2 + heightUnit} - (${
+									sizeNum / 2 + sizeUnit
+								}))`,
+							}),
+						}),
+				};
+
 				response.listSize[breakpoint] = {
-					...(typeOfList === 'ul' &&
-					listStyle === 'custom' &&
-					listStyleCustom &&
-					listStyleCustom.includes('</svg>')
-						? {
-								width: sizeNum + sizeUnit,
-								...(!isNil(heightNum) && {
-									height: heightNum + heightUnit,
-									// Vertically center the SVG marker content if the height is set
-									...(textPosition === 'middle' && {
-										top: `calc(${
-											heightNum / 2 + heightUnit
-										} - (${sizeNum / 2 + sizeUnit}))`,
-									}),
-								}),
-						  }
+					...(isCustomSVGMarker || isCustomURLMarker
+						? customImageMarkerSize
 						: {
-								'font-size': sizeNum + sizeUnit,
+								'font-size': markerSize,
 						  }),
 					'line-height':
 						lineHeightMarkerNum +

--- a/src/blocks/text-maxi/test/styles.js
+++ b/src/blocks/text-maxi/test/styles.js
@@ -60,6 +60,8 @@ describe('text-maxi styles', () => {
 				'list-gap-unit-general': 'em',
 				'list-marker-size-general': 48,
 				'list-marker-size-unit-general': 'px',
+				'list-marker-height-general': 12,
+				'list-marker-height-unit-general': 'px',
 				'list-marker-indent-general': 0,
 				'list-marker-indent-unit-general': 'px',
 				'list-marker-line-height-general': 1,
@@ -88,6 +90,44 @@ describe('text-maxi styles', () => {
 			expect.objectContaining({
 				width: '48px',
 				height: '48px',
+			})
+		);
+	});
+
+	it('uses marker height styles for custom SVG list markers', () => {
+		const styles = getStyles(
+			{
+				uniqueID: 'text-list',
+				isList: true,
+				typeOfList: 'ul',
+				listStyle: 'custom',
+				listStyleCustom: '<svg><path d="M0 0h10v10H0z" /></svg>',
+				blockStyle: 'light',
+				'list-gap-general': 1,
+				'list-gap-unit-general': 'em',
+				'list-marker-size-general': 48,
+				'list-marker-size-unit-general': 'px',
+				'list-marker-height-general': 12,
+				'list-marker-height-unit-general': 'px',
+				'list-marker-indent-general': 0,
+				'list-marker-indent-unit-general': 'px',
+				'list-marker-line-height-general': 1,
+				'list-marker-line-height-unit-general': 'em',
+				'list-style-position-general': 'outside',
+				'list-text-position-general': 'middle',
+			},
+			() => 1
+		);
+
+		const markerStyles =
+			styles['text-list'][
+				' ul li .maxi-list-item-block__content::before'
+			];
+
+		expect(markerStyles.listSize.general).toEqual(
+			expect.objectContaining({
+				width: '48px',
+				height: '12px',
 			})
 		);
 	});

--- a/src/blocks/text-maxi/test/styles.js
+++ b/src/blocks/text-maxi/test/styles.js
@@ -1,0 +1,94 @@
+import getStyles from '../styles';
+
+jest.mock('@extensions/styles', () => ({
+	getColorRGBAString: jest.fn(() => 'rgba(0, 0, 0, 1)'),
+	getGroupAttributes: jest.fn(() => ({})),
+	getLastBreakpointAttribute: jest.fn(
+		({ target, breakpoint, attributes }) =>
+			attributes[`${target}-${breakpoint}`] ??
+			attributes[`${target}-general`]
+	),
+	getPaletteAttributes: jest.fn(({ obj, prefix }) => ({
+		paletteStatus: obj[`${prefix}palette-status-general`] ?? false,
+		color: obj[`${prefix}color-general`],
+	})),
+	styleProcessor: jest.fn(styles => styles),
+}));
+
+jest.mock('@extensions/styles/helpers', () => ({
+	getAlignmentTextStyles: jest.fn(() => ({})),
+	getBlockBackgroundStyles: jest.fn(() => ({})),
+	getBorderStyles: jest.fn(() => ({})),
+	getBoxShadowStyles: jest.fn(() => ({})),
+	getCustomFormatsStyles: jest.fn(() => ({})),
+	getDisplayStyles: jest.fn(() => ({})),
+	getFlexStyles: jest.fn(() => ({})),
+	getLinkStyles: jest.fn(() => ({})),
+	getMarginPaddingStyles: jest.fn(() => ({})),
+	getOpacityStyles: jest.fn(() => ({})),
+	getOverflowStyles: jest.fn(() => ({})),
+	getPositionStyles: jest.fn(() => ({})),
+	getSizeStyles: jest.fn(() => ({})),
+	getTypographyStyles: jest.fn(() => ({})),
+	getZIndexStyles: jest.fn(() => ({})),
+}));
+
+jest.mock('../data', () => ({}));
+jest.mock('../utils', () => ({
+	getSVGListStyle: jest.fn(svg => svg),
+}));
+
+jest.mock('@wordpress/data', () => {
+	return {
+		select: jest.fn(() => ({
+			getEditorSettings: jest.fn(() => ({ isRTL: false })),
+		})),
+	};
+});
+
+describe('text-maxi styles', () => {
+	it('uses marker size styles for custom URL list markers', () => {
+		const styles = getStyles(
+			{
+				uniqueID: 'text-list',
+				isList: true,
+				typeOfList: 'ul',
+				listStyle: 'custom',
+				listStyleCustom: 'https://example.com/marker.png',
+				blockStyle: 'light',
+				'list-gap-general': 1,
+				'list-gap-unit-general': 'em',
+				'list-marker-size-general': 48,
+				'list-marker-size-unit-general': 'px',
+				'list-marker-indent-general': 0,
+				'list-marker-indent-unit-general': 'px',
+				'list-marker-line-height-general': 1,
+				'list-marker-line-height-unit-general': 'em',
+				'list-style-position-general': 'outside',
+				'list-text-position-general': 'middle',
+			},
+			() => 1
+		);
+
+		const markerStyles =
+			styles['text-list'][
+				' ul li .maxi-list-item-block__content::before'
+			];
+
+		expect(markerStyles.listStyle.general).toEqual(
+			expect.objectContaining({
+				content: '""',
+				'background-image': "url('https://example.com/marker.png')",
+				'background-position': 'center',
+				'background-repeat': 'no-repeat',
+				'background-size': 'contain',
+			})
+		);
+		expect(markerStyles.listSize.general).toEqual(
+			expect.objectContaining({
+				width: '48px',
+				height: '48px',
+			})
+		);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes Text Maxi custom URL list markers so marker size controls apply consistently, then cleans up the List Options inspector grouping for the same issue path.

## What changed
- Replaced URL marker sizing via `content: url(...)` with a pseudo-element background image and explicit marker dimensions.
- Moved list type, style, and custom marker source controls to the top of List Options.
- Grouped the remaining List Options controls into marker appearance, marker placement, and list spacing sections with divider lines.
- Added focused unit coverage for URL marker sizing and List Options control ordering.

## Why / root cause
Custom URL list markers were rendered through the `content` property, which meant the existing marker size attributes did not reliably control the rendered marker dimensions. The inspector also mixed source, appearance, placement, and spacing controls together, making the list marker workflow harder to scan while testing the fix.

## Testing
- `git diff --check origin/master...HEAD`
- `npm test -- src/blocks/text-maxi/components/list-options-control/test/order.js --runInBand`
- `npm test -- src/blocks/text-maxi/test/styles.js --runInBand`
- `npm run build`

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visual separators to better organize list formatting controls and group related options.

* **Improvements**
  * Reordered list option layout for a clearer workflow and adjusted styling hooks for the text-position control.
  * Improved handling and sizing/positioning for custom list markers (image URLs and SVGs).

* **Bug Fixes**
  * Ensured list-type reset/change keeps the list style synchronized.

* **Tests**
  * Added tests for control ordering and custom marker rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->