### PR TITLE
Fix responsive clip-path reset

### DIFF
--- a/src/extensions/styles/helpers/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/getBackgroundStyles.js
@@ -28,6 +28,31 @@ import { __ } from '@wordpress/i18n';
 
 const BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
+const hasUsableClipPath = clipPath => !isEmpty(clipPath) && clipPath !== 'none';
+
+const isClipPathDisabledAtBreakpoint = ({
+	target,
+	breakpoint,
+	props,
+	isHover,
+	clipPath,
+}) =>
+	getAttributeValue({
+		target,
+		props,
+		isHover,
+		breakpoint,
+		returnValueWithoutBreakpoint: false,
+	}) === false && hasUsableClipPath(clipPath);
+
+const getClipPathStyleValue = ({ clipPath, isActive, isDisabled }) => {
+	if (isDisabled) return 'none';
+
+	if (isActive) return isEmpty(clipPath) ? 'none' : clipPath;
+
+	return null;
+};
+
 /**
  * Clean BackgroundControl object for being delivered for styling
  *
@@ -93,6 +118,17 @@ export const getColorBackgroundObject = ({
 		breakpoint,
 		attributes: props,
 		isHover,
+	});
+	const bgColorClipPathStyle = getClipPathStyleValue({
+		clipPath: bgClipPath,
+		isActive: isBgColorClipPathActive,
+		isDisabled: isClipPathDisabledAtBreakpoint({
+			target: `${prefix}background-color-clip-path-status`,
+			breakpoint,
+			props,
+			isHover,
+			clipPath: bgClipPath,
+		}),
 	});
 
 	if (!paletteStatus && !isEmpty(color))
@@ -182,10 +218,8 @@ export const getColorBackgroundObject = ({
 		else response[breakpoint].background = '';
 	}
 
-	if (isBgColorClipPathActive)
-		response[breakpoint]['clip-path'] = isEmpty(bgClipPath)
-			? 'none'
-			: bgClipPath;
+	if (!isNil(bgColorClipPathStyle))
+		response[breakpoint]['clip-path'] = bgColorClipPathStyle;
 
 	return response;
 };
@@ -243,6 +277,17 @@ export const getGradientBackgroundObject = ({
 		breakpoint,
 		attributes: props,
 		isHover,
+	});
+	const bgGradientClipPathStyle = getClipPathStyleValue({
+		clipPath: bgGradientClipPath,
+		isActive: isbgGradientClipPathActive,
+		isDisabled: isClipPathDisabledAtBreakpoint({
+			target: `${prefix}background-gradient-clip-path-status`,
+			breakpoint,
+			props,
+			isHover,
+			clipPath: bgGradientClipPath,
+		}),
 	});
 
 	if (
@@ -314,10 +359,8 @@ export const getGradientBackgroundObject = ({
 			if (background) response[breakpoint].background = background;
 		}
 
-		if (isbgGradientClipPathActive)
-			response[breakpoint]['clip-path'] = isEmpty(bgGradientClipPath)
-				? 'none'
-				: bgGradientClipPath;
+		if (!isNil(bgGradientClipPathStyle))
+			response[breakpoint]['clip-path'] = bgGradientClipPathStyle;
 	}
 
 	return response;
@@ -420,6 +463,17 @@ export const getImageBackgroundObject = ({
 		breakpoint,
 		attributes: props,
 		isHover,
+	});
+	const bgImageClipPathStyle = getClipPathStyleValue({
+		clipPath: bgImageClipPath,
+		isActive: isbgImageClipPathActive,
+		isDisabled: isClipPathDisabledAtBreakpoint({
+			target: `${prefix}background-image-clip-path-status`,
+			breakpoint,
+			props,
+			isHover,
+			clipPath: bgImageClipPath,
+		}),
 	});
 
 	if (!isParallax) {
@@ -540,10 +594,8 @@ export const getImageBackgroundObject = ({
 	}
 
 	// Clip-path
-	if (isbgImageClipPathActive)
-		response[breakpoint]['clip-path'] = isEmpty(bgImageClipPath)
-			? 'none'
-			: bgImageClipPath;
+	if (!isNil(bgImageClipPathStyle))
+		response[breakpoint]['clip-path'] = bgImageClipPathStyle;
 
 	return response;
 };

--- a/src/extensions/styles/helpers/getClipPathStyles.js
+++ b/src/extensions/styles/helpers/getClipPathStyles.js
@@ -9,6 +9,8 @@ import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttr
  */
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
+const hasUsableClipPath = clipPath => !!clipPath && clipPath !== 'none';
+
 /**
  *
  * @param {Object} obj Block clip-path properties
@@ -24,6 +26,26 @@ const getClipPathStyles = ({ obj, isHover = false, isIB = false }) => {
 			isHover,
 			breakpoint,
 		});
+		const isCurrentBreakpointDisabled =
+			!isHover &&
+			getAttributeValue({
+				target: 'clip-path-status',
+				props: obj,
+				isHover,
+				breakpoint,
+				returnValueWithoutBreakpoint: false,
+			}) === false;
+		const inheritedClipPath = isCurrentBreakpointDisabled
+			? getLastBreakpointAttribute({
+					target: 'clip-path',
+					breakpoint,
+					attributes: obj,
+					isHover,
+			  })
+			: null;
+		const shouldResetClipPath =
+			isCurrentBreakpointDisabled &&
+			hasUsableClipPath(inheritedClipPath || currentClipPath);
 
 		omitClipPath = omitClipPath
 			? !currentClipPath || currentClipPath === 'none'
@@ -31,7 +53,9 @@ const getClipPathStyles = ({ obj, isHover = false, isIB = false }) => {
 		if (omitClipPath) return;
 
 		response[breakpoint] = {
-			...(currentClipPath &&
+			...(shouldResetClipPath && { 'clip-path': 'none' }),
+			...(!shouldResetClipPath &&
+				currentClipPath &&
 				(isHover
 					? obj['clip-path-status-hover']
 					: getLastBreakpointAttribute({

--- a/src/extensions/styles/helpers/test/__snapshots__/getClipPathStyles.js.snap
+++ b/src/extensions/styles/helpers/test/__snapshots__/getClipPathStyles.js.snap
@@ -11,7 +11,9 @@ exports[`getClipPathStyles Get a correct clipPath styles 1`] = `
   "m": {
     "clip-path": "none",
   },
-  "s": {},
+  "s": {
+    "clip-path": "none",
+  },
   "xl": {
     "clip-path": "polygon(50% 0%, 0% 100%, 100% 100%)",
   },

--- a/src/extensions/styles/helpers/test/getBackgroundStyles.js
+++ b/src/extensions/styles/helpers/test/getBackgroundStyles.js
@@ -3,6 +3,8 @@ import { isNaN, merge } from 'lodash';
 import {
 	getBlockBackgroundStyles,
 	getBackgroundStyles,
+	getColorBackgroundObject,
+	getImageBackgroundObject,
 } from '@extensions/styles/helpers/getBackgroundStyles';
 
 jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () => {
@@ -779,6 +781,58 @@ describe('getBackgroundStyles', () => {
 		const result = getBlockBackgroundNormalAndHoverStyles(attributes);
 
 		expect(result).toMatchSnapshot();
+	});
+
+	it('resets background image clip-path when disabled at a lower breakpoint', () => {
+		const result = getImageBackgroundObject({
+			breakpoint: 'm',
+			ignoreMediaAttributes: true,
+			'background-image-size-general': 'cover',
+			'background-image-clip-path-status-xl': true,
+			'background-image-clip-path-xl':
+				'polygon(50% 0%, 0% 100%, 100% 100%)',
+			'background-image-clip-path-status-m': false,
+		});
+
+		expect(result.m['clip-path']).toBe('none');
+	});
+
+	it('resets background color clip-path when disabled at a lower breakpoint', () => {
+		const result = getColorBackgroundObject({
+			breakpoint: 'm',
+			blockStyle: 'light',
+			'background-color-clip-path-status-xl': true,
+			'background-color-clip-path-xl':
+				'polygon(50% 0%, 0% 100%, 100% 100%)',
+			'background-color-clip-path-status-m': false,
+		});
+
+		expect(result.m['clip-path']).toBe('none');
+	});
+
+	it('keeps background image clip-path active on a lower breakpoint until explicitly disabled', () => {
+		const clipPath = 'polygon(50% 0%, 0% 100%, 100% 100%)';
+		const result = getImageBackgroundObject({
+			breakpoint: 'm',
+			ignoreMediaAttributes: true,
+			'background-image-size-general': 'cover',
+			'background-image-clip-path-status-xl': true,
+			'background-image-clip-path-xl': clipPath,
+		});
+
+		expect(result.m['clip-path']).toBe(clipPath);
+	});
+
+	it('does not activate background image clip-path from a stored shape without active status', () => {
+		const result = getImageBackgroundObject({
+			breakpoint: 'm',
+			ignoreMediaAttributes: true,
+			'background-image-size-general': 'cover',
+			'background-image-clip-path-xl':
+				'polygon(50% 0%, 0% 100%, 100% 100%)',
+		});
+
+		expect(result.m['clip-path']).toBeUndefined();
 	});
 
 	it('Get correct block background styles for video layer with different values on different responsive stages and hovers', () => {

--- a/src/extensions/styles/helpers/test/getClipPathStyles.js
+++ b/src/extensions/styles/helpers/test/getClipPathStyles.js
@@ -32,6 +32,32 @@ describe('getClipPathStyles', () => {
 		expect(result).toMatchSnapshot();
 	});
 
+	it('resets clipPath styles when disabled at a lower breakpoint', () => {
+		const result = getClipPathStyles({
+			obj: {
+				'clip-path-status-xl': true,
+				'clip-path-xl':
+					'polygon(50% 0%, 0% 100%, 100% 100%)',
+				'clip-path-status-m': false,
+			},
+		});
+
+		expect(result.m).toEqual({ 'clip-path': 'none' });
+	});
+
+	it('does not activate clipPath styles from a stored shape without active status', () => {
+		const result = getClipPathStyles({
+			obj: {
+				'clip-path-xl':
+					'polygon(50% 0%, 0% 100%, 100% 100%)',
+			},
+		});
+
+		expect(
+			Object.values(result).some(styles => styles['clip-path'])
+		).toBe(false);
+	});
+
 	it('Get a correct hover clipPath styles', () => {
 		const result = getClipPathStyles({ obj: object, isHover: true });
 		expect(result).toMatchSnapshot();


### PR DESCRIPTION
## Summary
Fixes responsive clip-path disable behavior so turning `Use clip-path` off at a breakpoint cancels inherited clip-path CSS at that breakpoint.

## What changed
- Added explicit breakpoint reset handling for background color, background gradient, background image, and normal clip-path style generation.
- When a breakpoint has clip-path status set to `false` and an inherited clip-path shape exists, the generated CSS now outputs `clip-path: none`.
- Kept activation behavior unchanged: a stored clip-path shape without an active status does not enable clip-path by itself.
- Added focused unit tests for breakpoint disable/reset behavior and for the stored-shape-without-status guard.

## Why / root cause
Clip-path values can inherit from larger breakpoints, but disabling the toggle at a lower breakpoint did not emit a CSS reset. Because no `clip-path: none` was generated, the larger breakpoint's clip-path remained visible even though the lower breakpoint toggle was off.

## Testing
- `npm test -- src/extensions/styles/helpers/test/getBackgroundStyles.js src/extensions/styles/helpers/test/getClipPathStyles.js --runInBand`
- `git diff --check`
- `npm run build` passed with the existing webpack asset-size warnings.
- Local site availability checked with `curl.exe -I http://localhost/maxi-blocks-local/` and received `200 OK`.

## Manual testing
1. Open a Maxi block with clip path active on a larger breakpoint.
2. Switch to `M`, `S`, or `XS`.
3. Turn `Use clip-path` off.
4. Confirm the shape disappears at that breakpoint.
5. Switch back to the larger breakpoint and confirm the original clip path is still active.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/6266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clip-path style handling and behavior across responsive breakpoints.
  * Clip-path now properly resets when disabled at specific breakpoints instead of inheriting from higher breakpoints.

* **Tests**
  * Added test coverage for clip-path responsiveness and status flag behavior across breakpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->