### PR TITLE
Fix repeater settings sync

### DIFF
--- a/src/components/dialog-box/index.js
+++ b/src/components/dialog-box/index.js
@@ -23,6 +23,7 @@ const DialogBox = props => {
 		cancelLabel,
 		confirmLabel,
 		onConfirm,
+		onCancel,
 		buttonDisabled,
 		buttonClassName,
 		buttonChildren,
@@ -39,6 +40,16 @@ const DialogBox = props => {
 		!getIsSiteEditor()
 			? document.getElementById('editor')
 			: document.getElementById('site-editor');
+
+	const handleCancel = () => {
+		onCancel?.();
+		setIsHidden(true);
+	};
+
+	const handleConfirm = () => {
+		onConfirm?.();
+		setIsHidden(true);
+	};
 
 	return isHidden ? (
 		buttonChildren ? (
@@ -62,15 +73,10 @@ const DialogBox = props => {
 					</div>
 					<div className='maxi-dialog-box-message'>{message}</div>
 					<div className='maxi-dialog-box-buttons'>
-						<Button onClick={() => setIsHidden(true)}>
+						<Button onClick={handleCancel}>
 							{cancelLabel}
 						</Button>
-						<Button
-							onClick={() => {
-								onConfirm();
-								setIsHidden(true);
-							}}
-						>
+						<Button onClick={handleConfirm}>
 							{confirmLabel}
 						</Button>
 					</div>
@@ -78,7 +84,7 @@ const DialogBox = props => {
 						<Button
 							label={__('Close', 'maxi-blocks')}
 							showTooltip
-							onClick={() => setIsHidden(true)}
+							onClick={handleCancel}
 							icon={closeIcon}
 						/>
 					</div>

--- a/src/components/dialog-box/test/index.js
+++ b/src/components/dialog-box/test/index.js
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+/**
+ * Internal dependencies
+ */
+import DialogBox from '../index';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@components/button', () => {
+	const Button = ({ children, icon, label, onClick }) => (
+		<button aria-label={label} type='button' onClick={onClick}>
+			{children || icon || label}
+		</button>
+	);
+
+	return Button;
+});
+
+jest.mock('@components/icon', () => {
+	const Icon = () => null;
+
+	return Icon;
+});
+
+jest.mock('@extensions/fse', () => ({
+	getIsSiteEditor: jest.fn(() => false),
+}));
+
+jest.mock('@maxi-icons', () => ({
+	closeIcon: 'close',
+	dialogIcon: 'dialog',
+}));
+
+describe('DialogBox', () => {
+	let editor;
+	let container;
+	let root;
+
+	beforeEach(() => {
+		editor = document.createElement('div');
+		editor.id = 'editor';
+		document.body.appendChild(editor);
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		document.body.innerHTML = '';
+	});
+
+	const renderDialog = props => {
+		act(() => {
+			root.render(
+				<DialogBox
+					message='Confirm change'
+					cancelLabel='Cancel'
+					confirmLabel='Continue'
+					isHidden={false}
+					setIsHidden={jest.fn()}
+					{...props}
+				/>
+			);
+		});
+	};
+
+	it('calls onCancel when the cancel button is clicked', () => {
+		const onCancel = jest.fn();
+		const setIsHidden = jest.fn();
+
+		renderDialog({ onCancel, setIsHidden });
+
+		act(() => {
+			editor.querySelector('button').click();
+		});
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(setIsHidden).toHaveBeenCalledWith(true);
+	});
+
+	it('calls onCancel when the close button is clicked', () => {
+		const onCancel = jest.fn();
+		const setIsHidden = jest.fn();
+
+		renderDialog({ onCancel, setIsHidden });
+
+		act(() => {
+			editor.querySelector('button[aria-label="Close"]').click();
+		});
+
+		expect(onCancel).toHaveBeenCalledTimes(1);
+		expect(setIsHidden).toHaveBeenCalledWith(true);
+	});
+
+	it('does not call onCancel when confirming', () => {
+		const onCancel = jest.fn();
+		const onConfirm = jest.fn();
+
+		renderDialog({ onCancel, onConfirm });
+
+		act(() => {
+			editor.querySelectorAll('button')[1].click();
+		});
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onCancel).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/repeater/enableRepeater.js
+++ b/src/components/repeater/enableRepeater.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { getAttributeKey } from '@extensions/styles';
+import { validateRowColumnsStructure } from '@extensions/repeater';
+
+const enableRepeater = async ({
+	clientId,
+	updateInnerBlocksPositions,
+	requestStructureConfirmation,
+	markNextChangeAsNotPersistent,
+	onChange,
+}) => {
+	const initialInnerBlocksPositions = updateInnerBlocksPositions();
+
+	const isStructureValidated = await validateRowColumnsStructure(
+		clientId,
+		initialInnerBlocksPositions,
+		requestStructureConfirmation,
+		undefined,
+		true,
+		true
+	);
+
+	if (!isStructureValidated) {
+		return false;
+	}
+
+	// Validation can clone first-column blocks into the other columns, so refresh
+	// the repeater map before later attribute changes try to sync same-position blocks.
+	updateInnerBlocksPositions();
+	markNextChangeAsNotPersistent();
+	onChange({
+		[getAttributeKey('repeater-status')]: true,
+	});
+
+	return true;
+};
+
+export default enableRepeater;

--- a/src/components/repeater/index.js
+++ b/src/components/repeater/index.js
@@ -36,6 +36,13 @@ const Repeater = ({
 	const [isModalHidden, setIsModalHidden] = useState(true);
 	const [resolveConfirmation, setResolveConfirmation] = useState(null);
 
+	const resolveStructureConfirmation = value => {
+		if (resolveConfirmation) {
+			resolveConfirmation(value);
+		}
+		setResolveConfirmation(null);
+	};
+
 	const disallowedBlocks = useSelect(
 		select => {
 			const blockEditor = select('core/block-editor');
@@ -111,12 +118,8 @@ const Repeater = ({
 				confirmLabel={__('Continue', 'maxi-blocks')}
 				isHidden={isModalHidden}
 				setIsHidden={setIsModalHidden}
-				onConfirm={() => {
-					if (resolveConfirmation) {
-						resolveConfirmation(true);
-					}
-					setResolveConfirmation(null);
-				}}
+				onCancel={() => resolveStructureConfirmation(false)}
+				onConfirm={() => resolveStructureConfirmation(true)}
 			/>
 			{isRepeaterInherited && (
 				<InfoBox

--- a/src/components/repeater/index.js
+++ b/src/components/repeater/index.js
@@ -12,10 +12,8 @@ import InfoBox from '@components/info-box';
 import ToggleSwitch from '@components/toggle-switch';
 import DialogBox from '@components/dialog-box';
 import { getAttributeKey, getAttributeValue } from '@extensions/styles';
-import {
-	getDisallowedRepeaterBlocksFromClientId,
-	validateRowColumnsStructure,
-} from '@extensions/repeater';
+import { getDisallowedRepeaterBlocksFromClientId } from '@extensions/repeater';
+import enableRepeater from './enableRepeater';
 
 const DISALLOWED_BLOCK_LABELS = {
 	'maxi-blocks/accordion-maxi': __('Accordion', 'maxi-blocks'),
@@ -78,29 +76,17 @@ const Repeater = ({
 							return;
 						}
 
-						const newInnerBlocksPositions =
-							updateInnerBlocksPositions();
-
-						const isStructureValidated =
-							await validateRowColumnsStructure(
-								clientId,
-								newInnerBlocksPositions,
-								async () =>
-									new Promise(resolve => {
-										setIsModalHidden(false);
-										setResolveConfirmation(() => resolve);
-									}),
-								undefined,
-								true,
-								true
-							);
-
-						if (isStructureValidated) {
-							markNextChangeAsNotPersistent();
-							onChange({
-								[getAttributeKey('repeater-status')]: val,
-							});
-						}
+						await enableRepeater({
+							clientId,
+							updateInnerBlocksPositions,
+							requestStructureConfirmation: async () =>
+								new Promise(resolve => {
+									setIsModalHidden(false);
+									setResolveConfirmation(() => resolve);
+								}),
+							markNextChangeAsNotPersistent,
+							onChange,
+						});
 					}}
 				/>
 			)}

--- a/src/components/repeater/test/enableRepeater.js
+++ b/src/components/repeater/test/enableRepeater.js
@@ -1,0 +1,86 @@
+import enableRepeater from '../enableRepeater';
+import { validateRowColumnsStructure } from '@extensions/repeater';
+
+jest.mock('@extensions/repeater', () => ({
+	validateRowColumnsStructure: jest.fn(),
+}));
+
+jest.mock('@extensions/styles', () => ({
+	getAttributeKey: jest.fn(target => target),
+}));
+
+describe('enableRepeater', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('refreshes inner block positions after validation before enabling repeater', async () => {
+		const initialPositions = {
+			'-1': ['column-1', 'column-2'],
+			0: ['text-1'],
+			1: ['image-1'],
+		};
+		const refreshedPositions = {
+			'-1': ['column-1', 'column-2'],
+			0: ['text-1', 'text-2'],
+			1: ['image-1', 'image-2'],
+		};
+		const updateInnerBlocksPositions = jest
+			.fn()
+			.mockReturnValueOnce(initialPositions)
+			.mockReturnValueOnce(refreshedPositions);
+		const requestStructureConfirmation = jest.fn();
+		const markNextChangeAsNotPersistent = jest.fn();
+		const onChange = jest.fn();
+
+		validateRowColumnsStructure.mockResolvedValue(true);
+
+		const result = await enableRepeater({
+			clientId: 'row',
+			updateInnerBlocksPositions,
+			requestStructureConfirmation,
+			markNextChangeAsNotPersistent,
+			onChange,
+		});
+
+		expect(result).toBe(true);
+		expect(validateRowColumnsStructure).toHaveBeenCalledWith(
+			'row',
+			initialPositions,
+			requestStructureConfirmation,
+			undefined,
+			true,
+			true
+		);
+		expect(updateInnerBlocksPositions).toHaveBeenCalledTimes(2);
+		expect(updateInnerBlocksPositions.mock.invocationCallOrder[1]).toBeLessThan(
+			markNextChangeAsNotPersistent.mock.invocationCallOrder[0]
+		);
+		expect(onChange).toHaveBeenCalledWith({
+			'repeater-status': true,
+		});
+	});
+
+	it('does not refresh positions or enable repeater when validation is rejected', async () => {
+		const updateInnerBlocksPositions = jest
+			.fn()
+			.mockReturnValue({ '-1': ['column-1', 'column-2'] });
+		const markNextChangeAsNotPersistent = jest.fn();
+		const onChange = jest.fn();
+
+		validateRowColumnsStructure.mockResolvedValue(false);
+
+		const result = await enableRepeater({
+			clientId: 'row',
+			updateInnerBlocksPositions,
+			requestStructureConfirmation: jest.fn(),
+			markNextChangeAsNotPersistent,
+			onChange,
+		});
+
+		expect(result).toBe(false);
+		expect(updateInnerBlocksPositions).toHaveBeenCalledTimes(1);
+		expect(markNextChangeAsNotPersistent).not.toHaveBeenCalled();
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/src/extensions/copy-paste/excludeAttributes.js
+++ b/src/extensions/copy-paste/excludeAttributes.js
@@ -45,6 +45,19 @@ const ALL_TIME_EXCLUDE = [
 	'cl-grandchild-accumulator',
 ];
 
+const IMAGE_SIZE_RESPONSE_ATTRIBUTES = ['mediaURL', 'mediaWidth', 'mediaHeight'];
+
+const shouldKeepImageSizeResponseAttribute = (
+	prop,
+	attributesToExclude,
+	isRepeater,
+	blockName
+) =>
+	isRepeater &&
+	blockName === 'maxi-blocks/image-maxi' &&
+	!isNil(attributesToExclude.imageSize) &&
+	IMAGE_SIZE_RESPONSE_ATTRIBUTES.includes(prop);
+
 const shouldDeleteKey = (
 	prop,
 	attributesToExclude,
@@ -63,6 +76,17 @@ const shouldDeleteKey = (
 	}
 
 	if (isDCLinkBlocksException) {
+		return false;
+	}
+
+	if (
+		shouldKeepImageSizeResponseAttribute(
+			prop,
+			attributesToExclude,
+			isRepeater,
+			blockName
+		)
+	) {
 		return false;
 	}
 

--- a/src/extensions/copy-paste/excludeAttributes.js
+++ b/src/extensions/copy-paste/excludeAttributes.js
@@ -47,15 +47,24 @@ const ALL_TIME_EXCLUDE = [
 
 const IMAGE_SIZE_RESPONSE_ATTRIBUTES = ['mediaURL', 'mediaWidth', 'mediaHeight'];
 
+const hasMatchingMediaID = (sourceAttributes, targetAttributes) => {
+	const sourceMediaID = sourceAttributes?.mediaID;
+	const targetMediaID = targetAttributes?.mediaID;
+
+	return (
+		!isNil(sourceMediaID) &&
+		sourceMediaID !== '' &&
+		!isNil(targetMediaID) &&
+		targetMediaID !== '' &&
+		String(sourceMediaID) === String(targetMediaID)
+	);
+};
+
 const shouldKeepImageSizeResponseAttribute = (
 	prop,
-	attributesToExclude,
-	isRepeater,
-	blockName
+	shouldKeepImageSizeResponseAttributes
 ) =>
-	isRepeater &&
-	blockName === 'maxi-blocks/image-maxi' &&
-	!isNil(attributesToExclude.imageSize) &&
+	shouldKeepImageSizeResponseAttributes &&
 	IMAGE_SIZE_RESPONSE_ATTRIBUTES.includes(prop);
 
 const shouldDeleteKey = (
@@ -64,7 +73,8 @@ const shouldDeleteKey = (
 	attributes,
 	isRepeater,
 	blockName,
-	customAllTimeExclude
+	customAllTimeExclude,
+	shouldKeepImageSizeResponseAttributes
 ) => {
 	const isDCLinkBlocksException =
 		!isRepeater &&
@@ -82,9 +92,7 @@ const shouldDeleteKey = (
 	if (
 		shouldKeepImageSizeResponseAttribute(
 			prop,
-			attributesToExclude,
-			isRepeater,
-			blockName
+			shouldKeepImageSizeResponseAttributes
 		)
 	) {
 		return false;
@@ -144,6 +152,11 @@ const excludeAttributes = (
 	customAllTimeExclude = []
 ) => {
 	const attributesToExclude = { ...rawAttributesToExclude };
+	const shouldKeepImageSizeResponseAttributes =
+		isRepeater &&
+		blockName === 'maxi-blocks/image-maxi' &&
+		!isNil(rawAttributesToExclude.imageSize) &&
+		hasMatchingMediaID(rawAttributesToExclude, attributes);
 
 	const keysToExclude = [
 		...(isRepeater ? REPEATER_GLOBAL_EXCLUDE : GLOBAL_EXCLUDE),
@@ -158,7 +171,8 @@ const excludeAttributes = (
 				attributes,
 				isRepeater,
 				blockName,
-				customAllTimeExclude
+				customAllTimeExclude,
+				shouldKeepImageSizeResponseAttributes
 			)
 		) {
 			delete attributesToExclude[prop];

--- a/src/extensions/copy-paste/test/excludeAttributes.js
+++ b/src/extensions/copy-paste/test/excludeAttributes.js
@@ -208,4 +208,71 @@ describe('excludeAttributes', () => {
 			normalAttr: 'keep',
 		});
 	});
+
+	it('Keeps image size response fields for image blocks in repeater mode', () => {
+		const rawAttributesToExclude = {
+			imageSize: 'medium',
+			mediaID: 123,
+			mediaURL: 'medium.jpg',
+			mediaWidth: 300,
+			mediaHeight: 200,
+			mediaAlt: 'Alt text',
+		};
+
+		const attributes = {
+			imageSize: 'full',
+			mediaID: 456,
+			mediaURL: 'full.jpg',
+			mediaWidth: 900,
+			mediaHeight: 600,
+			mediaAlt: 'Existing alt text',
+		};
+
+		const result = excludeAttributes(
+			rawAttributesToExclude,
+			attributes,
+			{
+				_exclude: [
+					'mediaID',
+					'mediaURL',
+					'mediaWidth',
+					'mediaHeight',
+					'mediaAlt',
+				],
+			},
+			true,
+			'maxi-blocks/image-maxi'
+		);
+
+		expect(result).toEqual({
+			imageSize: 'medium',
+			mediaURL: 'medium.jpg',
+			mediaWidth: 300,
+			mediaHeight: 200,
+		});
+	});
+
+	it('Still excludes image media fields in repeater mode when image size is unchanged', () => {
+		const rawAttributesToExclude = {
+			mediaURL: 'replacement.jpg',
+			mediaWidth: 300,
+			mediaHeight: 200,
+		};
+
+		const result = excludeAttributes(
+			rawAttributesToExclude,
+			{
+				mediaURL: 'existing.jpg',
+				mediaWidth: 900,
+				mediaHeight: 600,
+			},
+			{
+				_exclude: ['mediaURL', 'mediaWidth', 'mediaHeight'],
+			},
+			true,
+			'maxi-blocks/image-maxi'
+		);
+
+		expect(result).toEqual({});
+	});
 });

--- a/src/extensions/copy-paste/test/excludeAttributes.js
+++ b/src/extensions/copy-paste/test/excludeAttributes.js
@@ -209,7 +209,7 @@ describe('excludeAttributes', () => {
 		});
 	});
 
-	it('Keeps image size response fields for image blocks in repeater mode', () => {
+	it('Keeps image size response fields for matching image blocks in repeater mode', () => {
 		const rawAttributesToExclude = {
 			imageSize: 'medium',
 			mediaID: 123,
@@ -221,7 +221,7 @@ describe('excludeAttributes', () => {
 
 		const attributes = {
 			imageSize: 'full',
-			mediaID: 456,
+			mediaID: 123,
 			mediaURL: 'full.jpg',
 			mediaWidth: 900,
 			mediaHeight: 600,
@@ -249,6 +249,43 @@ describe('excludeAttributes', () => {
 			mediaURL: 'medium.jpg',
 			mediaWidth: 300,
 			mediaHeight: 200,
+		});
+	});
+
+	it('Does not copy image size response fields to repeater images with different media IDs', () => {
+		const rawAttributesToExclude = {
+			imageSize: 'medium',
+			mediaID: 123,
+			mediaURL: 'source-medium.jpg',
+			mediaWidth: 300,
+			mediaHeight: 200,
+		};
+
+		const attributes = {
+			imageSize: 'full',
+			mediaID: 456,
+			mediaURL: 'target-full.jpg',
+			mediaWidth: 900,
+			mediaHeight: 600,
+		};
+
+		const result = excludeAttributes(
+			rawAttributesToExclude,
+			attributes,
+			{
+				_exclude: [
+					'mediaID',
+					'mediaURL',
+					'mediaWidth',
+					'mediaHeight',
+				],
+			},
+			true,
+			'maxi-blocks/image-maxi'
+		);
+
+		expect(result).toEqual({
+			imageSize: 'medium',
 		});
 	});
 

--- a/src/extensions/maxi-block/handleSetAttributes.js
+++ b/src/extensions/maxi-block/handleSetAttributes.js
@@ -29,10 +29,15 @@ const handleSetAttributes = ({
 	isStyleCard = false,
 	onChangeInline,
 	cleanInlineStyles,
+	updateAttributesOnInlineChange = false,
 }) => {
 	if (meta?.inline) {
 		if (onChangeInline) {
-			return onChangeInline(obj, meta.inline);
+			const inlineResponse = onChangeInline(obj, meta.inline);
+
+			if (!updateAttributesOnInlineChange) {
+				return inlineResponse;
+			}
 		}
 	} else if (cleanInlineStyles) {
 		cleanInlineStyles(obj);

--- a/src/extensions/maxi-block/test/handleSetAttributes.js
+++ b/src/extensions/maxi-block/test/handleSetAttributes.js
@@ -88,6 +88,62 @@ jest.mock('@wordpress/data', () => {
 describe('handleSetAttributes', () => {
 	const onChange = result => result;
 
+	it('continues to attribute updates for repeater inline dimension changes when requested', () => {
+		const onChangeInline = jest.fn();
+		const onChangeWithInline = jest.fn(result => result);
+
+		handleSetAttributes({
+			obj: {
+				'object-size-general': 2,
+				meta: {
+					inline: {},
+				},
+			},
+			attributes: {},
+			onChange: onChangeWithInline,
+			onChangeInline,
+			updateAttributesOnInlineChange: true,
+		});
+
+		expect(onChangeInline).toHaveBeenCalledWith(
+			{
+				'object-size-general': 2,
+			},
+			{}
+		);
+		expect(onChangeWithInline).toHaveBeenCalledWith(
+			expect.objectContaining({
+				'object-size-general': 2,
+			})
+		);
+	});
+
+	it('keeps inline changes inline-only by default', () => {
+		const onChangeInline = jest.fn(() => 'inline-only');
+		const onChangeWithInline = jest.fn(result => result);
+
+		const result = handleSetAttributes({
+			obj: {
+				'object-size-general': 2,
+				meta: {
+					inline: {},
+				},
+			},
+			attributes: {},
+			onChange: onChangeWithInline,
+			onChangeInline,
+		});
+
+		expect(result).toBe('inline-only');
+		expect(onChangeInline).toHaveBeenCalledWith(
+			{
+				'object-size-general': 2,
+			},
+			{}
+		);
+		expect(onChangeWithInline).not.toHaveBeenCalled();
+	});
+
 	it('On change number attributes from XXL responsive without General attribute, it changes on XXL and General all time', () => {
 		const firstRound = {
 			obj: {

--- a/src/extensions/maxi-block/withMaxiProps.js
+++ b/src/extensions/maxi-block/withMaxiProps.js
@@ -291,6 +291,8 @@ const withMaxiProps = createHigherOrderComponent(
 								}
 							);
 						},
+						updateAttributesOnInlineChange:
+							!!repeaterContext?.repeaterStatus,
 						onChange: newAttributes => {
 							// Ensure that blockStyle is preserved in all cases where it's not explicitly changed
 							if (


### PR DESCRIPTION
## Summary

Fixes repeater settings not syncing across repeated columns for image dimension changes and inline style-backed controls such as text typography.

## What changed

- Refreshes repeater inner block positions again after row/column structure validation, so newly standardized columns are mapped before repeater mode is enabled.
- Lets inline-style-backed changes continue through attribute propagation while repeater mode is active, so matching repeated blocks receive the same setting update.
- Keeps image size response fields (`mediaURL`, `mediaWidth`, `mediaHeight`) when an image block Image Size change is propagated in repeater mode, while still excluding direct media replacement fields such as `mediaID` and `mediaAlt`.
- Adds focused unit coverage for repeater position refresh, inline attribute propagation in repeater mode, and image size copy/paste filtering behavior.

## Why / root cause

The issue had multiple related causes:

1. Repeater enablement captured inner block positions before column structure validation finished, so some repeated blocks could be missing from the active repeater map until repeater was toggled off and on again.
2. Inline-style-backed controls updated the selected block visually but did not continue into attribute propagation, so repeated blocks did not receive those setting changes.
3. Image Size changes emit `imageSize` plus derived media fields needed to render the selected size. The repeater copy/paste exclusion layer stripped those derived fields, leaving repeated image blocks with only `imageSize` and no updated rendered media dimensions.

## Testing

Automated checks run locally:

- `npm test -- src/extensions/copy-paste/test/excludeAttributes.js src/extensions/maxi-block/test/handleSetAttributes.js src/components/repeater/test/enableRepeater.js src/extensions/repeater/test/validateRowColumnsStructure.js src/extensions/repeater/test/disallowedBlocks.js --runInBand`
- `git diff --check`
- `npm run build`

Build completed successfully with existing webpack asset-size warnings.

Manual test steps:

1. Open the local WordPress editor with the Maxi Blocks plugin active.
2. Create a row with text and image blocks in the first column.
3. Enable repeater on the row.
4. Change Image block `Dimension > Image size` in the first repeated column.
5. Confirm the matching image blocks in the other repeated columns update too, not only the first column.
6. Change a text typography setting in the first repeated column.
7. Confirm the matching text blocks in the other repeated columns update too.
8. Toggle repeater off and on again and confirm the repeated blocks remain in sync.

## Closing issue link

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved repeater enable flow with validation and user confirmation
  * Copy-paste refinement for repeater image blocks to preserve image-size details when appropriate
  * Dialog confirmation UI now centralizes cancel/confirm handling and exposes cancel callbacks
  * Inline-attribute update option to control whether inline edits propagate when repeater is active

* **Tests**
  * Added tests covering repeater enablement, copy-paste image exclusion, inline attribute behavior, and dialog interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->