### PR TITLE
Fix image mask zero shadow outline

### DIFF
--- a/src/extensions/styles/helpers/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/getBoxShadowStyles.js
@@ -182,12 +182,8 @@ const getBoxShadowStyles = ({
 				? values[target].value
 				: values[target]?.defaultValue;
 
-		const horizontalValue = isNumber(values.horizontal?.value)
-			? values.horizontal.value
-			: values.horizontal?.defaultValue;
-		const verticalValue = isNumber(values.vertical?.value)
-			? values.vertical.value
-			: values.vertical?.defaultValue;
+		const horizontalValue = getDimensionValue('horizontal');
+		const verticalValue = getDimensionValue('vertical');
 		const hasNonZeroShadowDimension = [
 			'horizontal',
 			'vertical',

--- a/src/extensions/styles/helpers/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/getBoxShadowStyles.js
@@ -177,16 +177,33 @@ const getBoxShadowStyles = ({
 
 		if (!isNotDefault) return;
 
+		const getDimensionValue = target =>
+			isNumber(values[target]?.value)
+				? values[target].value
+				: values[target]?.defaultValue;
+
 		const horizontalValue = isNumber(values.horizontal?.value)
 			? values.horizontal.value
 			: values.horizontal?.defaultValue;
 		const verticalValue = isNumber(values.vertical?.value)
 			? values.vertical.value
 			: values.vertical?.defaultValue;
+		const hasNonZeroShadowDimension = [
+			'horizontal',
+			'vertical',
+			'blur',
+			'spread',
+		].some(target => {
+			const value = getDimensionValue(target);
+			return isNumber(value) && value !== 0;
+		});
 
 		let boxShadowString = '';
 
 		if (dropShadow) {
+			if (forClipPath && clipPathExists && !hasNonZeroShadowDimension)
+				return;
+
 			const blurValue = round(
 				(isNumber(values.blur?.value)
 					? values.blur.value

--- a/src/extensions/styles/helpers/test/getBoxShadowStyles.js
+++ b/src/extensions/styles/helpers/test/getBoxShadowStyles.js
@@ -171,4 +171,61 @@ describe('getBoxShadowStyles', () => {
 		});
 		expect(result).toMatchSnapshot();
 	});
+
+	it('Does not emit zero-value drop-shadow for masked image SVGs', () => {
+		const object = {
+			SVGElement: '<svg viewBox="0 0 36 36"></svg>',
+			'image-box-shadow-palette-status-general': true,
+			'image-box-shadow-palette-color-general': 4,
+			'image-box-shadow-palette-opacity-general': 1,
+			'image-box-shadow-horizontal-general': 0,
+			'image-box-shadow-horizontal-unit-general': 'px',
+			'image-box-shadow-vertical-general': 0,
+			'image-box-shadow-vertical-unit-general': 'px',
+			'image-box-shadow-blur-general': 0,
+			'image-box-shadow-blur-unit-general': 'px',
+			'image-box-shadow-spread-general': 0,
+			'image-box-shadow-spread-unit-general': 'px',
+		};
+
+		const result = getBoxShadowStyles({
+			obj: object,
+			blockStyle: 'light',
+			dropShadow: true,
+			forClipPath: true,
+			prefix: 'image-',
+		});
+
+		expect(result).toEqual({});
+	});
+
+	it('Preserves non-zero drop-shadow for masked image SVGs', () => {
+		const object = {
+			SVGElement: '<svg viewBox="0 0 36 36"></svg>',
+			'image-box-shadow-palette-status-general': true,
+			'image-box-shadow-palette-color-general': 4,
+			'image-box-shadow-palette-opacity-general': 1,
+			'image-box-shadow-horizontal-general': 0,
+			'image-box-shadow-horizontal-unit-general': 'px',
+			'image-box-shadow-vertical-general': 6,
+			'image-box-shadow-vertical-unit-general': 'px',
+			'image-box-shadow-blur-general': 9,
+			'image-box-shadow-blur-unit-general': 'px',
+			'image-box-shadow-spread-general': 0,
+			'image-box-shadow-spread-unit-general': 'px',
+		};
+
+		const result = getBoxShadowStyles({
+			obj: object,
+			blockStyle: 'light',
+			dropShadow: true,
+			forClipPath: true,
+			prefix: 'image-',
+		});
+
+		expect(result.general).toEqual({
+			filter:
+				'drop-shadow(0px 6px 3px rgba(var(--maxi-light-color-4,255,74,23),1))',
+		});
+	});
 });


### PR DESCRIPTION
## Summary
Fixes the visible outline on masked Image Maxi SVGs when box shadow is enabled but all shadow dimensions are zero.

## What changed
- Added a guard in `getBoxShadowStyles` so masked clip-path image shadows do not emit a zero-value `drop-shadow(...)` filter.
- Added focused regression coverage for zero-value masked image shadows and for preserving real non-zero masked image shadows.

## Why / root cause
Image masks use the `drop-shadow(...)` filter path when clip-path/SVG masking is active. When the shadow controls were enabled with horizontal, vertical, blur, and spread all set to `0`, the helper still emitted `drop-shadow(0px 0px 0px ...)`. Even though the dimensions were zero, browsers could still render a visible outline around the masked image.

## Testing
- `git diff --check origin/master...HEAD`
- `npm test -- src/extensions/styles/helpers/test/getBoxShadowStyles.js src/extensions/styles/helpers/test/getArrowStyles.js --runInBand`
- `npm run build` passed with the existing webpack asset-size warnings and `.env` load notices.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/4456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of box shadow rendering for masked elements—zero-dimension shadows are no longer generated unnecessarily.

* **Tests**
  * Added test coverage for drop-shadow behavior with masked images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->