### PR TITLE
Fix a random border crash on Landscaping LSCP-PRO-03

### DIFF
--- a/core/blocks/style-helpers/get_transition_styles.php
+++ b/core/blocks/style-helpers/get_transition_styles.php
@@ -23,6 +23,10 @@ function get_transition_styles($props, $transition_obj)
 
     foreach ($transition_obj as $type => $obj) {
         foreach ($obj as $key => $value) {
+            if (!isset($transition[$type][$key])) {
+                continue;
+            }
+
             $raw_hover_prop = $value['hoverProp'] ?? false;
             $is_transform = $value['isTransform'] ?? false;
             $hover_prop = !$raw_hover_prop || is_array($raw_hover_prop)

--- a/src/extensions/styles/helpers/getTransitionStyles.js
+++ b/src/extensions/styles/helpers/getTransitionStyles.js
@@ -28,6 +28,8 @@ const getTransitionStyles = (props, transitionObj = transitionDefault) => {
 
 	Object.entries(transitionObj).forEach(([type, obj]) => {
 		Object.entries(obj).forEach(([key, value]) => {
+			if (!transition[type]?.[key]) return;
+
 			const { hoverProp: rawHoverProp, isTransform = false } = value;
 			const hoverProp =
 				!rawHoverProp || isArray(rawHoverProp)


### PR DESCRIPTION
# Description

Fixes a border crash for Story Mix Light SML-PRO-162 on Landscaping LSCP-PRO-03. Guard from the same kind of crashes in general.

When a row (or any block) was created or saved with an older plugin version (before 2.1.9), its transition attribute may not contain all the types/keys that the current transitionObj defines. Accessing transition[type] returns undefined, and then [key] (e.g. ['border']) throws the TypeError.

# How Has This Been Tested?

Load Landscaping LSCP-PRO-03


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed potential errors during transition style processing when certain style properties are missing, improving stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->