### PR TITLE
Fix list migration in repeater rows

### DIFF
--- a/e2e-tests/components/dynamic-content/component.spec.js
+++ b/e2e-tests/components/dynamic-content/component.spec.js
@@ -13,6 +13,21 @@ const getDCContent = async page => {
 	);
 };
 
+const waitForDCContent = async page => {
+	const selector = '.maxi-text-block .maxi-text-block__content';
+	const frame = await getEditorFrame(page);
+	await frame.waitForFunction(
+		selector => {
+			const content = document.querySelector(selector)?.textContent.trim();
+			return content && content !== 'No content found';
+		},
+		{ timeout: 10000 },
+		selector
+	);
+
+	return getDCContent(page);
+};
+
 const getDCImageContent = async page => {
 	const frame = await getEditorFrame(page);
 	return frame.$eval(
@@ -129,7 +144,7 @@ describe('Dynamic content component for text blocks', () => {
 		await selectField.select('title');
 
 		// Will show the latest post (likely "Test Post for DC" from post test)
-		const content = await getDCContent(page);
+		const content = await waitForDCContent(page);
 		expect(content).toBeTruthy();
 		expect(content).not.toBe('No content found');
 

--- a/src/extensions/repeater/test/validateRowColumnsStructure.js
+++ b/src/extensions/repeater/test/validateRowColumnsStructure.js
@@ -68,6 +68,21 @@ jest.mock('../updateRelationsInColumn', () => jest.fn());
 
 const { select: mockSelect, dispatch: mockDispatch } =
 	jest.requireMock('@wordpress/data');
+const { goThroughMaxiBlocks } = jest.requireMock('@extensions/maxi-block');
+
+const createBlock = (clientId, name, innerBlocks = []) => ({
+	clientId,
+	name,
+	attributes: {},
+	innerBlocks,
+});
+
+const traverseBlocks = (callback, blocks = []) => {
+	blocks.forEach(block => {
+		callback(block);
+		traverseBlocks(callback, block.innerBlocks);
+	});
+};
 
 describe('validateRowColumnsStructure', () => {
 	beforeEach(() => {
@@ -90,6 +105,9 @@ describe('validateRowColumnsStructure', () => {
 		});
 
 		getDisallowedRepeaterBlocksFromClientId.mockReturnValue([]);
+		goThroughMaxiBlocks.mockImplementation((callback, _deep, blocks) =>
+			traverseBlocks(callback, blocks)
+		);
 	});
 
 	describe('rejectDisallowedBlocks flag', () => {
@@ -152,6 +170,71 @@ describe('validateRowColumnsStructure', () => {
 			const result = await validateRowColumnsStructure('row', null, null);
 
 			expect(result).toBe(true);
+		});
+	});
+
+	describe('structure confirmation', () => {
+		it('asks for confirmation once when multiple columns differ from the reference column', async () => {
+			const referenceText = createBlock(
+				'text-1',
+				'maxi-blocks/text-maxi'
+			);
+			const extraText = createBlock('text-2', 'maxi-blocks/text-maxi');
+			const extraButton = createBlock(
+				'button-1',
+				'maxi-blocks/button-maxi'
+			);
+			const referenceColumn = createBlock(
+				'col-1',
+				'maxi-blocks/column-maxi',
+				[referenceText]
+			);
+			const mismatchColumnOne = createBlock(
+				'col-2',
+				'maxi-blocks/column-maxi',
+				[referenceText, extraText]
+			);
+			const mismatchColumnTwo = createBlock(
+				'col-3',
+				'maxi-blocks/column-maxi',
+				[referenceText, extraText, extraButton]
+			);
+			const rowWithMismatchedColumns = {
+				...rowBlock,
+				innerBlocks: [
+					referenceColumn,
+					mismatchColumnOne,
+					mismatchColumnTwo,
+				],
+			};
+			const blocksByClientId = {
+				row: rowWithMismatchedColumns,
+				'col-1': referenceColumn,
+				'col-2': mismatchColumnOne,
+				'col-3': mismatchColumnTwo,
+			};
+			const confirmDifferentStructure = jest.fn(async () => true);
+
+			mockSelect.mockReturnValue({
+				getBlock: jest.fn(id => blocksByClientId[id] || null),
+				getBlocks: jest.fn(id =>
+					id === 'row' ? rowWithMismatchedColumns.innerBlocks : []
+				),
+				getBlockOrder: jest.fn(() => []),
+				getBlockName: jest.fn(() => 'maxi-blocks/column-maxi'),
+				getBlockAttributes: jest.fn(() => ({})),
+				getBlockParents: jest.fn(() => []),
+				getBlockParentsByBlockName: jest.fn(() => []),
+			});
+
+			const result = await validateRowColumnsStructure(
+				'row',
+				null,
+				confirmDifferentStructure
+			);
+
+			expect(result).toBe(true);
+			expect(confirmDifferentStructure).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/extensions/repeater/validateRowColumnsStructure.js
+++ b/src/extensions/repeater/validateRowColumnsStructure.js
@@ -216,9 +216,11 @@ const validateRowColumnsStructure = async (
 
 	let proceedTransformingColumns = null;
 
-	await goThroughColumns(childColumns, null, async column => {
+	for (let i = 0; i < childColumns.length; i++) {
+		const column = childColumns[i];
+
 		if (proceedTransformingColumns === false) {
-			return;
+			break;
 		}
 
 		// we can't just compare inner blocks, because if they different attributes - it's ok
@@ -238,7 +240,7 @@ const validateRowColumnsStructure = async (
 		);
 
 		if (isColumnToValidateBy) {
-			return;
+			continue;
 		}
 
 		if (
@@ -253,7 +255,7 @@ const validateRowColumnsStructure = async (
 				!differentColumnsStructureCallback ||
 				(await differentColumnsStructureCallback());
 		}
-	});
+	}
 
 	if (proceedTransformingColumns === false) {
 		return false;

--- a/src/extensions/styles/migrators/listItemMigrator.js
+++ b/src/extensions/styles/migrators/listItemMigrator.js
@@ -8,6 +8,8 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { getMaxiBlockAttributes, MaxiBlock } from '@components/maxi-block';
+import uniqueIDGenerator from '@extensions/attributes/uniqueIDGenerator';
+import getCustomLabel from '@extensions/maxi-block/getCustomLabel';
 
 /**
  * External dependencies
@@ -40,8 +42,12 @@ const migrate = newAttributes => {
 	// Use traditional for loop for better performance
 	for (let i = 0; i < matches.length; i++) {
 		const liContent = matches[i].replace(LI_CLEAN_REGEX, '');
+		const uniqueID = uniqueIDGenerator({ blockName: LIST_ITEM_BLOCK });
+
 		newInnerBlocks[i] = createBlock(LIST_ITEM_BLOCK, {
 			content: liContent,
+			customLabel: getCustomLabel('', uniqueID),
+			uniqueID,
 		});
 	}
 

--- a/src/extensions/styles/migrators/test/listItemMigrator.js
+++ b/src/extensions/styles/migrators/test/listItemMigrator.js
@@ -1,0 +1,89 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import listItemMigrator from '../listItemMigrator';
+import uniqueIDGenerator from '@extensions/attributes/uniqueIDGenerator';
+import getCustomLabel from '@extensions/maxi-block/getCustomLabel';
+
+jest.mock('@wordpress/blocks', () => ({
+	createBlock: jest.fn((name, attributes) => ({
+		name,
+		attributes,
+		innerBlocks: [],
+	})),
+}));
+
+jest.mock('@wordpress/block-editor', () => ({
+	RichText: {
+		Content: jest.fn(() => null),
+	},
+}));
+
+jest.mock('@components/maxi-block', () => ({
+	getMaxiBlockAttributes: jest.fn(() => ({})),
+	MaxiBlock: {
+		save: jest.fn(({ children }) => children),
+	},
+}));
+
+let mockGeneratedIdCount = 0;
+
+jest.mock('@extensions/attributes/uniqueIDGenerator', () =>
+	jest.fn(({ blockName }) => {
+		mockGeneratedIdCount += 1;
+		return `${blockName.replace('maxi-blocks/', '')}-${mockGeneratedIdCount}-u`;
+	})
+);
+
+jest.mock('@extensions/maxi-block/getCustomLabel', () =>
+	jest.fn((previousCustomLabel, uniqueID) =>
+		previousCustomLabel || `List-item_${uniqueID}`
+	)
+);
+
+describe('listItemMigrator', () => {
+	beforeEach(() => {
+		mockGeneratedIdCount = 0;
+		jest.clearAllMocks();
+	});
+
+	it('adds Maxi identity attributes to migrated list item blocks', () => {
+		const attributes = {
+			isList: true,
+			content:
+				'<li>Lorem ipsum dolor</li><br><li><span>Integer vitae</span></li>',
+		};
+
+		const [, innerBlocks] = listItemMigrator.migrate(attributes);
+
+		expect(innerBlocks).toHaveLength(2);
+		expect(uniqueIDGenerator).toHaveBeenCalledTimes(2);
+		expect(uniqueIDGenerator).toHaveBeenNthCalledWith(1, {
+			blockName: 'maxi-blocks/list-item-maxi',
+		});
+		expect(getCustomLabel).toHaveBeenCalledTimes(2);
+		expect(createBlock).toHaveBeenNthCalledWith(
+			1,
+			'maxi-blocks/list-item-maxi',
+			{
+				content: 'Lorem ipsum dolor',
+				customLabel: 'List-item_list-item-maxi-1-u',
+				uniqueID: 'list-item-maxi-1-u',
+			}
+		);
+		expect(createBlock).toHaveBeenNthCalledWith(
+			2,
+			'maxi-blocks/list-item-maxi',
+			{
+				content: '<span>Integer vitae</span>',
+				customLabel: 'List-item_list-item-maxi-2-u',
+				uniqueID: 'list-item-maxi-2-u',
+			}
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the migrated list + repeater regression from issue 5535.

## What changed

- Gives migrated list-item-maxi blocks their own Maxi uniqueID and customLabel when legacy Text Maxi list content is converted into inner list-item blocks.
- Changes repeater structure validation to check mismatched columns sequentially instead of in parallel.
- Adds focused unit coverage for migrated list-item identity attributes and for the repeater confirmation flow with multiple mismatched columns.

## Why / root cause

Legacy list migration created nested list-item-maxi blocks without Maxi identity attributes. Inside repeater rows, those blocks could be treated like newly inserted blocks and then mirrored into sibling columns.

Manual testing also showed repeater enabling could stall when more than one column differed from the reference column. The validation loop requested the standardize-columns confirmation for multiple columns in parallel, leaving one confirmation promise unresolved and preventing the repeater status from being applied.

## Testing

- git diff --check
- 
pm test -- listItemMigrator --runInBand
- 
pm test -- repeater --runInBand
- 
pm run build passed with the existing webpack asset-size warnings.

Manual WAMP check performed by Kyra: the repeater now switches on after confirming the structure modal.

## How to test

1. Open a page containing the old pricing/list layout from the issue in the editor.
2. Select the affected row and open the Repeater panel.
3. Turn on repeater.
4. If the standardize-columns modal appears, click Continue.
5. Confirm the repeater toggle stays enabled.
6. Save and reload the editor.
7. Confirm migrated list items are not duplicated by the migration path and the repeater remains usable.
8. Check the frontend for the pricing/list layout and confirm the visible list content remains correct.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved dynamic content testing with enhanced wait helpers for stable assertions
  * Added comprehensive test coverage for list item migration functionality
  * Enhanced test suite for column structure validation

* **Bug Fixes**
  * Refactored column structure validation logic for improved control flow
  * Enhanced list item processing with unique identification and custom labeling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->