### PR TITLE
Add responsive Search icon reveal position

### DIFF
--- a/src/blocks/search-maxi/components/position-control/index.js
+++ b/src/blocks/search-maxi/components/position-control/index.js
@@ -1,0 +1,23 @@
+import AxisPositionControl from '@components/axis-position-control';
+import { getResponsiveIconPosition } from '@blocks/search-maxi/utils';
+
+const SearchPositionControl = ({ attributes, breakpoint, onChange, skin }) => (
+	<AxisPositionControl
+		label='Button'
+		selected={getResponsiveIconPosition(attributes, breakpoint)}
+		onChange={val => {
+			onChange(val, breakpoint);
+		}}
+		breakpoint={breakpoint}
+		responsive
+		disableY
+		enableCenter={skin === 'icon-reveal'}
+		buttonClasses={{
+			left: 'maxi-search-control__left',
+			center: 'maxi-search-control__center',
+			right: 'maxi-search-control__right',
+		}}
+	/>
+);
+
+export default SearchPositionControl;

--- a/src/blocks/search-maxi/components/skin-control/index.js
+++ b/src/blocks/search-maxi/components/skin-control/index.js
@@ -10,6 +10,7 @@ import SelectControl from '@components/select-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import { getDefaultAttribute } from '@extensions/styles';
 import { prefixes } from '@blocks/search-maxi/data';
+import { getIconPositionResetAttributes } from '@blocks/search-maxi/utils';
 
 const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 	const { buttonPrefix, inputPrefix } = prefixes;
@@ -38,10 +39,7 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 		`${inputPrefix}border-left-width-general`,
 		`${inputPrefix}border-right-width-general`,
 	]);
-	const resetPosition = {
-		'icon-position': 'right',
-		'icon-position-general': 'right',
-	};
+	const resetPosition = getIconPositionResetAttributes();
 
 	return (
 		<>

--- a/src/blocks/search-maxi/components/skin-control/index.js
+++ b/src/blocks/search-maxi/components/skin-control/index.js
@@ -38,6 +38,10 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 		`${inputPrefix}border-left-width-general`,
 		`${inputPrefix}border-right-width-general`,
 	]);
+	const resetPosition = {
+		'icon-position': 'right',
+		'icon-position-general': 'right',
+	};
 
 	return (
 		<>
@@ -68,7 +72,7 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 							...resetBorders,
 							[`${inputPrefix}padding-left-general`]: 10,
 							[`${inputPrefix}padding-right-general`]: 30,
-							'icon-position': 'right',
+							...resetPosition,
 						});
 					} else if (skin === 'boxed') {
 						onChange({
@@ -77,7 +81,7 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 							...resetBorders,
 							[`${inputPrefix}padding-left-general`]: 10,
 							[`${inputPrefix}padding-right-general`]: 30,
-							'icon-position': 'right',
+							...resetPosition,
 						});
 					} else if (skin === 'icon-reveal') {
 						onChange({
@@ -91,7 +95,7 @@ const SkinControl = ({ skin, iconRevealAction, onChange }) => {
 							[`${inputPrefix}padding-left-general`]: 10,
 							[`${inputPrefix}padding-right-general`]: 30,
 							...resetBorders,
-							'icon-position': 'right',
+							...resetPosition,
 						});
 					}
 

--- a/src/blocks/search-maxi/edit.js
+++ b/src/blocks/search-maxi/edit.js
@@ -20,6 +20,7 @@ import { getMaxiBlockAttributes } from '@components/maxi-block';
 import { getIconPositionClass } from '@extensions/styles';
 import getStyles from './styles';
 import { prefixes, copyPasteMapping } from './data';
+import { getResponsiveIconPosition } from './utils';
 import withMaxiDC from '@extensions/DC/withMaxiDC';
 
 /**
@@ -169,7 +170,7 @@ class edit extends MaxiBlockComponent {
 		const classes = classnames(
 			'maxi-search-block',
 			getIconPositionClass(
-				attributes['icon-position'],
+				getResponsiveIconPosition(attributes, 'general'),
 				'maxi-search-block'
 			)
 		);

--- a/src/blocks/search-maxi/inspector.js
+++ b/src/blocks/search-maxi/inspector.js
@@ -21,7 +21,10 @@ import SkinControl from './components/skin-control';
 import PlaceholderColorControl from './components/placeholder-color-control';
 import { getGroupAttributes } from '@extensions/styles';
 import { ariaLabelsCategories, customCss, prefixes } from './data';
-import { getIconRevealPositionSettings } from './utils';
+import {
+	getIconRevealPositionSettings,
+	getResponsiveIconPosition,
+} from './utils';
 import { withMaxiInspector } from '@extensions/inspector';
 import * as inspectorTabs from '@components/inspector-tabs';
 
@@ -40,13 +43,13 @@ const Inspector = props => {
 
 	const { buttonPrefix, closeIconPrefix, inputPrefix } = prefixes;
 	const {
-		'icon-position': buttonPosition,
 		buttonSkin,
 		iconRevealAction,
 		skin,
 		'icon-content': iconContent,
 		[`${closeIconPrefix}icon-content`]: closeIconContent,
 	} = attributes;
+	const buttonPosition = getResponsiveIconPosition(attributes, deviceType);
 	const { selectors, categories } = customCss;
 
 	const getCategoriesCss = () => {
@@ -104,11 +107,18 @@ const Inspector = props => {
 	};
 
 	const positionSettings = val => {
-		const iconRevealPositionSettings = getIconRevealPositionSettings(val);
+		const breakpoint = deviceType || 'general';
+		const iconRevealPositionSettings = getIconRevealPositionSettings(
+			val,
+			breakpoint
+		);
 
 		iconRevealPositionSettings &&
 			maxiSetAttributes({
-				'icon-position': val,
+				[`icon-position-${breakpoint}`]: val,
+				...(breakpoint === 'general' && {
+					'icon-position': val,
+				}),
 				...iconRevealPositionSettings,
 			});
 	};
@@ -226,8 +236,7 @@ const Inspector = props => {
 																				prefix: closeIconPrefix,
 																			}
 																		)),
-																	...(deviceType ===
-																		'general' && {
+																	{
 																		label: __(
 																			'Position',
 																			'maxi-blocks'
@@ -247,6 +256,7 @@ const Inspector = props => {
 																					breakpoint={
 																						deviceType
 																					}
+																					responsive
 																					disableY
 																					enableCenter={
 																						skin ===
@@ -262,8 +272,9 @@ const Inspector = props => {
 																		extraIndicators:
 																			[
 																				'icon-position',
+																				`icon-position-${deviceType}`,
 																			],
-																	}),
+																	},
 																	...inspectorTabs.border(
 																		{
 																			props,

--- a/src/blocks/search-maxi/inspector.js
+++ b/src/blocks/search-maxi/inspector.js
@@ -14,17 +14,15 @@ import { isEmpty, without } from 'lodash';
  * Internal dependencies
  */
 import AccordionControl from '@components/accordion-control';
-import AxisPositionControl from '@components/axis-position-control';
+import ResponsiveTabsControl from '@components/responsive-tabs-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import ButtonControl from './components/button-control';
 import SkinControl from './components/skin-control';
 import PlaceholderColorControl from './components/placeholder-color-control';
+import SearchPositionControl from './components/position-control';
 import { getGroupAttributes } from '@extensions/styles';
 import { ariaLabelsCategories, customCss, prefixes } from './data';
-import {
-	getIconRevealPositionSettings,
-	getResponsiveIconPosition,
-} from './utils';
+import { getIconRevealPositionSettings } from './utils';
 import { withMaxiInspector } from '@extensions/inspector';
 import * as inspectorTabs from '@components/inspector-tabs';
 
@@ -49,7 +47,6 @@ const Inspector = props => {
 		'icon-content': iconContent,
 		[`${closeIconPrefix}icon-content`]: closeIconContent,
 	} = attributes;
-	const buttonPosition = getResponsiveIconPosition(attributes, deviceType);
 	const { selectors, categories } = customCss;
 
 	const getCategoriesCss = () => {
@@ -106,8 +103,7 @@ const Inspector = props => {
 		disableVideo: true,
 	};
 
-	const positionSettings = val => {
-		const breakpoint = deviceType || 'general';
+	const positionSettings = (val, breakpoint = deviceType || 'general') => {
 		const iconRevealPositionSettings = getIconRevealPositionSettings(
 			val,
 			breakpoint
@@ -243,36 +239,36 @@ const Inspector = props => {
 																		),
 																		content:
 																			(
-																				<AxisPositionControl
-																					label='Button'
-																					selected={
-																						buttonPosition
-																					}
-																					onChange={val => {
-																						positionSettings(
-																							val
-																						);
-																					}}
+																				<ResponsiveTabsControl
 																					breakpoint={
 																						deviceType
 																					}
-																					responsive
-																					disableY
-																					enableCenter={
-																						skin ===
-																						'icon-reveal'
-																					}
-																					buttonClasses={{
-																						left: 'maxi-search-control__left',
-																						center: 'maxi-search-control__center',
-																						right: 'maxi-search-control__right',
-																					}}
-																				/>
+																					target='search-icon-position'
+																				>
+																					<SearchPositionControl
+																						attributes={
+																							attributes
+																						}
+																						breakpoint={
+																							deviceType
+																						}
+																						onChange={
+																							positionSettings
+																						}
+																						skin={
+																							skin
+																						}
+																					/>
+																				</ResponsiveTabsControl>
 																			),
 																		extraIndicators:
 																			[
 																				'icon-position',
 																				`icon-position-${deviceType}`,
+																			],
+																		extraIndicatorsResponsive:
+																			[
+																				'icon-position',
 																			],
 																	},
 																	...inspectorTabs.border(

--- a/src/blocks/search-maxi/save.js
+++ b/src/blocks/search-maxi/save.js
@@ -4,6 +4,7 @@
 import { MaxiBlock, getMaxiBlockAttributes } from '@components/maxi-block';
 import { RawHTML } from '@components';
 import { getIconPositionClass } from '@extensions/styles';
+import { getResponsiveIconPosition } from './utils';
 
 /**
  * External dependencies
@@ -29,7 +30,10 @@ const save = props => {
 
 	const classes = classnames(
 		'maxi-search-block',
-		getIconPositionClass(attributes['icon-position'], 'maxi-search-block')
+		getIconPositionClass(
+			getResponsiveIconPosition(attributes, 'general'),
+			'maxi-search-block'
+		)
 	);
 
 	const inputClasses = classnames(

--- a/src/blocks/search-maxi/styles.js
+++ b/src/blocks/search-maxi/styles.js
@@ -23,6 +23,7 @@ import {
 	getZIndexStyles,
 } from '@extensions/styles/helpers';
 import data, { prefixes } from './data';
+import { getIconRevealPositionStyles } from './utils';
 
 const { buttonPrefix, closeIconPrefix, inputPrefix } = prefixes;
 
@@ -339,15 +340,36 @@ const getSearchInputPlaceholderStyles = props => {
 
 const getStyles = props => {
 	const { uniqueID } = props;
+	const iconRevealPositionStyles = getIconRevealPositionStyles(props);
 
 	const response = {
 		[uniqueID]: styleProcessor(
 			{
-				'': getNormalObject(props),
-				' .maxi-search-block__input': getSearchInputStyles(props),
+				'': {
+					...getNormalObject(props),
+					...(iconRevealPositionStyles.block && {
+						iconRevealPosition: iconRevealPositionStyles.block,
+					}),
+				},
+				' .maxi-search-block__input': {
+					...getSearchInputStyles(props),
+					...(iconRevealPositionStyles.input && {
+						iconRevealPosition: iconRevealPositionStyles.input,
+					}),
+				},
 				' .maxi-search-block__input::placeholder':
 					getSearchInputPlaceholderStyles(props),
-				' .maxi-search-block__button': getSearchButtonStyles(props),
+				' .maxi-search-block__button': {
+					...getSearchButtonStyles(props),
+					...(iconRevealPositionStyles.button && {
+						iconRevealPosition: iconRevealPositionStyles.button,
+					}),
+				},
+				...(iconRevealPositionStyles.hiddenInput && {
+					' .maxi-search-block__input--hidden': {
+						iconRevealPosition: iconRevealPositionStyles.hiddenInput,
+					},
+				}),
 				...getSearchButtonIconStyles(props),
 				' .maxi-search-block__button__content':
 					getSearchButtonContentStyles(props),

--- a/src/blocks/search-maxi/test/position-control.spec.js
+++ b/src/blocks/search-maxi/test/position-control.spec.js
@@ -1,0 +1,28 @@
+import SearchPositionControl from '@blocks/search-maxi/components/position-control';
+
+jest.mock('@components/axis-position-control', () => 'AxisPositionControl');
+
+describe('SearchPositionControl', () => {
+	it('passes responsive breakpoint state to the axis position control', () => {
+		const onChange = jest.fn();
+		const result = SearchPositionControl({
+			attributes: {
+				'icon-position': 'right',
+				'icon-position-general': 'right',
+				'icon-position-m': 'left',
+			},
+			breakpoint: 'm',
+			onChange,
+			skin: 'icon-reveal',
+		});
+
+		expect(result.props.breakpoint).toBe('m');
+		expect(result.props.selected).toBe('left');
+		expect(result.props.responsive).toBe(true);
+		expect(result.props.enableCenter).toBe(true);
+
+		result.props.onChange('center');
+
+		expect(onChange).toHaveBeenCalledWith('center', 'm');
+	});
+});

--- a/src/blocks/search-maxi/test/utils.spec.js
+++ b/src/blocks/search-maxi/test/utils.spec.js
@@ -1,4 +1,8 @@
-import { getIconRevealPositionSettings } from '@blocks/search-maxi/utils';
+import {
+	getIconRevealPositionSettings,
+	getIconRevealPositionStyles,
+	getResponsiveIconPosition,
+} from '@blocks/search-maxi/utils';
 
 describe('getIconRevealPositionSettings', () => {
 	it.each([
@@ -35,5 +39,75 @@ describe('getIconRevealPositionSettings', () => {
 
 	it('does not return settings for unsupported positions', () => {
 		expect(getIconRevealPositionSettings('top')).toBeUndefined();
+	});
+
+	it('returns spacing settings for the requested breakpoint', () => {
+		expect(getIconRevealPositionSettings('left', 'm')).toEqual({
+			'input-border-left-width-m': 0,
+			'input-border-right-width-m': 4,
+			'input-padding-left-m': 35,
+			'input-padding-right-m': 10,
+		});
+	});
+});
+
+describe('getResponsiveIconPosition', () => {
+	it('falls back through lower breakpoints before using the legacy position', () => {
+		const attributes = {
+			'icon-position': 'right',
+			'icon-position-general': 'center',
+			'icon-position-m': 'left',
+		};
+
+		expect(getResponsiveIconPosition(attributes, 's')).toBe('left');
+		expect(getResponsiveIconPosition(attributes, 'l')).toBe('center');
+	});
+
+	it('uses the legacy position when no responsive positions are set', () => {
+		expect(
+			getResponsiveIconPosition({ 'icon-position': 'right' }, 'm')
+		).toBe('right');
+	});
+});
+
+describe('getIconRevealPositionStyles', () => {
+	it('returns responsive layout styles only for configured breakpoint positions', () => {
+		expect(
+			getIconRevealPositionStyles({
+				'icon-position': 'right',
+				'icon-position-m': 'left',
+			})
+		).toEqual({
+			block: {
+				label: 'Icon reveal position',
+				m: {
+					'justify-content': 'flex-start',
+				},
+			},
+			button: {
+				label: 'Icon reveal button position',
+				m: {
+					order: 0,
+				},
+			},
+			input: {
+				label: 'Icon reveal input position',
+				m: {
+					'margin-left': '-25px !important',
+					'margin-right': '0 !important',
+				},
+			},
+			hiddenInput: {
+				label: 'Icon reveal hidden input position',
+				m: {
+					'border-left-width': '0 !important',
+					'border-right-width': '4px !important',
+					'margin-left': '-25px !important',
+					'margin-right': '0 !important',
+					'padding-left': '35px !important',
+					'padding-right': '10px !important',
+				},
+			},
+		});
 	});
 });

--- a/src/blocks/search-maxi/test/utils.spec.js
+++ b/src/blocks/search-maxi/test/utils.spec.js
@@ -1,8 +1,24 @@
 import {
+	getIconPositionResetAttributes,
 	getIconRevealPositionSettings,
 	getIconRevealPositionStyles,
 	getResponsiveIconPosition,
 } from '@blocks/search-maxi/utils';
+
+describe('getIconPositionResetAttributes', () => {
+	it('resets legacy and responsive icon position attributes', () => {
+		expect(getIconPositionResetAttributes()).toEqual({
+			'icon-position': 'right',
+			'icon-position-general': 'right',
+			'icon-position-xxl': 'right',
+			'icon-position-xl': 'right',
+			'icon-position-l': 'right',
+			'icon-position-m': 'right',
+			'icon-position-s': 'right',
+			'icon-position-xs': 'right',
+		});
+	});
+});
 
 describe('getIconRevealPositionSettings', () => {
 	it.each([
@@ -71,7 +87,7 @@ describe('getResponsiveIconPosition', () => {
 });
 
 describe('getIconRevealPositionStyles', () => {
-	it('returns responsive layout styles only for configured breakpoint positions', () => {
+	it('returns responsive layout styles for configured breakpoint positions', () => {
 		expect(
 			getIconRevealPositionStyles({
 				'icon-position': 'right',
@@ -80,18 +96,28 @@ describe('getIconRevealPositionStyles', () => {
 		).toEqual({
 			block: {
 				label: 'Icon reveal position',
+				general: {
+					'justify-content': 'flex-end',
+				},
 				m: {
 					'justify-content': 'flex-start',
 				},
 			},
 			button: {
 				label: 'Icon reveal button position',
+				general: {
+					order: 2,
+				},
 				m: {
 					order: 0,
 				},
 			},
 			input: {
 				label: 'Icon reveal input position',
+				general: {
+					'margin-left': '0 !important',
+					'margin-right': '-25px !important',
+				},
 				m: {
 					'margin-left': '-25px !important',
 					'margin-right': '0 !important',
@@ -99,6 +125,14 @@ describe('getIconRevealPositionStyles', () => {
 			},
 			hiddenInput: {
 				label: 'Icon reveal hidden input position',
+				general: {
+					'border-left-width': '4px !important',
+					'border-right-width': '0 !important',
+					'margin-left': '0 !important',
+					'margin-right': '-25px !important',
+					'padding-left': '10px !important',
+					'padding-right': '35px !important',
+				},
 				m: {
 					'border-left-width': '0 !important',
 					'border-right-width': '4px !important',
@@ -106,6 +140,45 @@ describe('getIconRevealPositionStyles', () => {
 					'margin-right': '0 !important',
 					'padding-left': '35px !important',
 					'padding-right': '10px !important',
+				},
+			},
+		});
+	});
+
+	it('uses the legacy icon position for general styles when responsive state is missing', () => {
+		expect(
+			getIconRevealPositionStyles({
+				'icon-position': 'right',
+			})
+		).toEqual({
+			block: {
+				label: 'Icon reveal position',
+				general: {
+					'justify-content': 'flex-end',
+				},
+			},
+			button: {
+				label: 'Icon reveal button position',
+				general: {
+					order: 2,
+				},
+			},
+			input: {
+				label: 'Icon reveal input position',
+				general: {
+					'margin-left': '0 !important',
+					'margin-right': '-25px !important',
+				},
+			},
+			hiddenInput: {
+				label: 'Icon reveal hidden input position',
+				general: {
+					'border-left-width': '4px !important',
+					'border-right-width': '0 !important',
+					'margin-left': '0 !important',
+					'margin-right': '-25px !important',
+					'padding-left': '10px !important',
+					'padding-right': '35px !important',
 				},
 			},
 		});

--- a/src/blocks/search-maxi/utils.js
+++ b/src/blocks/search-maxi/utils.js
@@ -1,4 +1,12 @@
-const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+export const iconPositionBreakpoints = [
+	'general',
+	'xxl',
+	'xl',
+	'l',
+	'm',
+	's',
+	'xs',
+];
 
 const breakpointFallbacks = {
 	general: ['general'],
@@ -97,6 +105,17 @@ const createResponsiveStyleObject = label => ({
 
 const hasBreakpointValue = styles => Object.keys(styles).length > 1;
 
+export const getIconPositionResetAttributes = (position = 'right') =>
+	iconPositionBreakpoints.reduce(
+		(acc, breakpoint) => ({
+			...acc,
+			[`icon-position-${breakpoint}`]: position,
+		}),
+		{
+			'icon-position': position,
+		}
+	);
+
 export const getIconRevealPositionSettings = (
 	position,
 	breakpoint = 'general'
@@ -137,8 +156,12 @@ export const getIconRevealPositionStyles = attributes => {
 		),
 	};
 
-	breakpoints.forEach(breakpoint => {
-		const position = attributes?.[`icon-position-${breakpoint}`];
+	iconPositionBreakpoints.forEach(breakpoint => {
+		const position =
+			attributes?.[`icon-position-${breakpoint}`] ||
+			(breakpoint === 'general'
+				? attributes?.['icon-position']
+				: undefined);
 		const positionStyles = positions[position];
 
 		if (!positionStyles) return;

--- a/src/blocks/search-maxi/utils.js
+++ b/src/blocks/search-maxi/utils.js
@@ -1,24 +1,156 @@
-export const getIconRevealPositionSettings = position => {
-	const positionSettings = {
-		left: {
-			'input-border-left-width-general': 0,
-			'input-border-right-width-general': 4,
-			'input-padding-left-general': 35,
-			'input-padding-right-general': 10,
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+const breakpointFallbacks = {
+	general: ['general'],
+	xxl: ['xxl', 'general'],
+	xl: ['xl', 'general'],
+	l: ['l', 'xl', 'general'],
+	m: ['m', 'l', 'xl', 'general'],
+	s: ['s', 'm', 'l', 'xl', 'general'],
+	xs: ['xs', 's', 'm', 'l', 'xl', 'general'],
+};
+
+const positions = {
+	left: {
+		block: {
+			'justify-content': 'flex-start',
 		},
-		center: {
-			'input-border-left-width-general': 4,
-			'input-border-right-width-general': 4,
-			'input-padding-left-general': 10,
-			'input-padding-right-general': 10,
+		button: {
+			order: 0,
 		},
-		right: {
-			'input-border-left-width-general': 4,
-			'input-border-right-width-general': 0,
-			'input-padding-left-general': 10,
-			'input-padding-right-general': 35,
+		input: {
+			'margin-left': '-25px !important',
+			'margin-right': '0 !important',
 		},
+		hiddenInput: {
+			'margin-left': '-25px !important',
+			'margin-right': '0 !important',
+			'padding-left': '35px !important',
+			'padding-right': '10px !important',
+			'border-left-width': '0 !important',
+			'border-right-width': '4px !important',
+		},
+		settings: {
+			'border-left-width': 0,
+			'border-right-width': 4,
+			'padding-left': 35,
+			'padding-right': 10,
+		},
+	},
+	center: {
+		block: {
+			'justify-content': 'center',
+		},
+		button: {
+			order: 1,
+		},
+		input: {
+			'margin-left': '0 !important',
+			'margin-right': '-25px !important',
+		},
+		hiddenInput: {
+			'margin-left': '0 !important',
+			'margin-right': '0 !important',
+			'padding-left': '0 !important',
+			'padding-right': '0 !important',
+			'border-left-width': '0 !important',
+			'border-right-width': '0 !important',
+		},
+		settings: {
+			'border-left-width': 4,
+			'border-right-width': 4,
+			'padding-left': 10,
+			'padding-right': 10,
+		},
+	},
+	right: {
+		block: {
+			'justify-content': 'flex-end',
+		},
+		button: {
+			order: 2,
+		},
+		input: {
+			'margin-left': '0 !important',
+			'margin-right': '-25px !important',
+		},
+		hiddenInput: {
+			'margin-left': '0 !important',
+			'margin-right': '-25px !important',
+			'padding-left': '10px !important',
+			'padding-right': '35px !important',
+			'border-left-width': '4px !important',
+			'border-right-width': '0 !important',
+		},
+		settings: {
+			'border-left-width': 4,
+			'border-right-width': 0,
+			'padding-left': 10,
+			'padding-right': 35,
+		},
+	},
+};
+
+const createResponsiveStyleObject = label => ({
+	label,
+});
+
+const hasBreakpointValue = styles => Object.keys(styles).length > 1;
+
+export const getIconRevealPositionSettings = (
+	position,
+	breakpoint = 'general'
+) => {
+	const settings = positions[position]?.settings;
+	if (!settings) return undefined;
+
+	return Object.entries(settings).reduce((acc, [key, value]) => {
+		acc[`input-${key}-${breakpoint}`] = value;
+		return acc;
+	}, {});
+};
+
+export const getResponsiveIconPosition = (
+	attributes,
+	breakpoint = 'general'
+) => {
+	const fallbackBreakpoints =
+		breakpointFallbacks[breakpoint] || breakpointFallbacks.general;
+
+	const responsivePosition = fallbackBreakpoints
+		.map(
+			currentBreakpoint =>
+				attributes?.[`icon-position-${currentBreakpoint}`]
+		)
+		.find(Boolean);
+
+	return responsivePosition || attributes?.['icon-position'];
+};
+
+export const getIconRevealPositionStyles = attributes => {
+	const response = {
+		block: createResponsiveStyleObject('Icon reveal position'),
+		button: createResponsiveStyleObject('Icon reveal button position'),
+		input: createResponsiveStyleObject('Icon reveal input position'),
+		hiddenInput: createResponsiveStyleObject(
+			'Icon reveal hidden input position'
+		),
 	};
 
-	return positionSettings[position];
+	breakpoints.forEach(breakpoint => {
+		const position = attributes?.[`icon-position-${breakpoint}`];
+		const positionStyles = positions[position];
+
+		if (!positionStyles) return;
+
+		response.block[breakpoint] = positionStyles.block;
+		response.button[breakpoint] = positionStyles.button;
+		response.input[breakpoint] = positionStyles.input;
+		response.hiddenInput[breakpoint] = positionStyles.hiddenInput;
+	});
+
+	return Object.entries(response).reduce((acc, [key, value]) => {
+		if (hasBreakpointValue(value)) acc[key] = value;
+		return acc;
+	}, {});
 };

--- a/src/components/axis-position-control/index.js
+++ b/src/components/axis-position-control/index.js
@@ -27,11 +27,12 @@ const AxisPositionControl = ({
 	disableY = false,
 	enableCenter = false,
 	buttonClasses = {},
+	responsive = false,
 }) => {
 	const classes = classnames('maxi-axis-position-control', className);
 
 	return (
-		breakpoint === 'general' && (
+		(breakpoint === 'general' || responsive) && (
 			<SettingTabsControl
 				label={__(`${label} position`, 'maxi-blocks')}
 				className={classes}

--- a/src/components/axis-position-control/test/index.js
+++ b/src/components/axis-position-control/test/index.js
@@ -1,0 +1,18 @@
+import AxisPositionControl from '@components/axis-position-control';
+
+jest.mock('@components/setting-tabs-control', () => 'SettingTabsControl');
+
+describe('AxisPositionControl', () => {
+	it('renders for responsive breakpoints when responsive support is enabled', () => {
+		const result = AxisPositionControl({
+			label: 'Button',
+			onChange: jest.fn(),
+			selected: 'left',
+			breakpoint: 'm',
+			responsive: true,
+		});
+
+		expect(result).toBeTruthy();
+		expect(result.props.selected).toBe('left');
+	});
+});

--- a/src/extensions/styles/defaults/icon.js
+++ b/src/extensions/styles/defaults/icon.js
@@ -31,6 +31,13 @@ export const icon = {
 	},
 	...breakpointAttributesCreator({
 		obj: {
+			'icon-position': {
+				type: 'string',
+			},
+		},
+	}),
+	...breakpointAttributesCreator({
+		obj: {
 			'icon-spacing': {
 				type: 'number',
 				default: 5,


### PR DESCRIPTION
## Summary

Adds responsive breakpoint support for the Search block icon reveal position control.

## What changed

- Added responsive `icon-position-*` attributes while preserving the legacy `icon-position` fallback.
- Wrapped the Search block Button position control in responsive tabs so each breakpoint can set its own icon reveal position.
- Updated Search block edit/save/style behavior so responsive icon positions affect button alignment, order, input spacing, and hidden input styling at the correct breakpoint.
- Kept `AxisPositionControl` non-responsive by default and made responsive behavior opt-in for Search.
- Added focused unit coverage for the responsive Search position helper, the Search position control wrapper, and the opt-in AxisPositionControl behavior.

## Why / root cause

The Search block icon reveal position was stored as one non-breakpoint attribute, and the position control rendered only the general value. That meant changing Left, Center, or Right could not be scoped per responsive breakpoint. The fix adds breakpoint attributes and a Search-specific responsive wrapper while keeping existing saved content compatible through the general/legacy fallback.

## How to test

1. Open the editor and insert a Search Maxi block.
2. Go to Search settings, then Button, then Position.
3. Switch between responsive breakpoints in the position control.
4. Set different button positions, for example Desktop: Right, Tablet: Center, Mobile: Left.
5. Confirm each breakpoint keeps its own selected position when switching back and forth.
6. Preview the page at those viewport widths and confirm the button/input layout follows the selected breakpoint position.
7. Change the Search skin and confirm the position resets cleanly without leaving stale breakpoint state.

Expected result: the Search button reveal position is independently controllable per breakpoint, existing Search blocks still use their saved general/legacy position, and other AxisPositionControl users remain unchanged.

## Testing

- `git diff --check origin/master...HEAD`
- `npm test -- src/blocks/search-maxi/test/utils.spec.js src/blocks/search-maxi/test/position-control.spec.js src/components/axis-position-control/test/index.js src/extensions/styles/test/getGroupAttributes.js src/extensions/styles/helpers/test/getButtonIconStyles.js --runInBand`
- `npm run build` passed with existing asset-size warnings only.
- WAMP smoke check: local homepage loaded and `wp-json` returned 200 from the main checkout. Search-specific browser validation still needs the manual editor checks above because the homepage did not contain a Search block.

## Closing issue link

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive icon-position controls for the search block, allowing distinct icon positions per breakpoint.

* **Bug Fixes**
  * Restores icon position correctly when switching search skins.

* **Improvements**
  * Icon-reveal styles now adapt across breakpoints for consistent layout and spacing.

* **Tests**
  * Added unit tests covering responsive position logic and the new position control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->