### PR TITLE
Fix Cloud library cost filter active state

### DIFF
--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -18,6 +18,7 @@ import masonryGenerator from './masonryGenerator';
 import useInterval from '@extensions/dom/useInterval';
 import InfiniteHits from './InfiniteHits';
 import onRequestInsertPattern from './utils/onRequestInsertPattern';
+import isMenuSelectItemRefined from './utils/menuSelect';
 import { ContentLoader } from '@components';
 
 /**
@@ -137,6 +138,17 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 		count: 0,
 		isRefined: false,
 	};
+	const isAllRefined = isEmpty(currentRefinement);
+	const isFreeRefined = isMenuSelectItemRefined(
+		currentRefinement,
+		freeElement,
+		'Free'
+	);
+	const isProRefined = isMenuSelectItemRefined(
+		currentRefinement,
+		proElement,
+		'Pro'
+	);
 
 	return (
 		<div className='top-Menu'>
@@ -145,9 +157,10 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 				value=''
 				className={classnames(
 					'maxi-cloud-container__content-svg-shape__button',
-					isEmpty(currentRefinement) &&
+					isAllRefined &&
 						' maxi-cloud-container__content-svg-shape__button___pressed'
 				)}
+				aria-pressed={isAllRefined}
 				onClick={event => {
 					event.preventDefault();
 					refine('');
@@ -160,14 +173,14 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 				key='Free'
 				className={classnames(
 					'maxi-cloud-container__content-svg-shape__button',
-					freeElement?.isRefined &&
+					isFreeRefined &&
 						' maxi-cloud-container__content-svg-shape__button___pressed'
 				)}
+				aria-pressed={isFreeRefined}
 				value='Free'
 				onClick={event => {
 					event.preventDefault();
 					refine('Free');
-					freeElement.isRefined = true;
 				}}
 			>
 				{__('Free', 'maxi-blocks')}
@@ -177,14 +190,14 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 				key='Pro'
 				className={classnames(
 					'maxi-cloud-container__content-svg-shape__button',
-					proElement?.isRefined &&
+					isProRefined &&
 						' maxi-cloud-container__content-svg-shape__button___pressed'
 				)}
+				aria-pressed={isProRefined}
 				value='Pro'
 				onClick={event => {
 					event.preventDefault();
 					refine('Pro');
-					proElement.isRefined = true;
 				}}
 			>
 				{__('Cloud', 'maxi-blocks')}

--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -141,12 +141,10 @@ const MenuSelect = ({ items, currentRefinement, refine }) => {
 	const isAllRefined = isEmpty(currentRefinement);
 	const isFreeRefined = isMenuSelectItemRefined(
 		currentRefinement,
-		freeElement,
 		'Free'
 	);
 	const isProRefined = isMenuSelectItemRefined(
 		currentRefinement,
-		proElement,
 		'Pro'
 	);
 

--- a/src/editor/library/utils/menuSelect.js
+++ b/src/editor/library/utils/menuSelect.js
@@ -1,0 +1,4 @@
+const isMenuSelectItemRefined = (currentRefinement, item, value) =>
+	Boolean(item?.isRefined || currentRefinement === value);
+
+export default isMenuSelectItemRefined;

--- a/src/editor/library/utils/menuSelect.js
+++ b/src/editor/library/utils/menuSelect.js
@@ -1,4 +1,4 @@
-const isMenuSelectItemRefined = (currentRefinement, item, value) =>
-	Boolean(item?.isRefined || currentRefinement === value);
+const isMenuSelectItemRefined = (currentRefinement, value) =>
+	currentRefinement === value;
 
 export default isMenuSelectItemRefined;

--- a/src/editor/library/utils/test/menuSelect.js
+++ b/src/editor/library/utils/test/menuSelect.js
@@ -2,43 +2,19 @@ import isMenuSelectItemRefined from '../menuSelect';
 
 describe('isMenuSelectItemRefined', () => {
 	it('uses currentRefinement for synthesized Free and Cloud menu items', () => {
-		const unrefinedItem = {
-			isRefined: false,
-		};
-
-		expect(
-			isMenuSelectItemRefined('Free', unrefinedItem, 'Free')
-		).toBe(true);
-		expect(isMenuSelectItemRefined('Pro', unrefinedItem, 'Pro')).toBe(
-			true
-		);
+		expect(isMenuSelectItemRefined('Free', 'Free')).toBe(true);
+		expect(isMenuSelectItemRefined('Pro', 'Pro')).toBe(true);
 	});
 
-	it('keeps Algolia refined items active when currentRefinement is empty', () => {
-		expect(
-			isMenuSelectItemRefined(
-				'',
-				{
-					isRefined: true,
-				},
-				'Free'
-			)
-		).toBe(true);
+	it('does not keep a stale menu item active after refinement changes', () => {
+		expect(isMenuSelectItemRefined('Free', 'Pro')).toBe(false);
 	});
 
 	it('does not mark unrelated menu items active', () => {
-		expect(
-			isMenuSelectItemRefined(
-				'Free',
-				{
-					isRefined: false,
-				},
-				'Pro'
-			)
-		).toBe(false);
+		expect(isMenuSelectItemRefined('Free', 'Pro')).toBe(false);
 	});
 
-	it('returns false when the menu item is missing and does not match', () => {
-		expect(isMenuSelectItemRefined('', undefined, 'Free')).toBe(false);
+	it('returns false when there is no current refinement for the item', () => {
+		expect(isMenuSelectItemRefined('', 'Free')).toBe(false);
 	});
 });

--- a/src/editor/library/utils/test/menuSelect.js
+++ b/src/editor/library/utils/test/menuSelect.js
@@ -1,0 +1,44 @@
+import isMenuSelectItemRefined from '../menuSelect';
+
+describe('isMenuSelectItemRefined', () => {
+	it('uses currentRefinement for synthesized Free and Cloud menu items', () => {
+		const unrefinedItem = {
+			isRefined: false,
+		};
+
+		expect(
+			isMenuSelectItemRefined('Free', unrefinedItem, 'Free')
+		).toBe(true);
+		expect(isMenuSelectItemRefined('Pro', unrefinedItem, 'Pro')).toBe(
+			true
+		);
+	});
+
+	it('keeps Algolia refined items active when currentRefinement is empty', () => {
+		expect(
+			isMenuSelectItemRefined(
+				'',
+				{
+					isRefined: true,
+				},
+				'Free'
+			)
+		).toBe(true);
+	});
+
+	it('does not mark unrelated menu items active', () => {
+		expect(
+			isMenuSelectItemRefined(
+				'Free',
+				{
+					isRefined: false,
+				},
+				'Pro'
+			)
+		).toBe(false);
+	});
+
+	it('returns false when the menu item is missing and does not match', () => {
+		expect(isMenuSelectItemRefined('', undefined, 'Free')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes the Cloud library cost filter buttons so Free and Cloud visibly show their active state when selected.

## What changed
- Added a small `isMenuSelectItemRefined` helper for the Cloud library menu selection state.
- Updated the All, Free, and Cloud cost filter buttons to derive pressed state from `currentRefinement`.
- Added `aria-pressed` to expose the selected state in the button markup.
- Added focused unit coverage for the selection helper.

## Why / root cause
The Free and Cloud buttons were relying on the menu item object's `isRefined` value and mutating that object in the click handler. For synthesized or stale menu items, that did not reliably reflect the active InstantSearch refinement, so the existing pressed-state CSS class was not applied. `currentRefinement` is the reliable source for the selected filter.

## Testing
- `npm test -- menuSelect --runInBand`
- `git diff --check master..HEAD`
- `npm run build`

Manual test steps:
1. Open the MaxiBlocks editor locally.
2. Open Cloud library > Patterns.
3. Click `Free`, then `Cloud`, then `All`.
4. Confirm the active state moves to the selected button each time.

Note: the advisory autoreview helper was attempted locally but could not complete because it requires sending the local diff to an external Codex/OpenAI service, and that escalation was denied for data-exfiltration risk. A local manual self-review was completed instead.

## Closing issue link
No linked issue. This was noticed during manual QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu filter buttons so their pressed states are derived reliably (no direct internal mutation) and aria-pressed is applied for better accessibility.

* **Tests**
  * Added unit tests covering menu item refinement detection to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->