### PR TITLE
Issue 6322: Fix duplicated blocks removal on wp 6.9.4

### DIFF
--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -844,6 +844,30 @@ class MaxiBlockComponent extends Component {
 			this.popoverStyles = null;
 		}
 
+		const keepStylesOnEditor = !!select('core/block-editor').getBlock(
+			this.props.clientId
+		);
+
+		// Check both the parent document AND the iframe document for cloned elements.
+		// Blocks render inside iframe[name="editor-canvas"], so bare `document`
+		// (parent frame) won't find them.
+		let keepStylesOnCloning =
+			Array.from(document.getElementsByClassName(uniqueID)).length > 1;
+		if (!keepStylesOnCloning) {
+			try {
+				if (this.editorIframe?.contentDocument) {
+					keepStylesOnCloning =
+						Array.from(
+							this.editorIframe.contentDocument.getElementsByClassName(
+								uniqueID
+							)
+						).length > 1;
+				}
+			} catch (e) {
+				// Cross-origin or disconnected iframe — ignore
+			}
+		}
+
 		// Clear DOM references
 		this.rootSlot = null;
 		this.editorIframe = null;
@@ -857,33 +881,6 @@ class MaxiBlockComponent extends Component {
 		}
 		if (this.areFontsLoaded) {
 			this.areFontsLoaded.current = false;
-		}
-
-		const keepStylesOnEditor = !!select('core/block-editor').getBlock(
-			this.props.clientId
-		);
-
-		// Check both the parent document AND the iframe document for cloned elements.
-		// Blocks render inside iframe[name="editor-canvas"], so bare `document`
-		// (parent frame) won't find them.
-		let keepStylesOnCloning =
-			Array.from(document.getElementsByClassName(uniqueID)).length > 1;
-		if (!keepStylesOnCloning) {
-			try {
-				const editorIframe = document.querySelector(
-					'iframe[name="editor-canvas"]'
-				);
-				if (editorIframe?.contentDocument) {
-					keepStylesOnCloning =
-						Array.from(
-							editorIframe.contentDocument.getElementsByClassName(
-								uniqueID
-							)
-						).length > 1;
-				}
-			} catch (e) {
-				// Cross-origin or disconnected iframe — ignore
-			}
 		}
 
 		// Fallback: verify the block is truly gone by checking if its clientId

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -862,15 +862,68 @@ class MaxiBlockComponent extends Component {
 		const keepStylesOnEditor = !!select('core/block-editor').getBlock(
 			this.props.clientId
 		);
-		const keepStylesOnCloning =
+
+		// Check both the parent document AND the iframe document for cloned elements.
+		// Blocks render inside iframe[name="editor-canvas"], so bare `document`
+		// (parent frame) won't find them.
+		let keepStylesOnCloning =
 			Array.from(document.getElementsByClassName(uniqueID)).length > 1;
-		const isBlockBeingRemoved = !keepStylesOnEditor && !keepStylesOnCloning;
+		if (!keepStylesOnCloning) {
+			try {
+				const editorIframe = document.querySelector(
+					'iframe[name="editor-canvas"]'
+				);
+				if (editorIframe?.contentDocument) {
+					keepStylesOnCloning =
+						Array.from(
+							editorIframe.contentDocument.getElementsByClassName(
+								uniqueID
+							)
+						).length > 1;
+				}
+			} catch (e) {
+				// Cross-origin or disconnected iframe — ignore
+			}
+		}
+
+		// Fallback: verify the block is truly gone by checking if its clientId
+		// is still listed among descendants. This guards against transient
+		// block-tree inconsistencies in WP 6.9.x where getBlock() can briefly
+		// return null during reconciliation after a sibling removal.
+		let keepStylesOnStorePresence = false;
+		if (!keepStylesOnEditor && !keepStylesOnCloning) {
+			try {
+				const allClientIds =
+					select(
+						'core/block-editor'
+					).getClientIdsWithDescendants();
+				keepStylesOnStorePresence = allClientIds.includes(
+					this.props.clientId
+				);
+			} catch (e) {
+				// Selector unavailable — skip
+			}
+		}
+
+		const isBlockBeingRemoved =
+			!keepStylesOnEditor &&
+			!keepStylesOnCloning &&
+			!keepStylesOnStorePresence;
 
 		if (isBlockBeingRemoved) {
 			const { clientId } = this.props;
 
 			// Use a single rAF for all style operations
 			const batchStyleOperations = () => {
+				// Double-check: the block might have been re-added (reconciliation)
+				// between unmount and this rAF callback firing
+				const stillGone = !select('core/block-editor').getBlock(
+					clientId
+				);
+				if (!stillGone) {
+					return;
+				}
+
 				const obj = this.getStylesObject;
 
 				// Batch all style removals into a single operation


### PR DESCRIPTION
# Description

Adds guards to prevent original styles removal when removing duplicated blocks on the older WP.

Fixes #6322



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block removal and style cleanup to prevent leftover or flickering styles across different editor contexts. Added additional presence checks and timing safeguards to ensure styles are removed only when a block is truly gone, reducing visual glitches during complex removals and edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxi-blocks/maxi-blocks/pull/6324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->