### PR TITLE
Fix hidden state for empty DC SVG groups

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -3379,6 +3379,13 @@ class MaxiBlocks_DynamicContent
                         $content_sanitized,
                     );
 
+                    // SVG icon blocks are decorative companions to DC text in some patterns.
+                    $content_sanitized = preg_replace(
+                        '/<div[^>]*class="[^"]*maxi-svg-icon-block__icon[^"]*"[^>]*>.*?<\/div>/s',
+                        '',
+                        $content_sanitized,
+                    );
+
                     $allowed_tags = '<svg><img><iframe><hr>';
                     $text_content = strip_tags(
                         $content_sanitized ?? '',

--- a/src/extensions/DC/test/renderDCClasses.js
+++ b/src/extensions/DC/test/renderDCClasses.js
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+const normalizePhpPath = filePath => filePath.replace(/\\/g, '/');
+
+const phpCandidates = [
+	process.env.PHP_BINARY,
+	'C:/wamp/bin/php/php8.4.15/php.exe',
+	'C:/wamp/bin/php/php8.3.28/php.exe',
+	'C:/wamp/bin/php/php8.2.29/php.exe',
+	'php',
+].filter(Boolean);
+
+const getPhpBinary = () =>
+	phpCandidates.find(candidate => {
+		const result = spawnSync(candidate, ['-v'], { encoding: 'utf8' });
+		return result.status === 0;
+	});
+
+const phpBinary = getPhpBinary();
+const maybeIt = phpBinary ? it : it.skip;
+
+const makeFakeWordPressRoot = () => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'maxi-wp-'));
+	const includesPath = path.join(root, 'wp-admin', 'includes');
+
+	fs.mkdirSync(includesPath, { recursive: true });
+
+	['file.php', 'media.php', 'image.php'].forEach(fileName => {
+		fs.writeFileSync(path.join(includesPath, fileName), '<?php\n');
+	});
+
+	return root;
+};
+
+const runRenderClasses = content => {
+	if (!phpBinary) {
+		throw new Error('PHP binary was not found for dynamic content renderer test.');
+	}
+
+	const wpRoot = makeFakeWordPressRoot();
+	const phpCode = `
+if (!defined('ABSPATH')) define('ABSPATH', '${normalizePhpPath(wpRoot)}/');
+if (!defined('MAXI_PLUGIN_DIR_PATH')) define('MAXI_PLUGIN_DIR_PATH', '${normalizePhpPath(repoRoot)}/');
+if (!defined('DAY_IN_SECONDS')) define('DAY_IN_SECONDS', 86400);
+if (!function_exists('__')) { function __($text, $domain = null) { return $text; } }
+if (!function_exists('get_transient')) { function get_transient($key) { return 1; } }
+if (!function_exists('set_transient')) { function set_transient($key, $value, $expiration = 0) { return true; } }
+if (!function_exists('plugin_dir_path')) {
+	function plugin_dir_path($file) {
+		return rtrim(dirname($file), '/\\\\') . DIRECTORY_SEPARATOR;
+	}
+}
+require_once MAXI_PLUGIN_DIR_PATH . 'core/class-maxi-dynamic-content.php';
+$renderer = new MaxiBlocks_DynamicContent();
+$attributes = [
+	'uniqueID' => 'group-maxi-render-test-u',
+	'dc-hide' => true,
+];
+$content = <<<'HTML'
+${content}
+HTML;
+echo $renderer->render_dc_classes($attributes, $content);
+`;
+
+	const result = spawnSync(phpBinary, ['-d', 'display_errors=1', '-r', phpCode], {
+		cwd: repoRoot,
+		encoding: 'utf8',
+		maxBuffer: 1024 * 1024 * 4,
+	});
+
+	fs.rmSync(wpRoot, { recursive: true, force: true });
+
+	if (result.status !== 0) {
+		throw new Error(result.stderr || result.stdout);
+	}
+
+	return result.stdout;
+};
+
+describe('MaxiBlocks_DynamicContent render_dc_classes', () => {
+	maybeIt('hides a group when only no-content dynamic text and a Maxi SVG icon remain', () => {
+		const result = runRenderClasses(`
+<div class="wp-block-maxi-blocks-group-maxi maxi-block maxi-group-block" id="group-maxi-render-test-u">
+	<div class="wp-block-maxi-blocks-svg-icon-maxi maxi-block maxi-svg-icon-block" id="svg-icon-maxi-render-test-u">
+		<div class="maxi-svg-icon-block__icon">
+			<svg viewBox="0 0 36 36"><path d="M1 1h10v10z"></path></svg>
+		</div>
+	</div>
+	<div class="wp-block-maxi-blocks-text-maxi maxi-block maxi-text-block" id="text-maxi-render-test-u">
+		<p class="maxi-text-block__content">No content found</p>
+	</div>
+</div>`);
+
+		expect(result).toContain(
+			'class="maxi-block--hidden wp-block-maxi-blocks-group-maxi maxi-block maxi-group-block"'
+		);
+		expect(result).toContain(
+			'class="maxi-block--hidden wp-block-maxi-blocks-svg-icon-maxi maxi-block maxi-svg-icon-block"'
+		);
+	});
+
+	maybeIt('keeps a group visible when it still has meaningful text content', () => {
+		const result = runRenderClasses(`
+<div class="wp-block-maxi-blocks-group-maxi maxi-block maxi-group-block" id="group-maxi-render-test-u">
+	<div class="wp-block-maxi-blocks-svg-icon-maxi maxi-block maxi-svg-icon-block" id="svg-icon-maxi-render-test-u">
+		<div class="maxi-svg-icon-block__icon">
+			<svg viewBox="0 0 36 36"><path d="M1 1h10v10z"></path></svg>
+		</div>
+	</div>
+	<div class="wp-block-maxi-blocks-text-maxi maxi-block maxi-text-block" id="text-maxi-render-test-u">
+		<p class="maxi-text-block__content">Featured story</p>
+	</div>
+</div>`);
+
+		expect(result).not.toContain('maxi-block--hidden');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the dynamic-content hidden-state check for groups that contain an empty DC text block alongside a Maxi SVG icon block.

## What changed

- Updated the dynamic-content emptiness check to ignore rendered Maxi SVG icon payloads when deciding whether a group/row/column/container should be hidden.
- Added a PHP-backed Jest regression test for the exact SVG + `No content found` group case.
- Added a positive regression case to confirm meaningful text content still keeps the group visible.

## Why / root cause

When a DC text block resolved to `No content found`, parent block hiding depended on checking whether the rendered group content was effectively empty. SVG icon block markup was still counted during that check, so a group containing only the empty DC text state plus a decorative SVG icon appeared non-empty and did not receive `maxi-block--hidden`.

The fix removes the rendered Maxi SVG icon payload from the emptiness check only. It does not remove the icon from real output when the group has meaningful content.

## Testing

- `git diff master...HEAD --check`
- `C:\wamp\bin\php\php8.4.15\php.exe -l core\class-maxi-dynamic-content.php`
- `npm test -- src/extensions/DC/test/renderDCClasses.js --runInBand`
- `npm test -- src/extensions/DC/test --runInBand`
- `npm run build`
- Confirmed WAMP plugin junction points to `C:\Users\kyra\maxi-blocks`
- Confirmed `http://localhost/maxi-blocks-local/` returns HTTP 200 and loads in browser without fatal/parse error text

Manual test steps:

1. Open `http://localhost/maxi-blocks-local/wp-admin/`.
2. Create or open the issue repro page using PBGL-PRO-03.
3. Configure the post query so posts have no matching tag.
4. View the frontend page.
5. Confirm the grouped DC text plus SVG block is hidden when the DC text resolves to `No content found`.
6. Change the setup so meaningful text is present.
7. Confirm the group remains visible.

## Closing issue link

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty content detection to properly handle SVG icon blocks, preventing false "empty" status when only decorative icons are present.

* **Tests**
  * Added comprehensive test suite for content rendering to ensure correct visibility behavior with dynamic content and icon elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->