### PR TITLE
Fix old svg breaking after added a link to canvas

### DIFF
--- a/src/blocks/svg-icon-maxi/save.js
+++ b/src/blocks/svg-icon-maxi/save.js
@@ -64,32 +64,52 @@ const save = props => {
 		attributes.altDescription,
 		attributes.uniqueID
 	);
-	const shouldWrapCanvas = linkSettings?.linkElement === 'canvas';
-	const shouldWrapIcon =
-		!shouldWrapCanvas && getHasLink(linkSettings, dynamicContent);
+	const hasLink = getHasLink(linkSettings, dynamicContent);
 
-	return (
+	// 'svg' = link wraps just the icon (internal <a> inside the block)
+	// 'canvas' or undefined = link wraps the whole block (external <a>)
+	const wrapIcon =
+		linkSettings?.linkElement === 'svg' && hasLink;
+	const wrapCanvas =
+		!wrapIcon && hasLink;
+
+	const icon = wrapIcon ? (
+		<div className='maxi-svg-icon-block__icon-wrapper'>
+			<WithLink
+				linkSettings={linkSettings ?? {}}
+				dynamicContent={dynamicContent}
+				className='maxi-svg-icon-block__icon'
+			>
+				<RawHTML>{iconContent}</RawHTML>
+			</WithLink>
+		</div>
+	) : (
+		<RawHTML className='maxi-svg-icon-block__icon'>
+			{iconContent}
+		</RawHTML>
+	);
+
+	const block = (
 		<MaxiBlock.save
 			{...getMaxiBlockAttributes({ ...props, name })}
 			aria-label={attributes.ariaLabels?.canvas}
 		>
-			{shouldWrapIcon ? (
-				<div className='maxi-svg-icon-block__icon-wrapper'>
-					<WithLink
-						linkSettings={linkSettings ?? {}}
-						dynamicContent={dynamicContent}
-						className='maxi-svg-icon-block__icon'
-					>
-						<RawHTML>{iconContent}</RawHTML>
-					</WithLink>
-				</div>
-			) : (
-				<RawHTML className='maxi-svg-icon-block__icon'>
-					{iconContent}
-				</RawHTML>
-			)}
+			{icon}
 		</MaxiBlock.save>
 	);
+
+	if (wrapCanvas) {
+		return (
+			<WithLink
+				linkSettings={linkSettings ?? {}}
+				dynamicContent={dynamicContent}
+			>
+				{block}
+			</WithLink>
+		);
+	}
+
+	return block;
 };
 
 export default save;

--- a/src/blocks/svg-icon-maxi/test/save.js
+++ b/src/blocks/svg-icon-maxi/test/save.js
@@ -62,15 +62,36 @@ describe('svg icon save', () => {
 		);
 	});
 
-	it('keeps the icon unwrapped inside the block when the canvas target is selected', () => {
-		const block = resolveElement(
-			renderSvgIcon({
-				url: 'https://example.com',
-				linkElement: 'canvas',
-			})
-		);
+	it('wraps the whole block when canvas target is selected', () => {
+		const element = renderSvgIcon({
+			url: 'https://example.com',
+			linkElement: 'canvas',
+		});
+		const link = resolveElement(element);
+
+		expect(link.type).toBe('a');
+		expect(link.props.className).toBe('maxi-link-wrapper');
+
+		const block = resolveElement(link.props.children);
 		const icon = block.props.children;
 
+		expect(block.type).toBe('div');
+		expect(block.props.className).toBe('maxi-block');
 		expect(icon.props.className).toBe('maxi-svg-icon-block__icon');
+	});
+
+	it('wraps the whole block when linkElement is absent (backward compat)', () => {
+		const element = renderSvgIcon({
+			url: 'https://example.com',
+		});
+		const link = resolveElement(element);
+
+		expect(link.type).toBe('a');
+		expect(link.props.className).toBe('maxi-link-wrapper');
+
+		const block = resolveElement(link.props.children);
+
+		expect(block.type).toBe('div');
+		expect(block.props.className).toBe('maxi-block');
 	});
 });

--- a/src/components/toolbar/components/link/index.js
+++ b/src/components/toolbar/components/link/index.js
@@ -87,6 +87,20 @@ const Link = props => {
 		}
 	}, [selectedDCType, dcField, dcLinkStatus]);
 
+	// Auto-set the default linkElement for blocks that need it, but skip
+	// svg-icon-maxi: its save.js handles both linkElement states and
+	// auto-injecting would corrupt old blocks that use the external wrapper.
+	useEffect(() => {
+		if (blockName === 'maxi-blocks/svg-icon-maxi') return;
+
+		const linkSettingsWithDefaultElement =
+			getLinkSettingsWithDefaultLinkElement(linkSettings, linkElements);
+
+		if (linkSettingsWithDefaultElement !== linkSettings) {
+			onChange(linkSettingsWithDefaultElement);
+		}
+	}, [blockName, linkElements, linkSettings, onChange]);
+
 	const updateCanvasLinkElement = checked => {
 		onChange({
 			...linkSettings,

--- a/src/components/toolbar/components/link/index.js
+++ b/src/components/toolbar/components/link/index.js
@@ -87,15 +87,6 @@ const Link = props => {
 		}
 	}, [selectedDCType, dcField, dcLinkStatus]);
 
-	useEffect(() => {
-		const linkSettingsWithDefaultElement =
-			getLinkSettingsWithDefaultLinkElement(linkSettings, linkElements);
-
-		if (linkSettingsWithDefaultElement !== linkSettings) {
-			onChange(linkSettingsWithDefaultElement);
-		}
-	}, [linkElements, linkSettings, onChange]);
-
 	const updateCanvasLinkElement = checked => {
 		onChange({
 			...linkSettings,

--- a/src/extensions/save/index.js
+++ b/src/extensions/save/index.js
@@ -24,7 +24,6 @@ const allowedBlocks = [
 	'maxi-blocks/group-maxi',
 	'maxi-blocks/pane-maxi',
 	'maxi-blocks/number-counter-maxi',
-	'maxi-blocks/svg-icon-maxi',
 	'maxi-blocks/slider-maxi',
 	'maxi-blocks/slide-maxi',
 	'maxi-blocks/video-maxi',

--- a/src/extensions/save/test/linkWrapper.js
+++ b/src/extensions/save/test/linkWrapper.js
@@ -1,9 +1,9 @@
 import { shouldWrapWithLink } from '../linkWrapper';
 
 const allowedBlocks = [
-	'maxi-blocks/svg-icon-maxi',
 	'maxi-blocks/image-maxi',
 	'maxi-blocks/pane-maxi',
+	'maxi-blocks/button-maxi',
 ];
 
 describe('save link wrapper', () => {
@@ -22,13 +22,13 @@ describe('save link wrapper', () => {
 		).toBe(true);
 	});
 
-	it('does not wrap the canvas when an element-specific link target is selected', () => {
+	it('does not wrap when an element-specific link target is selected', () => {
 		expect(
 			shouldWrapWithLink({
-				blockName: 'maxi-blocks/svg-icon-maxi',
+				blockName: 'maxi-blocks/button-maxi',
 				allowedBlocks,
-				linkElements: ['svg', 'canvas'],
-				linkSettings: { linkElement: 'svg' },
+				linkElements: ['button', 'canvas'],
+				linkSettings: { linkElement: 'button' },
 			})
 		).toBe(false);
 	});
@@ -36,11 +36,20 @@ describe('save link wrapper', () => {
 	it('wraps the canvas when the canvas link target is selected', () => {
 		expect(
 			shouldWrapWithLink({
-				blockName: 'maxi-blocks/svg-icon-maxi',
+				blockName: 'maxi-blocks/button-maxi',
 				allowedBlocks,
-				linkElements: ['svg', 'canvas'],
+				linkElements: ['button', 'canvas'],
 				linkSettings: { linkElement: 'canvas' },
 			})
 		).toBe(true);
+	});
+
+	it('does not wrap blocks not in allowedBlocks', () => {
+		expect(
+			shouldWrapWithLink({
+				blockName: 'maxi-blocks/svg-icon-maxi',
+				allowedBlocks,
+			})
+		).toBe(false);
 	});
 });


### PR DESCRIPTION
# Description

Fixes old svgs with links breaking after 1ad8e0f29, f8f7de734, c06bfb88d commits.

Check on Pure Image Light PIL-PRO-108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized SVG icon block link-wrapping into a clearer two-stage flow so the icon or entire block can be wrapped appropriately.
  * Stopped automatic link-settings normalization for the SVG icon block and adjusted save logic so that the block decides wrapping behavior.

* **Tests**
  * Updated tests to verify correct link-wrapping behavior for SVG icon and button blocks across different link target settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->