### PR TITLE
Add Style Card layout defaults for Container and Row

### DIFF
--- a/core/class-maxi-style-cards.php
+++ b/core/class-maxi-style-cards.php
@@ -1471,6 +1471,15 @@ class MaxiBlocks_StyleCards
                         continue;
                     }
 
+                    if ($element === 'blockDefaults') {
+                        foreach ($element_data as $block_default) {
+                            $var_name = $block_default['var_name'];
+                            $value = $block_default['value'];
+                            $var_sc_string .= "{$var_name}:{$value};";
+                        }
+                        continue;
+                    }
+
                     foreach ($element_data as $breakpoint => $breakpoint_data) {
                         foreach ($breakpoint_data as $setting => $value) {
                             if (is_array($value)) {
@@ -1690,6 +1699,41 @@ class MaxiBlocks_StyleCards
 
                     $organized_values[$style]['menu'][$menu_prop] = [
                         'value' => $rgba_value,
+                        'var_name' => $var_name
+                    ];
+                }
+            }
+
+            if (isset($style_data['blockDefaults']) && is_array($style_data['blockDefaults'])) {
+                foreach ($style_data['blockDefaults'] as $key => $value) {
+                    if (strpos($key, '|') === false || strpos($key, '-unit-') !== false) {
+                        continue;
+                    }
+
+                    $parts = explode('|', $key, 2);
+                    $block_name = $parts[0];
+                    $attr = $parts[1];
+                    $block_default_breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+                    $unit_attr = null;
+
+                    foreach ($block_default_breakpoints as $breakpoint) {
+                        if (substr($attr, -strlen("-{$breakpoint}")) === "-{$breakpoint}") {
+                            $base_attr = substr($attr, 0, -strlen("-{$breakpoint}"));
+                            $unit_attr = "{$base_attr}-unit-{$breakpoint}";
+                            break;
+                        }
+                    }
+
+                    $unit_key = $unit_attr ? "{$block_name}|{$unit_attr}" : null;
+                    $unit = $unit_key && isset($style_data['blockDefaults'][$unit_key])
+                        ? $style_data['blockDefaults'][$unit_key]
+                        : '';
+                    $sanitized_block_name = preg_replace('/[^a-zA-Z0-9-]/', '-', $block_name);
+                    $sanitized_attr = preg_replace('/[^a-zA-Z0-9-]/', '-', $attr);
+                    $var_name = "--maxi-{$style}-block-default-{$sanitized_block_name}-{$sanitized_attr}";
+
+                    $organized_values[$style]['blockDefaults'][$var_name] = [
+                        'value' => "{$value}{$unit}",
                         'var_name' => $var_name
                     ];
                 }

--- a/core/defaults/defaultSC.json
+++ b/core/defaults/defaultSC.json
@@ -1166,6 +1166,8 @@
 				}
 			}
 		},
-		"gutenberg_blocks_status": true
+		"gutenberg_blocks_status": true,
+		"sync_style_settings_tones_status": true,
+		"dark_tone_style_overrides": []
 	}
 }

--- a/core/defaults/defaultSC.json
+++ b/core/defaults/defaultSC.json
@@ -5,6 +5,7 @@
 		"dark": {
 			"styleCard": {},
 			"defaultStyleCard": {
+				"blockDefaults": {},
 				"color": {
 					"1": "0,0,0",
 					"2": "5,23,33",
@@ -586,6 +587,7 @@
 		"light": {
 			"styleCard": {},
 			"defaultStyleCard": {
+				"blockDefaults": {},
 				"color": {
 					"1": "255,255,255",
 					"2": "242,249,253",

--- a/src/blocks/container-maxi/edit.js
+++ b/src/blocks/container-maxi/edit.js
@@ -23,6 +23,7 @@ import {
 	withMaxiContextLoopContext,
 } from '@extensions/DC';
 import withMaxiDC from '@extensions/DC/withMaxiDC';
+import { shouldApplySCBlockDefaultsToControl } from '@extensions/style-cards/blockDefaults';
 
 /**
  * General
@@ -113,6 +114,10 @@ class edit extends MaxiBlockComponent {
 			isSelected,
 		} = this.props;
 		const { uniqueID, isFirstOnHierarchy } = attributes;
+		const applyStyleCardDefaults = shouldApplySCBlockDefaultsToControl({
+			name: this.props.name,
+			attributes,
+		});
 
 		return [
 			<Inspector key={`block-settings-${uniqueID}`} {...this.props} />,
@@ -157,10 +162,14 @@ class edit extends MaxiBlockComponent {
 						/>
 						<BlockIndicators
 							key={`indicators-${uniqueID}`}
-							{...getGroupAttributes(attributes, [
-								'padding',
-								'margin',
-							])}
+							{...getGroupAttributes(
+								attributes,
+								['padding', 'margin'],
+								false,
+								'',
+								false,
+								applyStyleCardDefaults
+							)}
 							onChange={obj => maxiSetAttributes(obj)}
 							breakpoint={deviceType}
 							avoidIndicators={

--- a/src/blocks/container-maxi/styles.js
+++ b/src/blocks/container-maxi/styles.js
@@ -23,6 +23,13 @@ import {
 } from '@extensions/styles/helpers';
 import data from './data';
 
+const getStyleCardGroupAttributes = (
+	props,
+	target,
+	isHover = false,
+	prefix = ''
+) => getGroupAttributes(props, target, isHover, prefix, false, true);
+
 const getNormalObject = props => {
 	const response = {
 		border: getBorderStyles({
@@ -36,7 +43,7 @@ const getNormalObject = props => {
 			blockStyle: props.blockStyle,
 		}),
 		size: getSizeStyles({
-			...getGroupAttributes(props, 'size'),
+			...getStyleCardGroupAttributes(props, 'size'),
 		}),
 		boxShadow: getBoxShadowStyles({
 			obj: {
@@ -61,16 +68,16 @@ const getNormalObject = props => {
 		}),
 		margin: getMarginPaddingStyles({
 			obj: {
-				...getGroupAttributes(props, 'margin'),
+				...getStyleCardGroupAttributes(props, 'margin'),
 			},
 		}),
 		padding: getMarginPaddingStyles({
 			obj: {
-				...getGroupAttributes(props, 'padding'),
+				...getStyleCardGroupAttributes(props, 'padding'),
 			},
 		}),
 		flex: getFlexStyles({
-			...getGroupAttributes(props, 'flex'),
+			...getStyleCardGroupAttributes(props, 'flex'),
 		}),
 	};
 
@@ -125,7 +132,7 @@ const getStyles = props => {
 						shapeDivider: {
 							...getShapeDividerStyles(
 								{
-									...getGroupAttributes(props, [
+									...getStyleCardGroupAttributes(props, [
 										'shapeDivider',
 										'padding',
 									]),
@@ -138,7 +145,7 @@ const getStyles = props => {
 						shapeDivider: {
 							...getShapeDividerSVGStyles(
 								{
-									...getGroupAttributes(props, [
+									...getStyleCardGroupAttributes(props, [
 										'shapeDivider',
 										'padding',
 									]),
@@ -154,7 +161,7 @@ const getStyles = props => {
 						shapeDivider: {
 							...getShapeDividerStyles(
 								{
-									...getGroupAttributes(props, [
+									...getStyleCardGroupAttributes(props, [
 										'shapeDivider',
 										'padding',
 									]),
@@ -167,7 +174,7 @@ const getStyles = props => {
 						shapeDivider: {
 							...getShapeDividerSVGStyles(
 								{
-									...getGroupAttributes(props, [
+									...getStyleCardGroupAttributes(props, [
 										'shapeDivider',
 										'padding',
 									]),

--- a/src/blocks/container-maxi/test/styles.js
+++ b/src/blocks/container-maxi/test/styles.js
@@ -54,6 +54,7 @@ jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () => {
 import getStyles from '../styles';
 import { getBlockDefaultKey } from '@extensions/style-cards/blockDefaults';
 import frontendStyleGenerator from '@extensions/styles/frontendStyleGenerator';
+import styleGenerator from '@extensions/styles/styleGenerator';
 import styleResolver from '@extensions/styles/styleResolver';
 
 const getBaseStyleCard = () => ({
@@ -223,5 +224,52 @@ describe('container-maxi styles', () => {
 		expect(frontendCss).toContain(
 			`@media only screen and (max-width:1920px){body.maxi-blocks--active #${uniqueID}{min-width:initial;padding-top:var(--maxi-light-block-default-container-maxi-padding-top-xl, 200px);}}`
 		);
+	});
+
+	it('renders editor and frontend CSS with XL Style Card padding over a 150px library container', () => {
+		const uniqueID = 'container-maxi-sc-editor-xl-padding-test-u';
+
+		mockActiveStyleCard.light.styleCard.blockDefaults = {
+			[getBlockDefaultKey('container-maxi', 'padding-top-xl')]: '20',
+			[getBlockDefaultKey('container-maxi', 'padding-top-unit-xl')]:
+				'px',
+			[getBlockDefaultKey('container-maxi', 'padding-bottom-xl')]: '20',
+			[getBlockDefaultKey('container-maxi', 'padding-bottom-unit-xl')]:
+				'px',
+		};
+
+		const resolvedStyles = styleResolver({
+			styles: getStyles({
+				uniqueID,
+				blockStyle: 'light',
+				'padding-top-general': '150',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '200',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '150',
+				'padding-top-unit-xl': 'px',
+				'padding-bottom-general': '150',
+				'padding-bottom-unit-general': 'px',
+				'padding-bottom-xxl': '200',
+				'padding-bottom-unit-xxl': 'px',
+				'padding-bottom-xl': '150',
+				'padding-bottom-unit-xl': 'px',
+			}),
+			breakpoints,
+			uniqueID,
+		});
+
+		const frontendCss = frontendStyleGenerator(
+			Object.entries(resolvedStyles)[0]
+		);
+		const editorCss = styleGenerator(resolvedStyles, true, false, 'xl');
+
+		expect(frontendCss).toContain(
+			`padding-top:var(--maxi-light-block-default-container-maxi-padding-top-xl, 20px);padding-bottom:var(--maxi-light-block-default-container-maxi-padding-bottom-xl, 20px);`
+		);
+		expect(editorCss).toContain(
+			`padding-top: var(--maxi-light-block-default-container-maxi-padding-top-xl, 20px); padding-bottom: var(--maxi-light-block-default-container-maxi-padding-bottom-xl, 20px);`
+		);
+		expect(editorCss).not.toContain('maxi-block-indicators');
 	});
 });

--- a/src/blocks/container-maxi/test/styles.js
+++ b/src/blocks/container-maxi/test/styles.js
@@ -4,6 +4,38 @@ jest.mock('@extensions/styles', () => ({
 	styleProcessor: jest.fn(styles => styles),
 }));
 
+let mockActiveStyleCard;
+let mockStyleCards;
+
+jest.mock('@wordpress/data', () => ({
+	select: jest.fn(store => {
+		if (store === 'core/block-editor') {
+			return {
+				getBlockAttributes: jest.fn(() => null),
+				getSelectedBlockClientId: jest.fn(() => null),
+				getSelectedBlockClientIds: jest.fn(() => []),
+				getSelectedBlockCount: jest.fn(() => 1),
+			};
+		}
+		if (store === 'maxiBlocks') {
+			return {
+				receiveBaseBreakpoint: jest.fn(() => 'xl'),
+				receiveMaxiDeviceType: jest.fn(() => 'xl'),
+			};
+		}
+		if (store === 'maxiBlocks/style-cards') {
+			return {
+				receiveMaxiStyleCards: jest.fn(() => mockStyleCards),
+			};
+		}
+
+		return {};
+	}),
+	dispatch: jest.fn(() => ({
+		updateStyles: jest.fn(),
+	})),
+}));
+
 jest.mock('@extensions/relations', () => ({
 	getCanvasSettings: jest.fn(() => ({})),
 	getAdvancedSettings: jest.fn(() => ({})),
@@ -14,34 +46,64 @@ jest.mock('src/extensions/styles/getDefaultAttribute.js', () =>
 );
 
 jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () => {
-	return jest.fn(() => {
-		return {
-			value: {
-				name: 'Maxi (Default)',
-				status: 'active',
-				light: {
-					styleCard: {},
-					defaultStyleCard: {
-						color: {
-							1: '255,255,255',
-							2: '242,249,253',
-							3: '155,155,155',
-							4: '255,74,23',
-							5: '0,0,0',
-							6: '201,52,10',
-							7: '8,18,25',
-							8: '150,176,203',
-						},
-					},
-				},
-			},
-		};
-	});
+	return jest.fn(() => ({
+		value: mockActiveStyleCard,
+	}));
 });
 
 import getStyles from '../styles';
+import { getBlockDefaultKey } from '@extensions/style-cards/blockDefaults';
+import frontendStyleGenerator from '@extensions/styles/frontendStyleGenerator';
+import styleResolver from '@extensions/styles/styleResolver';
+
+const getBaseStyleCard = () => ({
+	name: 'Maxi (Default)',
+	status: 'active',
+	light: {
+		styleCard: {
+			blockDefaults: {},
+		},
+		defaultStyleCard: {
+			blockDefaults: {},
+			color: {
+				1: '255,255,255',
+				2: '242,249,253',
+				3: '155,155,155',
+				4: '255,74,23',
+				5: '0,0,0',
+				6: '201,52,10',
+				7: '8,18,25',
+				8: '150,176,203',
+			},
+		},
+	},
+	dark: {
+		styleCard: {
+			blockDefaults: {},
+		},
+		defaultStyleCard: {
+			blockDefaults: {},
+		},
+	},
+});
+
+const breakpoints = {
+	xxl: 1920,
+	xl: 1920,
+	l: 1366,
+	m: 1024,
+	s: 767,
+	xs: 480,
+};
 
 describe('container-maxi styles', () => {
+	beforeEach(() => {
+		mockActiveStyleCard = getBaseStyleCard();
+		mockStyleCards = {
+			sc_maxi: mockActiveStyleCard,
+		};
+	});
+
 	it('passes background transition settings to callout arrow color elements', () => {
 		const uniqueID = 'container-maxi-arrow-transition-test-u';
 		const result = getStyles({
@@ -84,5 +146,82 @@ describe('container-maxi styles', () => {
 				' .maxi-container-arrow .maxi-container-arrow--content:after'
 			].transition.general.transition
 		).toBe('background-color 0.3s 0s ease');
+	});
+
+	it('uses Style Card block default variables in generated library container padding styles', () => {
+		const uniqueID = 'container-maxi-sc-padding-test-u';
+
+		mockActiveStyleCard.light.styleCard.blockDefaults = {
+			[getBlockDefaultKey('container-maxi', 'padding-top-xl')]: '90',
+			[getBlockDefaultKey('container-maxi', 'padding-top-unit-xl')]:
+				'px',
+		};
+
+		const result = getStyles({
+			uniqueID,
+			blockStyle: 'light',
+			'padding-top-general': '100',
+			'padding-top-unit-general': 'px',
+			'padding-top-xxl': '150',
+			'padding-top-unit-xxl': 'px',
+			'padding-top-xl': '100',
+			'padding-top-unit-xl': 'px',
+		});
+
+		expect(result[uniqueID][''].padding.xl['padding-top']).toBe(
+			'var(--maxi-light-block-default-container-maxi-padding-top-xl, 90px)'
+		);
+	});
+
+	it('generates container padding styles from Style Card defaults when the block has no explicit padding', () => {
+		const uniqueID = 'container-maxi-sc-new-padding-test-u';
+
+		mockActiveStyleCard.light.styleCard.blockDefaults = {
+			[getBlockDefaultKey('container-maxi', 'padding-top-xl')]: '120',
+			[getBlockDefaultKey('container-maxi', 'padding-top-unit-xl')]:
+				'px',
+		};
+
+		const result = getStyles({
+			uniqueID,
+			blockStyle: 'light',
+		});
+
+		expect(result[uniqueID][''].padding.xl['padding-top']).toBe(
+			'var(--maxi-light-block-default-container-maxi-padding-top-xl, 120px)'
+		);
+	});
+
+	it('renders frontend CSS with Style Card block default padding variables', () => {
+		const uniqueID = 'container-maxi-sc-frontend-padding-test-u';
+
+		mockActiveStyleCard.light.styleCard.blockDefaults = {
+			[getBlockDefaultKey('container-maxi', 'padding-top-xl')]: '200',
+			[getBlockDefaultKey('container-maxi', 'padding-top-unit-xl')]:
+				'px',
+		};
+
+		const resolvedStyles = styleResolver({
+			styles: getStyles({
+				uniqueID,
+				blockStyle: 'light',
+				'padding-top-general': '100',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '150',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '100',
+				'padding-top-unit-xl': 'px',
+			}),
+			breakpoints,
+			uniqueID,
+		});
+
+		const frontendCss = frontendStyleGenerator(
+			Object.entries(resolvedStyles)[0]
+		);
+
+		expect(frontendCss).toContain(
+			`@media only screen and (max-width:1920px){body.maxi-blocks--active #${uniqueID}{min-width:initial;padding-top:var(--maxi-light-block-default-container-maxi-padding-top-xl, 200px);}}`
+		);
 	});
 });

--- a/src/blocks/row-maxi/styles.js
+++ b/src/blocks/row-maxi/styles.js
@@ -37,6 +37,13 @@ import data from './data';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
+const getStyleCardGroupAttributes = (
+	props,
+	target,
+	isHover = false,
+	prefix = ''
+) => getGroupAttributes(props, target, isHover, prefix, false, true);
+
 const getNormalObject = props => {
 	const response = {
 		boxShadow: getBoxShadowStyles({
@@ -56,13 +63,13 @@ const getNormalObject = props => {
 			blockStyle: props.blockStyle,
 		}),
 		size: getSizeStyles({
-			...getGroupAttributes(props, 'size'),
+			...getStyleCardGroupAttributes(props, 'size'),
 		}),
 		margin: getMarginPaddingStyles({
-			obj: { ...getGroupAttributes(props, 'margin') },
+			obj: { ...getStyleCardGroupAttributes(props, 'margin') },
 		}),
 		padding: getMarginPaddingStyles({
-			obj: { ...getGroupAttributes(props, 'padding') },
+			obj: { ...getStyleCardGroupAttributes(props, 'padding') },
 		}),
 		opacity: getOpacityStyles({
 			...getGroupAttributes(props, 'opacity'),
@@ -83,7 +90,7 @@ const getNormalObject = props => {
 			...getGroupAttributes(props, 'overflow'),
 		}),
 		flex: getFlexStyles({
-			...getGroupAttributes(props, 'flex'),
+			...getStyleCardGroupAttributes(props, 'flex'),
 		}),
 	};
 

--- a/src/blocks/row-maxi/test/styles.js
+++ b/src/blocks/row-maxi/test/styles.js
@@ -1,0 +1,118 @@
+jest.mock('@extensions/styles', () => ({
+	getGroupAttributes: jest.requireActual('@extensions/styles/getGroupAttributes')
+		.default,
+	styleProcessor: jest.fn(styles => styles),
+	createIconTransitions: jest.fn(() => ({})),
+}));
+
+let mockActiveStyleCard;
+let mockStyleCards;
+
+jest.mock('@wordpress/data', () => ({
+	select: jest.fn(store => {
+		if (store === 'core/block-editor') {
+			return {
+				getBlockAttributes: jest.fn(() => null),
+				getSelectedBlockClientId: jest.fn(() => null),
+				getSelectedBlockClientIds: jest.fn(() => []),
+				getSelectedBlockCount: jest.fn(() => 1),
+			};
+		}
+		if (store === 'maxiBlocks') {
+			return {
+				receiveBaseBreakpoint: jest.fn(() => 'xl'),
+				receiveMaxiDeviceType: jest.fn(() => 'xl'),
+			};
+		}
+		if (store === 'maxiBlocks/style-cards') {
+			return {
+				receiveMaxiStyleCards: jest.fn(() => mockStyleCards),
+			};
+		}
+
+		return {};
+	}),
+}));
+
+jest.mock('@extensions/relations', () => ({
+	getCanvasSettings: jest.fn(() => ({})),
+	getAdvancedSettings: jest.fn(() => ({})),
+}));
+
+jest.mock('src/extensions/styles/getDefaultAttribute.js', () =>
+	jest.fn(() => 0)
+);
+
+jest.mock('src/extensions/style-cards/getActiveStyleCard.js', () =>
+	jest.fn(() => ({
+		value: mockActiveStyleCard,
+	}))
+);
+
+import getStyles from '../styles';
+import { getBlockDefaultKey } from '@extensions/style-cards/blockDefaults';
+
+const getBaseStyleCard = () => ({
+	name: 'Maxi (Default)',
+	status: 'active',
+	light: {
+		styleCard: {
+			blockDefaults: {},
+		},
+		defaultStyleCard: {
+			blockDefaults: {},
+		},
+	},
+	dark: {
+		styleCard: {
+			blockDefaults: {},
+		},
+		defaultStyleCard: {
+			blockDefaults: {},
+		},
+	},
+});
+
+describe('row-maxi styles', () => {
+	beforeEach(() => {
+		mockActiveStyleCard = getBaseStyleCard();
+		mockStyleCards = {
+			sc_maxi: mockActiveStyleCard,
+		};
+	});
+
+	it('uses Style Card block default variables in generated row layout styles', () => {
+		const uniqueID = 'row-maxi-sc-layout-test-u';
+
+		mockActiveStyleCard.light.styleCard.blockDefaults = {
+			[getBlockDefaultKey('row-maxi', 'padding-top-xl')]: '80',
+			[getBlockDefaultKey('row-maxi', 'padding-top-unit-xl')]: 'px',
+			[getBlockDefaultKey('row-maxi', 'row-gap-general')]: '30',
+			[getBlockDefaultKey('row-maxi', 'row-gap-unit-general')]: 'px',
+		};
+
+		const result = getStyles({
+			uniqueID,
+			blockStyle: 'light',
+			'padding-top-general': '150',
+			'padding-top-unit-general': 'px',
+			'padding-top-xxl': '200',
+			'padding-top-unit-xxl': 'px',
+			'padding-top-xl': '150',
+			'padding-top-unit-xl': 'px',
+			'padding-top-s': '0',
+			'padding-top-unit-s': 'px',
+			'row-gap-general': 20,
+			'row-gap-unit-general': 'px',
+			'row-gap-xs': 10,
+			'row-gap-unit-xs': 'px',
+		});
+
+		expect(result[uniqueID][''].padding.xl['padding-top']).toBe(
+			'var(--maxi-light-block-default-row-maxi-padding-top-xl, 80px)'
+		);
+		expect(result[uniqueID][''].flex.general['row-gap']).toBe(
+			'var(--maxi-light-block-default-row-maxi-row-gap-general, 30px)'
+		);
+	});
+});

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -9,9 +9,11 @@ import { __ } from '@wordpress/i18n';
 import AdvancedNumberControl from '@components/advanced-number-control';
 import ToggleSwitch from '@components/toggle-switch';
 import withRTC from '@extensions/maxi-block/withRTC';
+import { getSCBlockDefaultsExcludedAttributesUpdate } from '@extensions/style-cards/blockDefaults';
 import {
 	getLastBreakpointAttribute,
 	getDefaultAttribute,
+	getGroupAttributes,
 } from '@extensions/styles';
 
 /**
@@ -45,6 +47,21 @@ const FullSizeControl = props => {
 	} = props;
 
 	const classes = classnames('maxi-full-size-control', className);
+	const effectiveSizeAttributes =
+		getGroupAttributes(props, 'size', false, prefix) || {};
+	const getSizeAttribute = target =>
+		getLastBreakpointAttribute({
+			target: `${prefix}${target}`,
+			breakpoint,
+			attributes: effectiveSizeAttributes,
+			forceSingle: true,
+		});
+	const getBlockDefaultExclusionUpdate = (attr, exclude) =>
+		getSCBlockDefaultsExcludedAttributesUpdate({
+			attributes: props,
+			attr,
+			exclude,
+		});
 
 	const minMaxSettings = {
 		px: {
@@ -74,11 +91,7 @@ const FullSizeControl = props => {
 	const showWidth =
 		!hideWidth &&
 		!isBlockFullWidth &&
-		!getLastBreakpointAttribute({
-			target: `${prefix}width-fit-content`,
-			breakpoint,
-			attributes: props,
-		});
+		!getSizeAttribute('width-fit-content');
 
 	return (
 		<div className={classes}>
@@ -91,6 +104,10 @@ const FullSizeControl = props => {
 						onChange={val =>
 							onChange({
 								[`full-width-${breakpoint}`]: val,
+								...getBlockDefaultExclusionUpdate(
+									`full-width-${breakpoint}`,
+									val === false
+								),
 							})
 						}
 					/>
@@ -106,10 +123,18 @@ const FullSizeControl = props => {
 										[`img-width-${breakpoint}`]: 100,
 										[`${prefix}full-width-${breakpoint}`]:
 											val,
+										...getBlockDefaultExclusionUpdate(
+											`${prefix}full-width-${breakpoint}`,
+											val === false
+										),
 								  })
 								: onChange({
 										[`${prefix}full-width-${breakpoint}`]:
 											val,
+										...getBlockDefaultExclusionUpdate(
+											`${prefix}full-width-${breakpoint}`,
+											val === false
+										),
 								  })
 						}
 					/>
@@ -118,14 +143,14 @@ const FullSizeControl = props => {
 				<ToggleSwitch
 					label={__('Set width to fit content', 'maxi-blocks')}
 					className='maxi-full-size-control__width-fit-content'
-					selected={getLastBreakpointAttribute({
-						target: `${prefix}width-fit-content`,
-						breakpoint,
-						attributes: props,
-					})}
+					selected={getSizeAttribute('width-fit-content')}
 					onChange={val => {
 						onChange({
 							[`${prefix}width-fit-content-${breakpoint}`]: val,
+							...getBlockDefaultExclusionUpdate(
+								`${prefix}width-fit-content-${breakpoint}`,
+								val === false
+							),
 						});
 					}}
 				/>
@@ -135,19 +160,11 @@ const FullSizeControl = props => {
 					label={__('Width', 'maxi-blocks')}
 					className='maxi-full-size-control__width'
 					enableUnit
-					unit={getLastBreakpointAttribute({
-						target: `${prefix}width-unit`,
-						breakpoint,
-						attributes: props,
-					})}
+					unit={getSizeAttribute('width-unit')}
 					onChangeUnit={val =>
 						onChange({ [`${prefix}width-unit-${breakpoint}`]: val })
 					}
-					value={getLastBreakpointAttribute({
-						target: `${prefix}width`,
-						breakpoint,
-						attributes: props,
-					})}
+					value={getSizeAttribute('width')}
 					onChangeValue={(val, meta) =>
 						onChange({
 							[`${prefix}width-${breakpoint}`]: val,
@@ -179,11 +196,7 @@ const FullSizeControl = props => {
 						'maxi-blocks'
 					)}
 					className='maxi-full-size-control__force-aspect-ratio'
-					selected={getLastBreakpointAttribute({
-						target: `${prefix}force-aspect-ratio`,
-						breakpoint,
-						attributes: props,
-					})}
+					selected={getSizeAttribute('force-aspect-ratio')}
 					onChange={val =>
 						onChange({
 							[`${prefix}force-aspect-ratio-${breakpoint}`]: val,
@@ -191,56 +204,43 @@ const FullSizeControl = props => {
 					}
 				/>
 			)}
-			{!getLastBreakpointAttribute({
-				target: `${prefix}force-aspect-ratio`,
-				breakpoint,
-				attributes: props,
-			}) &&
-				!hideHeight && (
-					<AdvancedNumberControl
-						label={__('Height', 'maxi-blocks')}
-						className='maxi-full-size-control__height'
-						enableUnit
-						unit={getLastBreakpointAttribute({
-							target: `${prefix}height-unit`,
-							breakpoint,
-							attributes: props,
-						})}
-						onChangeUnit={val =>
-							onChange({
-								[`${prefix}height-unit-${breakpoint}`]: val,
-							})
-						}
-						value={getLastBreakpointAttribute({
-							target: `${prefix}height`,
-							breakpoint,
-							attributes: props,
-						})}
-						onChangeValue={(val, meta) =>
-							onChange({
-								[`${prefix}height-${breakpoint}`]: val,
-								meta,
-							})
-						}
-						onReset={() => {
-							onChange({
-								[`${prefix}height-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}height-${breakpoint}`
-									),
+			{!getSizeAttribute('force-aspect-ratio') && !hideHeight && (
+				<AdvancedNumberControl
+					label={__('Height', 'maxi-blocks')}
+					className='maxi-full-size-control__height'
+					enableUnit
+					unit={getSizeAttribute('height-unit')}
+					onChangeUnit={val =>
+						onChange({
+							[`${prefix}height-unit-${breakpoint}`]: val,
+						})
+					}
+					value={getSizeAttribute('height')}
+					onChangeValue={(val, meta) =>
+						onChange({
+							[`${prefix}height-${breakpoint}`]: val,
+							meta,
+						})
+					}
+					onReset={() => {
+						onChange({
+							[`${prefix}height-${breakpoint}`]:
+								getDefaultAttribute(
+									`${prefix}height-${breakpoint}`
+								),
 
-								[`${prefix}height-unit-${breakpoint}`]:
-									getDefaultAttribute(
-										`${prefix}height-unit-${breakpoint}`
-									),
-								isReset: true,
-							});
-						}}
-						minMaxSettings={minMaxSettings}
-						allowedUnits={['px', '%', 'em', 'vw', 'vh']}
-						optionType='string'
-					/>
-				)}
+							[`${prefix}height-unit-${breakpoint}`]:
+								getDefaultAttribute(
+									`${prefix}height-unit-${breakpoint}`
+								),
+							isReset: true,
+						});
+					}}
+					minMaxSettings={minMaxSettings}
+					allowedUnits={['px', '%', 'em', 'vw', 'vh']}
+					optionType='string'
+				/>
+			)}
 			<ToggleSwitch
 				label={__('Set custom min/max values', 'maxi-blocks')}
 				className='maxi-full-size-control__custom-min-max'
@@ -253,82 +253,56 @@ const FullSizeControl = props => {
 			/>
 			{props[`${prefix}size-advanced-options`] && (
 				<>
-					{!hideMaxWidth &&
-						!getLastBreakpointAttribute({
-							target: `${prefix}width-fit-content`,
-							breakpoint,
-							attributes: props,
-						}) && (
-							<AdvancedNumberControl
-								label={__('Maximum width', 'maxi-blocks')}
-								className='maxi-full-size-control__max-width'
-								enableUnit
-								unit={getLastBreakpointAttribute({
-									target: `${prefix}max-width-unit`,
-									breakpoint,
-									attributes: props,
-								})}
-								onChangeUnit={val =>
-									onChange({
-										[`${prefix}max-width-unit-${breakpoint}`]:
-											val,
-									})
-								}
-								value={getLastBreakpointAttribute({
-									target: `${prefix}max-width`,
-									breakpoint,
-									attributes: props,
-								})}
-								onChangeValue={(val, meta) =>
-									onChange({
-										[`${prefix}max-width-${breakpoint}`]:
-											val,
-										meta,
-									})
-								}
-								onReset={() => {
-									onChange({
-										[`${prefix}max-width-${breakpoint}`]:
-											getDefaultAttribute(
-												`${prefix}max-width-${breakpoint}`
-											),
-										[`${prefix}max-width-unit-${breakpoint}`]:
-											getDefaultAttribute(
-												`${prefix}max-width-unit-${breakpoint}`
-											),
-										isReset: true,
-									});
-								}}
-								minMaxSettings={minMaxSettings}
-								allowedUnits={['px', 'em', 'vw', '%']}
-								optionType='string'
-							/>
-						)}
-					{!getLastBreakpointAttribute({
-						target: `${prefix}width-fit-content`,
-						breakpoint,
-						attributes: props,
-					}) && (
+					{!hideMaxWidth && !getSizeAttribute('width-fit-content') && (
+						<AdvancedNumberControl
+							label={__('Maximum width', 'maxi-blocks')}
+							className='maxi-full-size-control__max-width'
+							enableUnit
+							unit={getSizeAttribute('max-width-unit')}
+							onChangeUnit={val =>
+								onChange({
+									[`${prefix}max-width-unit-${breakpoint}`]:
+										val,
+								})
+							}
+							value={getSizeAttribute('max-width')}
+							onChangeValue={(val, meta) =>
+								onChange({
+									[`${prefix}max-width-${breakpoint}`]: val,
+									meta,
+								})
+							}
+							onReset={() => {
+								onChange({
+									[`${prefix}max-width-${breakpoint}`]:
+										getDefaultAttribute(
+											`${prefix}max-width-${breakpoint}`
+										),
+									[`${prefix}max-width-unit-${breakpoint}`]:
+										getDefaultAttribute(
+											`${prefix}max-width-unit-${breakpoint}`
+										),
+									isReset: true,
+								});
+							}}
+							minMaxSettings={minMaxSettings}
+							allowedUnits={['px', 'em', 'vw', '%']}
+							optionType='string'
+						/>
+					)}
+					{!getSizeAttribute('width-fit-content') && (
 						<AdvancedNumberControl
 							label={__('Minimum width', 'maxi-blocks')}
 							className='maxi-full-size-control__min-width'
 							enableUnit
-							unit={getLastBreakpointAttribute({
-								target: `${prefix}min-width-unit`,
-								breakpoint,
-								attributes: props,
-							})}
+							unit={getSizeAttribute('min-width-unit')}
 							onChangeUnit={val =>
 								onChange({
 									[`${prefix}min-width-unit-${breakpoint}`]:
 										val,
 								})
 							}
-							value={getLastBreakpointAttribute({
-								target: `${prefix}min-width`,
-								breakpoint,
-								attributes: props,
-							})}
+							value={getSizeAttribute('min-width')}
 							onChangeValue={(val, meta) =>
 								onChange({
 									[`${prefix}min-width-${breakpoint}`]: val,
@@ -357,21 +331,13 @@ const FullSizeControl = props => {
 						label={__('Maximum height', 'maxi-blocks')}
 						className='maxi-full-size-control__max-height'
 						enableUnit
-						unit={getLastBreakpointAttribute({
-							target: `${prefix}max-height-unit`,
-							breakpoint,
-							attributes: props,
-						})}
+						unit={getSizeAttribute('max-height-unit')}
 						onChangeUnit={val =>
 							onChange({
 								[`${prefix}max-height-unit-${breakpoint}`]: val,
 							})
 						}
-						value={getLastBreakpointAttribute({
-							target: `${prefix}max-height`,
-							breakpoint,
-							attributes: props,
-						})}
+						value={getSizeAttribute('max-height')}
 						onChangeValue={(val, meta) =>
 							onChange({
 								[`${prefix}max-height-${breakpoint}`]: val,
@@ -399,21 +365,13 @@ const FullSizeControl = props => {
 						label={__('Minimum height', 'maxi-blocks')}
 						className='maxi-full-size-control__min-height'
 						enableUnit
-						unit={getLastBreakpointAttribute({
-							target: `${prefix}min-height-unit`,
-							breakpoint,
-							attributes: props,
-						})}
+						unit={getSizeAttribute('min-height-unit')}
 						onChangeUnit={val =>
 							onChange({
 								[`${prefix}min-height-unit-${breakpoint}`]: val,
 							})
 						}
-						value={getLastBreakpointAttribute({
-							target: `${prefix}min-height`,
-							breakpoint,
-							attributes: props,
-						})}
+						value={getSizeAttribute('min-height')}
 						onChangeValue={(val, meta) =>
 							onChange({
 								[`${prefix}min-height-${breakpoint}`]: val,

--- a/src/components/full-size-control/index.js
+++ b/src/components/full-size-control/index.js
@@ -42,6 +42,8 @@ const FullSizeControl = props => {
 		isBlockFullWidth,
 		allowForceAspectRatio = false,
 		showFullWidth = false,
+		forceSizeAdvancedOptions = false,
+		hideSizeAdvancedOptionsToggle = false,
 		block = false,
 		isImage = false,
 	} = props;
@@ -92,6 +94,8 @@ const FullSizeControl = props => {
 		!hideWidth &&
 		!isBlockFullWidth &&
 		!getSizeAttribute('width-fit-content');
+	const showSizeAdvancedOptions =
+		forceSizeAdvancedOptions || props[`${prefix}size-advanced-options`];
 
 	return (
 		<div className={classes}>
@@ -241,17 +245,19 @@ const FullSizeControl = props => {
 					optionType='string'
 				/>
 			)}
-			<ToggleSwitch
-				label={__('Set custom min/max values', 'maxi-blocks')}
-				className='maxi-full-size-control__custom-min-max'
-				selected={props[`${prefix}size-advanced-options`] || 0}
-				onChange={val => {
-					onChange({
-						[`${prefix}size-advanced-options`]: val,
-					});
-				}}
-			/>
-			{props[`${prefix}size-advanced-options`] && (
+			{!hideSizeAdvancedOptionsToggle && (
+				<ToggleSwitch
+					label={__('Set custom min/max values', 'maxi-blocks')}
+					className='maxi-full-size-control__custom-min-max'
+					selected={showSizeAdvancedOptions}
+					onChange={val => {
+						onChange({
+							[`${prefix}size-advanced-options`]: val,
+						});
+					}}
+				/>
+			)}
+			{showSizeAdvancedOptions && (
 				<>
 					{!hideMaxWidth && !getSizeAttribute('width-fit-content') && (
 						<AdvancedNumberControl

--- a/src/components/inspector-tabs/inspector-margin-padding.js
+++ b/src/components/inspector-tabs/inspector-margin-padding.js
@@ -13,6 +13,7 @@ import {
 	getGroupAttributes,
 	getLastBreakpointAttribute,
 } from '@extensions/styles';
+import { shouldApplySCBlockDefaultsToControl } from '@extensions/style-cards/blockDefaults';
 
 const MarginPaddingContent = ({
 	breakpoint,
@@ -21,28 +22,48 @@ const MarginPaddingContent = ({
 	prefix,
 	disableMargin,
 	fullWidth,
-}) => (
-	<>
-		{!disableMargin && (
-			<MarginControl
-				{...getGroupAttributes(attributes, 'margin', false, prefix)}
+	applyStyleCardDefaults,
+}) => {
+	const marginAttributes = getGroupAttributes(
+		attributes,
+		'margin',
+		false,
+		prefix,
+		false,
+		applyStyleCardDefaults
+	);
+	const paddingAttributes = getGroupAttributes(
+		attributes,
+		'padding',
+		false,
+		prefix,
+		false,
+		applyStyleCardDefaults
+	);
+
+	return (
+		<>
+			{!disableMargin && (
+				<MarginControl
+					{...marginAttributes}
+					prefix={prefix}
+					onChange={obj => maxiSetAttributes(obj)}
+					breakpoint={breakpoint}
+					fullWidth={fullWidth}
+					noResponsiveTabs
+				/>
+			)}
+			{!disableMargin && <hr />}
+			<PaddingControl
+				{...paddingAttributes}
 				prefix={prefix}
 				onChange={obj => maxiSetAttributes(obj)}
 				breakpoint={breakpoint}
-				fullWidth={fullWidth}
 				noResponsiveTabs
 			/>
-		)}
-		{!disableMargin && <hr />}
-		<PaddingControl
-			{...getGroupAttributes(attributes, 'padding', false, prefix)}
-			prefix={prefix}
-			onChange={obj => maxiSetAttributes(obj)}
-			breakpoint={breakpoint}
-			noResponsiveTabs
-		/>
-	</>
-);
+		</>
+	);
+};
 
 /**
  * Component
@@ -53,12 +74,24 @@ const marginPadding = ({
 	customLabel,
 	disableMargin = false,
 }) => {
-	const { attributes, deviceType, maxiSetAttributes } = props;
+	const { attributes, deviceType, maxiSetAttributes, name } = props;
+	const applyStyleCardDefaults = shouldApplySCBlockDefaultsToControl({
+		name,
+		attributes,
+		prefix,
+	});
 
 	const fullWidth = getLastBreakpointAttribute({
 		target: `${prefix}full-width`,
 		breakpoint: deviceType,
-		attributes,
+		attributes: getGroupAttributes(
+			attributes,
+			'size',
+			false,
+			prefix,
+			false,
+			applyStyleCardDefaults
+		),
 	});
 
 	return {
@@ -71,6 +104,7 @@ const marginPadding = ({
 					prefix={prefix}
 					disableMargin={disableMargin}
 					fullWidth={fullWidth}
+					applyStyleCardDefaults={applyStyleCardDefaults}
 				/>
 			</ResponsiveTabsControl>
 		),

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -45,6 +45,9 @@ const size = ({
 			<FullSizeControl
 				{...getGroupAttributes(attributes, 'size', false, prefix)}
 				prefix={prefix}
+				scBlockDefaultsExcludedAttributes={
+					attributes.scBlockDefaultsExcludedAttributes
+				}
 				onChange={obj => maxiSetAttributes(obj)}
 				breakpoint={deviceType}
 				hideHeight={hideHeight}
@@ -58,9 +61,7 @@ const size = ({
 				isImage={isImage}
 			/>
 		),
-		extraIndicators: [
-			isFirstOnHierarchy ? 'blockFullWidth' : 'fullWidth',
-		],
+		extraIndicators: [isFirstOnHierarchy ? 'blockFullWidth' : 'fullWidth'],
 	};
 };
 

--- a/src/components/inspector-tabs/inspector-size.js
+++ b/src/components/inspector-tabs/inspector-size.js
@@ -11,6 +11,7 @@ import {
 	getGroupAttributes,
 	getLastBreakpointAttribute,
 } from '@extensions/styles';
+import { shouldApplySCBlockDefaultsToControl } from '@extensions/style-cards/blockDefaults';
 
 /**
  * Component
@@ -28,11 +29,24 @@ const size = ({
 }) => {
 	const { attributes, deviceType, maxiSetAttributes, name } = props;
 	const { isFirstOnHierarchy } = attributes;
+	const applyStyleCardDefaults = shouldApplySCBlockDefaultsToControl({
+		name,
+		attributes,
+		prefix,
+	});
+	const sizeAttributes = getGroupAttributes(
+		attributes,
+		'size',
+		false,
+		prefix,
+		false,
+		applyStyleCardDefaults
+	);
 
 	const isBlockFullWidth = getLastBreakpointAttribute({
 		target: `${prefix}full-width`,
 		breakpoint: deviceType,
-		attributes,
+		attributes: sizeAttributes,
 	});
 
 	const showFullWidth =
@@ -43,7 +57,7 @@ const size = ({
 		label: __('Height / Width', 'maxi-blocks'),
 		content: (
 			<FullSizeControl
-				{...getGroupAttributes(attributes, 'size', false, prefix)}
+				{...sizeAttributes}
 				prefix={prefix}
 				scBlockDefaultsExcludedAttributes={
 					attributes.scBlockDefaultsExcludedAttributes

--- a/src/editor/library/container.js
+++ b/src/editor/library/container.js
@@ -11,6 +11,10 @@ import { CheckboxControl } from '@wordpress/components';
  * Internal dependencies
  */
 import { updateSCOnEditor } from '@extensions/style-cards';
+import {
+	DARK_TONE_STYLE_OVERRIDES,
+	SYNC_STYLE_SETTINGS_TONES_STATUS,
+} from '@extensions/style-cards/syncTypography';
 import { svgAttributesReplacer, isSVGColorLight, fitSvg } from './util';
 import { injectImgSVG } from '@extensions/svg';
 import MasonryItem from './MasonryItem';
@@ -802,6 +806,8 @@ const LibraryContainer = props => {
 
 		const defaultSCvalues = {
 			gutenberg_blocks_status: true,
+			[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+			[DARK_TONE_STYLE_OVERRIDES]: [],
 			dark: {
 				defaultStyleCard: {
 					link: {
@@ -1424,11 +1430,11 @@ const LibraryContainer = props => {
 									className='maxi-cloud-container__content-svg-shape__categories'
 									attribute='svg_category'
 									defaultRefinement={
-									type === 'navigation-icon' &&
-									prefix.includes('dot')
-										? 'Shape'
-										: 'Line'
-								}
+										type === 'navigation-icon' &&
+										prefix.includes('dot')
+											? 'Shape'
+											: 'Line'
+									}
 									translations={{
 										seeAllOption: __(
 											'All icons',

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -205,6 +205,114 @@ $breakpoints: (
 	display: flex;
 }
 
+.maxi-style-cards-global-tabs {
+	> .maxi-tabs-control {
+		.maxi-tabs-control__button {
+			padding: 10px 8px;
+		}
+	}
+}
+
+.maxi-style-cards__sync-style-settings {
+	display: block;
+	margin: 0;
+	padding: 8px 0 10px;
+
+	.maxi-base-control__field {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		width: 100%;
+	}
+
+	.maxi-base-control__label {
+		flex: 1;
+		margin: 0;
+		line-height: 1.35;
+		white-space: normal;
+	}
+
+	.maxi-toggle-switch__toggle {
+		flex: 0 0 44px;
+	}
+
+	.maxi-base-control__help {
+		margin: 4px 0 0;
+		color: $grey-dark;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+}
+
+.maxi-style-cards__dark-tone-overrides {
+	clear: both;
+	margin-top: 10px;
+	padding-top: 10px;
+	border-top: $border-style;
+
+	.maxi-style-cards__dark-tone-overrides-toggle {
+		display: block;
+		width: 100%;
+		margin: 0;
+
+		.maxi-base-control__field {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 12px;
+			width: 100%;
+		}
+
+		.maxi-base-control__label {
+			flex: 1;
+			margin: 0;
+			line-height: 1.35;
+			white-space: normal;
+		}
+
+		.maxi-toggle-switch__toggle {
+			flex: 0 0 44px;
+		}
+	}
+
+	.maxi-base-control__help {
+		margin: 4px 0 0;
+		color: $grey-dark;
+		font-size: 12px;
+		line-height: 1.4;
+	}
+}
+
+.maxi-style-cards__dark-tone-overrides-content {
+	padding-top: 8px;
+}
+
+.maxi-style-cards-block-default-tabs {
+	> .maxi-tabs-control {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		padding: 8px 0;
+
+		.maxi-tabs-control__button {
+			flex: 1 1 calc(50% - 4px);
+			min-width: calc(50% - 4px);
+			min-height: 34px;
+			padding: 7px 6px;
+			border: 1.5px solid var(--maxi-grey-light) !important;
+			border-radius: 5px;
+			font-size: 12px;
+			line-height: 1.2;
+			white-space: normal;
+		}
+	}
+
+	> .maxi-tabs-content {
+		padding: 0;
+	}
+}
+
 .maxi-style-cards__settings {
 	padding: 0;
 

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -213,10 +213,19 @@ $breakpoints: (
 	}
 }
 
+.maxi-style-cards__sync-style-settings-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 0 10px;
+}
+
 .maxi-style-cards__sync-style-settings {
 	display: block;
+	flex: 1 1 auto;
+	min-width: 0;
 	margin: 0;
-	padding: 8px 0 10px;
+	padding: 0;
 
 	.maxi-base-control__field {
 		display: flex;
@@ -236,13 +245,26 @@ $breakpoints: (
 	.maxi-toggle-switch__toggle {
 		flex: 0 0 44px;
 	}
+}
 
-	.maxi-base-control__help {
-		margin: 4px 0 0;
-		color: $grey-dark;
-		font-size: 12px;
-		line-height: 1.4;
-	}
+.maxi-style-cards__sync-style-settings-info-button.block-info-icon {
+	position: static;
+	flex: 0 0 16px;
+	padding: 0;
+	border: 2px solid var(--maxi-grey-light);
+	background: var(--maxi-white);
+	color: $grey-dark;
+}
+
+.maxi-style-cards__sync-style-settings-help {
+	margin: -4px 0 8px;
+	padding: 8px;
+	border: $border-style;
+	background: var(--maxi-white);
+	color: $grey-dark;
+	font-size: 12px;
+	font-style: italic;
+	line-height: 1.4;
 }
 
 .maxi-style-cards__dark-tone-overrides {
@@ -286,6 +308,44 @@ $breakpoints: (
 
 .maxi-style-cards__dark-tone-overrides-content {
 	padding-top: 8px;
+}
+
+.maxi-style-cards-advanced-globals {
+	.maxi-style-cards-advanced-globals__blocks,
+	.maxi-style-cards-advanced-globals__sections {
+		margin: 0;
+	}
+
+	.maxi-style-cards-advanced-globals__blocks {
+		border-top: $border-style;
+	}
+
+	.maxi-style-cards-advanced-globals__blocks,
+	.maxi-style-cards-advanced-globals__sections {
+
+		> .maxi-accordion-control__item {
+			> .maxi-accordion-tab
+				> .maxi-accordion-control__item__button {
+				border-top: 0 !important;
+			}
+
+			+ .maxi-accordion-control__item {
+				> .maxi-accordion-tab
+					> .maxi-accordion-control__item__button {
+					border-top: $border-style !important;
+				}
+			}
+
+			> .maxi-accordion-control__item__panel:not([hidden]) {
+				padding: 0 8px 8px;
+				border-top: $border-style;
+			}
+		}
+	}
+
+	.maxi-style-cards-advanced-globals__sections {
+		margin-bottom: 8px;
+	}
 }
 
 .maxi-style-cards__settings {

--- a/src/editor/style-cards/editor.scss
+++ b/src/editor/style-cards/editor.scss
@@ -288,31 +288,6 @@ $breakpoints: (
 	padding-top: 8px;
 }
 
-.maxi-style-cards-block-default-tabs {
-	> .maxi-tabs-control {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 4px;
-		padding: 8px 0;
-
-		.maxi-tabs-control__button {
-			flex: 1 1 calc(50% - 4px);
-			min-width: calc(50% - 4px);
-			min-height: 34px;
-			padding: 7px 6px;
-			border: 1.5px solid var(--maxi-grey-light) !important;
-			border-radius: 5px;
-			font-size: 12px;
-			line-height: 1.2;
-			white-space: normal;
-		}
-	}
-
-	> .maxi-tabs-content {
-		padding: 0;
-	}
-}
-
 .maxi-style-cards__settings {
 	padding: 0;
 

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -341,7 +341,9 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 		const toneKeys = getStyleCardToneKeysForChange({
 			currentSCStyle: activeSCStyle,
 			forceToneOnly: options.forceToneOnly,
+			forceSyncedTones: options.forceSyncedTones,
 			type,
+			group: options.group,
 			styleCard: selectedSCValue,
 		});
 
@@ -377,8 +379,31 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 				...newSC,
 			},
 		};
+		const getBlockDefaultsSummary = tone =>
+			Object.entries(newSC?.[tone]?.styleCard?.blockDefaults ?? {})
+				.filter(
+					([key]) =>
+						!options.group || key.startsWith(`${options.group}|`)
+				)
+				.slice(0, 40)
+				.map(([key, value]) => `${key}=${value}`);
+
 		debugSCBlockDefaults('editor onChangeValue result', {
 			type,
+			activeSCStyle,
+			toneKeys,
+			group: options.group,
+			changedKeys: Object.keys(newObj),
+			toneBlockDefaultSummary:
+				type === BLOCK_DEFAULTS_GROUP
+					? toneKeys.reduce(
+							(acc, tone) => ({
+								...acc,
+								[tone]: getBlockDefaultsSummary(tone),
+							}),
+							{}
+					  )
+					: undefined,
 			newObj,
 			styleCardBlockDefaults:
 				newSC?.[activeSCStyle]?.styleCard?.blockDefaults,

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -23,10 +23,25 @@ import Icon from '@components/icon';
 import SettingTabsControl from '@components/setting-tabs-control';
 import ToggleSwitch from '@components/toggle-switch';
 import ReactSelectControl from '@components/react-select-control';
-import MaxiStyleCardsTab from './maxiStyleCardsTab';
+import MaxiStyleCardsTab, {
+	MaxiStyleCardsAdvancedTab,
+} from './maxiStyleCardsTab';
 import MaxiModal from '@editor/library/modal';
 import { exportStyleCard, getActiveColourFromSC } from './utils';
 import { updateSCOnEditor } from '@extensions/style-cards';
+import {
+	BLOCK_DEFAULTS_GROUP,
+	debugSCBlockDefaults,
+	SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+} from '@extensions/style-cards/blockDefaults';
+import {
+	DARK_TONE_STYLE_OVERRIDES,
+	SYNC_STYLE_SETTINGS_TONES_STATUS,
+	applyStyleCardTypeChange,
+	getDarkToneStyleOverridesUpdate,
+	getStyleCardToneKeysForChange,
+	isStyleSettingsSyncEnabled,
+} from '@extensions/style-cards/syncTypography';
 import { clearCSSVariableCache } from '@extensions/style-cards/getPaletteColor';
 import { handleSetAttributes } from '@extensions/maxi-block';
 import standardSC from '@maxi-core/defaults/defaultSC.json';
@@ -169,7 +184,7 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 	const [styleCardName, setStyleCardName] = useState(
 		`${activeSCValue?.name} - `
 	);
-	const [currentSCStyle, setCurrentSCStyle] = useState('light');
+	const [currentSCStyle] = useState('light');
 
 	const getIsUserCreatedStyleCard = (card = selectedSCValue) => {
 		return card?.type === 'user';
@@ -240,11 +255,24 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 		const gutenbergStatusChanged =
 			styleCards[keySC]?.gutenberg_blocks_status !==
 			savedStyleCards[keySC]?.gutenberg_blocks_status;
+		const styleSettingsSyncChanged =
+			isStyleSettingsSyncEnabled(styleCards[keySC]) !==
+			isStyleSettingsSyncEnabled(savedStyleCards[keySC]);
+		const darkToneOverridesChanged = !isEqual(
+			styleCards[keySC]?.[DARK_TONE_STYLE_OVERRIDES] ?? [],
+			savedStyleCards[keySC]?.[DARK_TONE_STYLE_OVERRIDES] ?? []
+		);
 
 		// Use general objects comparison for other changes
 		const otherChanges = !isEqual(currentSC, savedSC);
 
-		return customColorsChanged || otherChanges || gutenbergStatusChanged;
+		return (
+			customColorsChanged ||
+			otherChanges ||
+			gutenbergStatusChanged ||
+			styleSettingsSyncChanged ||
+			darkToneOverridesChanged
+		);
 	};
 
 	const canBeApplied = (keySC, activeSCKey) => {
@@ -259,7 +287,16 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 		return true;
 	};
 
-	const onChangeValue = (obj, type) => {
+	const onChangeValue = (obj, type, options = {}) => {
+		const activeSCStyle = options.SCStyle ?? currentSCStyle;
+		debugSCBlockDefaults('editor onChangeValue start', {
+			type,
+			obj,
+			currentSCStyle: activeSCStyle,
+			selectedSCKey,
+			options,
+		});
+
 		let newSC = { ...selectedSCValue };
 		// Special case for customColors
 		if (type === 'color' && 'customColors' in obj) {
@@ -301,42 +338,37 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 		}
 
 		const isTypography = Object.keys(obj)[0] === 'typography';
+		const toneKeys = getStyleCardToneKeysForChange({
+			currentSCStyle: activeSCStyle,
+			forceToneOnly: options.forceToneOnly,
+			type,
+			styleCard: selectedSCValue,
+		});
 
 		const newObj = handleSetAttributes({
 			obj: isTypography ? obj.typography : obj,
 			attributes: {
-				...(selectedSCValue[currentSCStyle].defaultStyleCard[type] ??
+				...(selectedSCValue[activeSCStyle].defaultStyleCard[type] ??
 					{}),
-				...(selectedSCValue[currentSCStyle].styleCard[type] ?? {}),
+				...(selectedSCValue[activeSCStyle].styleCard[type] ?? {}),
 			},
 			defaultAttributes:
-				selectedSCValue[currentSCStyle].defaultStyleCard[type] ?? {},
+				selectedSCValue[activeSCStyle].defaultStyleCard[type] ?? {},
 			onChange: response => response,
 			isStyleCard: true,
 		});
 
 		Object.entries(newObj).forEach(([prop, value]) => {
-			if (isTypography) {
-				if (isNil(value)) {
-					delete selectedSCValue[currentSCStyle].styleCard?.[type]?.[
-						prop
-					];
-				}
-			}
-
-			newSC = {
-				...newSC,
-				[currentSCStyle]: {
-					...newSC[currentSCStyle],
-					styleCard: {
-						...newSC[currentSCStyle].styleCard,
-						[type]: {
-							...(newSC[currentSCStyle].styleCard[type] ?? {}),
-							[prop]: value,
-						},
-					},
-				},
-			};
+			toneKeys.forEach(tone => {
+				newSC = applyStyleCardTypeChange({
+					styleCard: newSC,
+					tone,
+					type,
+					prop,
+					value,
+					shouldDeleteNilValue: isTypography && isNil(value),
+				});
+			});
 		});
 
 		const newStyleCards = {
@@ -345,8 +377,35 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 				...newSC,
 			},
 		};
+		debugSCBlockDefaults('editor onChangeValue result', {
+			type,
+			newObj,
+			styleCardBlockDefaults:
+				newSC?.[activeSCStyle]?.styleCard?.blockDefaults,
+			defaultBlockDefaults:
+				newSC?.[activeSCStyle]?.defaultStyleCard?.blockDefaults,
+		});
 		saveMaxiStyleCards(newStyleCards);
 		updateSCOnEditor(newSC, activeSCColour);
+
+		if (type === BLOCK_DEFAULTS_GROUP) {
+			const blockDefaults =
+				newSC?.[activeSCStyle]?.styleCard?.blockDefaults ?? {};
+
+			debugSCBlockDefaults('editor dispatch block defaults update', {
+				currentSCStyle: activeSCStyle,
+				blockDefaults,
+			});
+
+			window.dispatchEvent(
+				new CustomEvent(SC_BLOCK_DEFAULTS_UPDATE_EVENT, {
+					detail: {
+						blockDefaults,
+						currentSCStyle: activeSCStyle,
+					},
+				})
+			);
+		}
 	};
 
 	const [postDate] = useState();
@@ -541,6 +600,36 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 			[selectedSCKey]: {
 				...selectedSCValue,
 				gutenberg_blocks_status: value,
+			},
+		};
+
+		saveMaxiStyleCards(newStyleCards);
+		updateSCOnEditor(newStyleCards[selectedSCKey], activeSCColour);
+	};
+
+	const onChangeStyleSettingsSyncStatus = value => {
+		const newStyleCards = {
+			...styleCards,
+			[selectedSCKey]: {
+				...selectedSCValue,
+				[SYNC_STYLE_SETTINGS_TONES_STATUS]: value,
+			},
+		};
+
+		saveMaxiStyleCards(newStyleCards);
+		updateSCOnEditor(newStyleCards[selectedSCKey], activeSCColour);
+	};
+
+	const onChangeDarkToneOverride = (group, value) => {
+		const newStyleCards = {
+			...styleCards,
+			[selectedSCKey]: {
+				...selectedSCValue,
+				...getDarkToneStyleOverridesUpdate({
+					styleCard: selectedSCValue,
+					group,
+					enabled: value,
+				}),
 			},
 		};
 
@@ -965,6 +1054,15 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 													selectedSCValue
 														? selectedSCValue.gutenberg_blocks_status
 														: true,
+												[SYNC_STYLE_SETTINGS_TONES_STATUS]:
+													isStyleSettingsSyncEnabled(
+														selectedSCValue
+													),
+												[DARK_TONE_STYLE_OVERRIDES]: [
+													...(selectedSCValue?.[
+														DARK_TONE_STYLE_OVERRIDES
+													] ?? []),
+												],
 												dark: {
 													defaultStyleCard: {
 														...(selectedSCValue.dark
@@ -1038,38 +1136,43 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 						}
 					>
 						<SettingTabsControl
+							className='maxi-style-cards-global-tabs'
 							disablePadding
-							returnValue={({ key }) => setCurrentSCStyle(key)}
 							items={[
 								{
-									label: __(
-										'Light tone globals',
-										'maxi-blocks'
-									),
-									key: 'light',
+									label: __('Tone globals', 'maxi-blocks'),
+									key: 'tone-globals',
 									content: (
 										<MaxiStyleCardsTab
-											SC={selectedSCValue.light}
-											SCStyle='light'
+											styleCard={selectedSCValue}
 											onChangeValue={onChangeValue}
 											breakpoint={breakpoint}
-											currentKey={selectedSCKey}
+											onChangeDarkToneOverride={
+												onChangeDarkToneOverride
+											}
+											isStyleSettingsSyncSelected={isStyleSettingsSyncEnabled(
+												selectedSCValue
+											)}
+											onChangeStyleSettingsSyncStatus={
+												onChangeStyleSettingsSyncStatus
+											}
 										/>
 									),
 								},
 								{
 									label: __(
-										'Dark tone globals',
+										'Advanced globals',
 										'maxi-blocks'
 									),
-									key: 'dark',
+									key: 'advanced-globals',
 									content: (
-										<MaxiStyleCardsTab
-											SC={selectedSCValue.dark}
-											SCStyle='dark'
-											onChangeValue={onChangeValue}
+										<MaxiStyleCardsAdvancedTab
+											styleCard={selectedSCValue}
 											breakpoint={breakpoint}
-											currentKey={selectedSCKey}
+											onChangeValue={onChangeValue}
+											onChangeDarkToneOverride={
+												onChangeDarkToneOverride
+											}
 										/>
 									),
 								},

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -32,7 +32,8 @@ import { updateSCOnEditor } from '@extensions/style-cards';
 import {
 	BLOCK_DEFAULTS_GROUP,
 	debugSCBlockDefaults,
-	SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+	dispatchSCBlockDefaultsUpdate,
+	getLayoutDebugValueSummary,
 } from '@extensions/style-cards/blockDefaults';
 import {
 	DARK_TONE_STYLE_OVERRIDES,
@@ -394,6 +395,10 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 			toneKeys,
 			group: options.group,
 			changedKeys: Object.keys(newObj),
+			changedLayoutSummary:
+				type === BLOCK_DEFAULTS_GROUP
+					? getLayoutDebugValueSummary(newObj, options.group)
+					: undefined,
 			toneBlockDefaultSummary:
 				type === BLOCK_DEFAULTS_GROUP
 					? toneKeys.reduce(
@@ -419,17 +424,17 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 
 			debugSCBlockDefaults('editor dispatch block defaults update', {
 				currentSCStyle: activeSCStyle,
+				blockDefaultsSummary: getLayoutDebugValueSummary(
+					blockDefaults,
+					options.group
+				),
 				blockDefaults,
 			});
 
-			window.dispatchEvent(
-				new CustomEvent(SC_BLOCK_DEFAULTS_UPDATE_EVENT, {
-					detail: {
-						blockDefaults,
-						currentSCStyle: activeSCStyle,
-					},
-				})
-			);
+			dispatchSCBlockDefaultsUpdate({
+				blockDefaults,
+				currentSCStyle: activeSCStyle,
+			});
 		}
 	};
 

--- a/src/editor/style-cards/maxiStyleCardsEditor.js
+++ b/src/editor/style-cards/maxiStyleCardsEditor.js
@@ -305,11 +305,12 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 		const newObj = handleSetAttributes({
 			obj: isTypography ? obj.typography : obj,
 			attributes: {
-				...selectedSCValue[currentSCStyle].defaultStyleCard[type],
-				...selectedSCValue[currentSCStyle].styleCard[type],
+				...(selectedSCValue[currentSCStyle].defaultStyleCard[type] ??
+					{}),
+				...(selectedSCValue[currentSCStyle].styleCard[type] ?? {}),
 			},
 			defaultAttributes:
-				selectedSCValue[currentSCStyle].defaultStyleCard[type],
+				selectedSCValue[currentSCStyle].defaultStyleCard[type] ?? {},
 			onChange: response => response,
 			isStyleCard: true,
 		});
@@ -330,7 +331,7 @@ const MaxiStyleCardsEditor = forwardRef(({ styleCards, setIsVisible }, ref) => {
 					styleCard: {
 						...newSC[currentSCStyle].styleCard,
 						[type]: {
-							...newSC[currentSCStyle].styleCard[type],
+							...(newSC[currentSCStyle].styleCard[type] ?? {}),
 							[prop]: value,
 						},
 					},

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -22,6 +22,7 @@ import TypographyControl from '@components/typography-control';
 import ToggleSwitch from '@components/toggle-switch';
 import AdvancedNumberControl from '@components/advanced-number-control';
 import PaddingControl from '@components/padding-control';
+import SelectControl from '@components/select-control';
 import { getStandardPaletteColorLabel } from '@components/color-control/utils';
 import handleDeletedCustomColor from '@extensions/style-cards/customColorsUtils';
 import {
@@ -35,6 +36,12 @@ import {
 	getTypographyFromSC,
 } from '@extensions/style-cards';
 import getDefaultSCAttribute from './getDefaultSCAttribute';
+import {
+	blockDefaultBlocks,
+	BLOCK_DEFAULTS_GROUP,
+	getBlockDefaultKey,
+	getShippedBlockDefault,
+} from '@extensions/style-cards/blockDefaults';
 
 /**
  * Icons
@@ -412,6 +419,122 @@ const SCAccordion = props => {
 					)}
 				</>
 			)}
+		</>
+	);
+};
+
+const formatBlockLabel = blockName =>
+	blockName
+		.replace('-maxi', '')
+		.split('-')
+		.map(part => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+
+const blockDefaultSizeControls = [
+	{
+		label: __('Max width', 'maxi-blocks'),
+		target: 'max-width',
+	},
+	{
+		label: __('Width', 'maxi-blocks'),
+		target: 'width',
+	},
+	{
+		label: __('Min width', 'maxi-blocks'),
+		target: 'min-width',
+	},
+	{
+		label: __('Max height', 'maxi-blocks'),
+		target: 'max-height',
+	},
+	{
+		label: __('Height', 'maxi-blocks'),
+		target: 'height',
+	},
+	{
+		label: __('Min height', 'maxi-blocks'),
+		target: 'min-height',
+	},
+];
+
+const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => {
+	const [selectedBlock, setSelectedBlock] = useState('row-maxi');
+
+	const getAttr = target => `${target}-${breakpoint}`;
+	const getUnitAttr = target => `${target}-unit-${breakpoint}`;
+	const getSCAttr = attr =>
+		processSCAttribute(
+			SC,
+			getBlockDefaultKey(selectedBlock, attr),
+			BLOCK_DEFAULTS_GROUP
+		);
+	const getDefaultValue = attr =>
+		getShippedBlockDefault(selectedBlock, attr, '');
+	const getDefaultUnit = attr =>
+		getShippedBlockDefault(selectedBlock, attr, 'px');
+
+	return (
+		<>
+			<SelectControl
+				label={__('Block', 'maxi-blocks')}
+				value={selectedBlock}
+				options={blockDefaultBlocks.map(blockName => ({
+					label: formatBlockLabel(blockName),
+					value: blockName,
+				}))}
+				onChange={setSelectedBlock}
+			/>
+			{blockDefaultSizeControls.map(({ label, target }) => {
+				const attr = getAttr(target);
+				const unitAttr = getUnitAttr(target);
+				const defaultValue = getDefaultValue(attr);
+				const defaultUnit = getDefaultUnit(unitAttr);
+
+				return (
+					<AdvancedNumberControl
+						key={`${selectedBlock}-${attr}`}
+						label={label}
+						value={getSCAttr(attr) ?? defaultValue}
+						unit={getSCAttr(unitAttr) ?? defaultUnit}
+						defaultValue={defaultValue}
+						enableUnit
+						optionType='string'
+						onChangeValue={value =>
+							onChangeValue(
+								{
+									[getBlockDefaultKey(selectedBlock, attr)]:
+										value,
+								},
+								BLOCK_DEFAULTS_GROUP
+							)
+						}
+						onChangeUnit={unit =>
+							onChangeValue(
+								{
+									[getBlockDefaultKey(
+										selectedBlock,
+										unitAttr
+									)]: unit,
+								},
+								BLOCK_DEFAULTS_GROUP
+							)
+						}
+						onReset={() =>
+							onChangeValue(
+								{
+									[getBlockDefaultKey(selectedBlock, attr)]:
+										defaultValue,
+									[getBlockDefaultKey(
+										selectedBlock,
+										unitAttr
+									)]: defaultUnit,
+								},
+								BLOCK_DEFAULTS_GROUP
+							)
+						}
+					/>
+				);
+			})}
 		</>
 	);
 };
@@ -1220,6 +1343,18 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 								/>
 							),
 						},
+						{
+							label: __('Block defaults', 'maxi-blocks'),
+							classNameItem:
+								'maxi-blocks-sc__type--block-defaults',
+							content: (
+								<BlockDefaults
+									SC={SC}
+									breakpoint={breakpoint}
+									onChangeValue={onChangeValue}
+								/>
+							),
+						},
 						breakpoint === 'general' && {
 							label: linkTabs.label,
 							classNameItem: 'maxi-blocks-sc__type--link',
@@ -1241,7 +1376,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 							content: (
 								<ResponsiveTabsControl breakpoint={breakpoint}>
 									<SettingTabsControl
-										className="maxi-style-cards-headings-tabs"
+										className='maxi-style-cards-headings-tabs'
 										hasBorder
 										items={headingItems()}
 									/>

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -44,6 +44,8 @@ import {
 	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES,
 	BLOCK_DEFAULTS_GROUP,
 	debugSCBlockDefaults,
+	getLayoutDebugValueSummary,
+	getShippedBlockDefault,
 	getUnitAttribute,
 } from '@extensions/style-cards/blockDefaults';
 import { hasDarkToneStyleOverride } from '@extensions/style-cards/syncTypography';
@@ -436,6 +438,35 @@ const getBlockDefaultAttributes = (styleCard, blockName) =>
 			return acc;
 		}, {});
 
+const blockDefaultSizeControlAttrs = [
+	'size-advanced-options',
+	...[
+		'max-width',
+		'width',
+		'min-width',
+		'max-height',
+		'height',
+		'min-height',
+	].flatMap(target =>
+		['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'].flatMap(breakpoint => [
+			`${target}-${breakpoint}`,
+			`${target}-unit-${breakpoint}`,
+		])
+	),
+];
+
+const getBlockDefaultSizeAttributes = (styleCard, blockName) => ({
+	...blockDefaultSizeControlAttrs.reduce((acc, attr) => {
+		const defaultValue = getShippedBlockDefault(blockName, attr);
+
+		if (defaultValue !== '') acc[attr] = defaultValue;
+
+		return acc;
+	}, {}),
+	...getBlockDefaultAttributes(styleCard, blockName),
+	'size-advanced-options': true,
+});
+
 const BlockDefaultMarginPaddingControls = ({
 	SC,
 	blockName,
@@ -524,9 +555,11 @@ const getBlockDefaultHeightWidthItems = ({
 		label: __('Height / Width', 'maxi-blocks'),
 		content: (
 			<FullSizeControl
-				{...getBlockDefaultAttributes(SC, blockName)}
+				{...getBlockDefaultSizeAttributes(SC, blockName)}
 				onChange={onChange}
 				breakpoint={breakpoint}
+				forceSizeAdvancedOptions
+				hideSizeAdvancedOptionsToggle
 			/>
 		),
 	},
@@ -737,6 +770,10 @@ const BlockDefaultsWithOverrides = ({
 			blockName,
 			breakpoint,
 			tone: 'light',
+			layoutSummary: getLayoutDebugValueSummary(
+				prefixedValues,
+				blockName
+			),
 			values,
 			prefixedValues,
 		});
@@ -750,6 +787,10 @@ const BlockDefaultsWithOverrides = ({
 			blockName,
 			breakpoint,
 			tone: 'dark',
+			layoutSummary: getLayoutDebugValueSummary(
+				prefixedValues,
+				blockName
+			),
 			values,
 			prefixedValues,
 		});

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -1348,11 +1348,13 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 							classNameItem:
 								'maxi-blocks-sc__type--block-defaults',
 							content: (
-								<BlockDefaults
-									SC={SC}
-									breakpoint={breakpoint}
-									onChangeValue={onChangeValue}
-								/>
+								<ResponsiveTabsControl breakpoint={breakpoint}>
+									<BlockDefaults
+										SC={SC}
+										breakpoint={breakpoint}
+										onChangeValue={onChangeValue}
+									/>
+								</ResponsiveTabsControl>
 							),
 						},
 						breakpoint === 'general' && {

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -17,11 +17,15 @@ import Button from '@components/button';
 import ColorControl from '@components/color-control';
 import Icon from '@components/icon';
 import ResponsiveTabsControl from '@components/responsive-tabs-control';
+import FullSizeControl from '@components/full-size-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import TypographyControl from '@components/typography-control';
 import ToggleSwitch from '@components/toggle-switch';
-import AdvancedNumberControl from '@components/advanced-number-control';
+import MarginControl from '@components/margin-control';
 import PaddingControl from '@components/padding-control';
+import FlexGapControl from '@components/flex-settings-control/flex-gap-control';
+import FlexWrapControl from '@components/flex-settings-control/flex-wrap-control';
+import AdvancedNumberControl from '@components/advanced-number-control';
 import { getStandardPaletteColorLabel } from '@components/color-control/utils';
 import handleDeletedCustomColor from '@extensions/style-cards/customColorsUtils';
 import {
@@ -36,11 +40,11 @@ import {
 } from '@extensions/style-cards';
 import getDefaultSCAttribute from './getDefaultSCAttribute';
 import {
-	blockDefaultBlocks,
+	getBlockDefaultKey,
+	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES,
 	BLOCK_DEFAULTS_GROUP,
 	debugSCBlockDefaults,
-	getBlockDefaultKey,
-	getShippedBlockDefault,
+	getUnitAttribute,
 } from '@extensions/style-cards/blockDefaults';
 import { hasDarkToneStyleOverride } from '@extensions/style-cards/syncTypography';
 
@@ -424,137 +428,149 @@ const SCAccordion = props => {
 	);
 };
 
-const formatBlockLabel = blockName =>
-	blockName
-		.replace('-maxi', '')
-		.split('-')
-		.map(part => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(' ');
+const getBlockDefaultAttributes = (styleCard, blockName) =>
+	Object.entries(processSCAttributes(styleCard, '', BLOCK_DEFAULTS_GROUP))
+		.filter(([key]) => key.startsWith(`${blockName}|`))
+		.reduce((acc, [key, value]) => {
+			acc[key.replace(`${blockName}|`, '')] = value;
+			return acc;
+		}, {});
 
-const blockDefaultSizeControls = [
-	{
-		label: __('Max width', 'maxi-blocks'),
-		target: 'max-width',
-	},
-	{
-		label: __('Width', 'maxi-blocks'),
-		target: 'width',
-	},
-	{
-		label: __('Min width', 'maxi-blocks'),
-		target: 'min-width',
-	},
-	{
-		label: __('Max height', 'maxi-blocks'),
-		target: 'max-height',
-	},
-	{
-		label: __('Height', 'maxi-blocks'),
-		target: 'height',
-	},
-	{
-		label: __('Min height', 'maxi-blocks'),
-		target: 'min-height',
-	},
-];
-
-const BlockDefaultsControls = ({
+const BlockDefaultMarginPaddingControls = ({
 	SC,
-	breakpoint,
-	onChangeValue,
 	blockName,
+	onChange,
+	breakpoint,
 }) => {
-	const getAttr = target => `${target}-${breakpoint}`;
-	const getUnitAttr = target => `${target}-unit-${breakpoint}`;
-	const getSCAttr = attr =>
-		processSCAttribute(
-			SC,
-			getBlockDefaultKey(blockName, attr),
-			BLOCK_DEFAULTS_GROUP
-		);
-	const getDefaultValue = attr => getShippedBlockDefault(blockName, attr, '');
-	const getDefaultUnit = attr =>
-		getShippedBlockDefault(blockName, attr, 'px');
-	const updateBlockDefault = (attr, value) => {
-		debugSCBlockDefaults('control change', {
-			blockName,
-			breakpoint,
-			attr,
-			value,
-		});
-		onChangeValue(
-			{
-				[getBlockDefaultKey(blockName, attr)]: value,
-			},
-			BLOCK_DEFAULTS_GROUP
-		);
-	};
+	const defaultAttrs = getBlockDefaultAttributes(SC, blockName);
 
 	return (
 		<>
-			{blockDefaultSizeControls.map(({ label, target }) => {
-				const attr = getAttr(target);
-				const unitAttr = getUnitAttr(target);
-				const defaultValue = getDefaultValue(attr);
-				const defaultUnit = getDefaultUnit(unitAttr);
-
-				return (
-					<AdvancedNumberControl
-						key={`${blockName}-${attr}`}
-						label={label}
-						value={getSCAttr(attr) ?? defaultValue}
-						unit={getSCAttr(unitAttr) ?? defaultUnit}
-						defaultValue={defaultValue}
-						enableUnit
-						optionType='string'
-						onChangeValue={value => updateBlockDefault(attr, value)}
-						onChangeUnit={unit =>
-							updateBlockDefault(unitAttr, unit)
-						}
-						onReset={() => {
-							debugSCBlockDefaults('control reset', {
-								blockName,
-								breakpoint,
-								attr,
-								unitAttr,
-								defaultValue,
-								defaultUnit,
-							});
-							onChangeValue(
-								{
-									[getBlockDefaultKey(blockName, attr)]:
-										defaultValue,
-									[getBlockDefaultKey(blockName, unitAttr)]:
-										defaultUnit,
-								},
-								BLOCK_DEFAULTS_GROUP
-							);
-						}}
-					/>
-				);
-			})}
+			<MarginControl
+				{...defaultAttrs}
+				onChange={onChange}
+				breakpoint={breakpoint}
+				noResponsiveTabs
+			/>
+			<hr />
+			<PaddingControl
+				{...defaultAttrs}
+				onChange={onChange}
+				breakpoint={breakpoint}
+				noResponsiveTabs
+			/>
 		</>
 	);
 };
 
-export const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => (
-	<SettingTabsControl
-		disablePadding
-		className='maxi-style-cards-advanced-globals-tabs'
-		items={blockDefaultBlocks.map(blockName => ({
-			label: formatBlockLabel(blockName),
-			key: blockName,
-			content: (
-				<BlockDefaultsControls
+const BlockDefaultRowSpacingControls = ({
+	SC,
+	blockName,
+	onChange,
+	breakpoint,
+}) => {
+	const defaultAttrs = getBlockDefaultAttributes(SC, blockName);
+
+	return (
+		<>
+			<FlexGapControl
+				{...defaultAttrs}
+				onChange={onChange}
+				breakpoint={breakpoint}
+			/>
+			<FlexWrapControl
+				{...defaultAttrs}
+				onChange={onChange}
+				breakpoint={breakpoint}
+			/>
+		</>
+	);
+};
+
+const addBlockDefaultPrefix = (blockName, values) => {
+	const inlineUnit = values?.meta?.inline?.unit;
+
+	return Object.entries(values).reduce((acc, [key, value]) => {
+		if (
+			key === 'meta' ||
+			key === 'isReset' ||
+			key === SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES
+		) {
+			return acc;
+		}
+
+		acc[getBlockDefaultKey(blockName, key)] = value;
+
+		const unitAttribute = inlineUnit ? getUnitAttribute(key) : null;
+
+		if (
+			unitAttribute &&
+			!Object.prototype.hasOwnProperty.call(values, unitAttribute)
+		) {
+			acc[getBlockDefaultKey(blockName, unitAttribute)] = inlineUnit;
+		}
+
+		return acc;
+	}, {});
+};
+
+const getBlockDefaultHeightWidthItems = ({
+	blockName,
+	SC,
+	breakpoint,
+	onChange,
+}) => [
+	{
+		label: __('Height / Width', 'maxi-blocks'),
+		content: (
+			<FullSizeControl
+				{...getBlockDefaultAttributes(SC, blockName)}
+				onChange={onChange}
+				breakpoint={breakpoint}
+			/>
+		),
+	},
+	{
+		label: __('Margin / Padding', 'maxi-blocks'),
+		content: (
+			<ResponsiveTabsControl breakpoint={breakpoint}>
+				<BlockDefaultMarginPaddingControls
 					SC={SC}
-					breakpoint={breakpoint}
-					onChangeValue={onChangeValue}
 					blockName={blockName}
+					onChange={onChange}
+					breakpoint={breakpoint}
 				/>
-			),
-		}))}
-	/>
-);
+			</ResponsiveTabsControl>
+		),
+	},
+];
+
+const getRowLayoutItems = ({
+	blockName,
+	SC,
+	breakpoint,
+	onChange,
+}) => [
+	...getBlockDefaultHeightWidthItems({
+		blockName,
+		SC,
+		breakpoint,
+		onChange,
+	}),
+	{
+		label: __('Row spacing', 'maxi-blocks'),
+		content: (
+			<ResponsiveTabsControl breakpoint={breakpoint}>
+				<BlockDefaultRowSpacingControls
+					SC={SC}
+					blockName={blockName}
+					onChange={onChange}
+					breakpoint={breakpoint}
+				/>
+			</ResponsiveTabsControl>
+		),
+	},
+];
 
 const ColourPaletteControls = ({
 	SC,
@@ -696,42 +712,89 @@ export const DarkToneOverrides = ({ enabled, onChange, children }) => (
 const BlockDefaultsWithOverrides = ({
 	styleCard,
 	breakpoint,
+	blockName,
 	onChangeValue,
 	onChangeDarkToneOverride,
+	showDarkToneOverrides = false,
 }) => {
 	const lightSC = styleCard?.light;
-	const darkSC = styleCard?.dark;
-	const isDarkOverrideEnabled = hasDarkToneStyleOverride(
-		styleCard,
-		BLOCK_DEFAULTS_GROUP
-	);
 	const lightOnChangeValue = (obj, type) =>
-		onChangeValue(obj, type, { SCStyle: 'light' });
+		onChangeValue(obj, type, {
+			SCStyle: 'light',
+			group: blockName,
+			forceSyncedTones: !showDarkToneOverrides,
+		});
 	const darkOnChangeValue = (obj, type) =>
 		onChangeValue(obj, type, {
 			SCStyle: 'dark',
+			group: blockName,
 			forceToneOnly: true,
 		});
+	const lightOnChange = values => {
+		const prefixedValues = addBlockDefaultPrefix(blockName, values);
+
+		debugSCBlockDefaults('advanced globals change', {
+			blockName,
+			breakpoint,
+			tone: 'light',
+			values,
+			prefixedValues,
+		});
+
+		lightOnChangeValue(prefixedValues, BLOCK_DEFAULTS_GROUP);
+	};
+	const darkOnChange = values => {
+		const prefixedValues = addBlockDefaultPrefix(blockName, values);
+
+		debugSCBlockDefaults('advanced globals change', {
+			blockName,
+			breakpoint,
+			tone: 'dark',
+			values,
+			prefixedValues,
+		});
+
+		darkOnChangeValue(prefixedValues, BLOCK_DEFAULTS_GROUP);
+	};
+	const getControls = (currentSC, onChangeHandler) => {
+		const controlProps = {
+			blockName,
+			SC: currentSC,
+			breakpoint,
+			onChange: onChangeHandler,
+		};
+
+		return blockName === 'row-maxi'
+			? getRowLayoutItems(controlProps)
+			: getBlockDefaultHeightWidthItems(controlProps);
+	};
 
 	return (
 		<>
-			<BlockDefaults
-				SC={lightSC}
-				breakpoint={breakpoint}
-				onChangeValue={lightOnChangeValue}
+			<AccordionControl
+				className='maxi-style-cards-advanced-globals__sections'
+				isSecondary
+				isStyleCard
+				items={getControls(lightSC, lightOnChange)}
 			/>
-			<DarkToneOverrides
-				enabled={isDarkOverrideEnabled}
-				onChange={value =>
-					onChangeDarkToneOverride(BLOCK_DEFAULTS_GROUP, value)
-				}
-			>
-				<BlockDefaults
-					SC={darkSC}
-					breakpoint={breakpoint}
-					onChangeValue={darkOnChangeValue}
-				/>
-			</DarkToneOverrides>
+			{showDarkToneOverrides && (
+				<DarkToneOverrides
+					enabled={hasDarkToneStyleOverride(
+						styleCard,
+						blockName
+					)}
+					onChange={value =>
+						onChangeDarkToneOverride(blockName, value)
+					}
+				>
+					<AccordionControl
+						className='maxi-style-cards-advanced-globals__sections'
+						isSecondary
+						isStyleCard
+						items={getControls(styleCard?.dark, darkOnChange)}
+					/>
+				</DarkToneOverrides>
+			)}
 		</>
 	);
 };
@@ -741,33 +804,45 @@ export const MaxiStyleCardsAdvancedTab = ({
 	breakpoint,
 	onChangeValue,
 	onChangeDarkToneOverride,
-}) => (
-	<div className='maxi-tab-content__box maxi-style-cards-advanced-globals'>
-		<AccordionControl
-			key='sc-accordion__advanced-block-defaults'
-			isSecondary
-			isStyleCard
-			items={[
-				{
-					label: __('Block defaults', 'maxi-blocks'),
-					classNameItem: 'maxi-blocks-sc__type--block-defaults',
-					content: (
-						<ResponsiveTabsControl breakpoint={breakpoint}>
-							<BlockDefaultsWithOverrides
-								styleCard={styleCard}
-								breakpoint={breakpoint}
-								onChangeValue={onChangeValue}
-								onChangeDarkToneOverride={
-									onChangeDarkToneOverride
-								}
-							/>
-						</ResponsiveTabsControl>
-					),
-				},
-			]}
-		/>
-	</div>
-);
+}) => {
+	const blockDefaultItems = [
+		{
+			label: __('Container layout', 'maxi-blocks'),
+			blockName: 'container-maxi',
+			classNameItem: 'maxi-blocks-sc__type--container',
+		},
+		{
+			label: __('Row layout', 'maxi-blocks'),
+			blockName: 'row-maxi',
+			classNameItem: 'maxi-blocks-sc__type--row',
+		},
+	].map(({ label, blockName, classNameItem }) => ({
+		label,
+		classNameItem,
+		content: (
+			<BlockDefaultsWithOverrides
+				styleCard={styleCard}
+				breakpoint={breakpoint}
+				blockName={blockName}
+				onChangeValue={onChangeValue}
+				onChangeDarkToneOverride={onChangeDarkToneOverride}
+				showDarkToneOverrides={false}
+			/>
+		),
+	}));
+
+	return (
+		<div className='maxi-tab-content__box maxi-style-cards-advanced-globals'>
+			<AccordionControl
+				className='maxi-style-cards-advanced-globals__blocks'
+				key='sc-accordion__advanced-block-defaults'
+				isSecondary
+				isStyleCard
+				items={blockDefaultItems}
+			/>
+		</div>
+	);
+};
 
 const MaxiStyleCardsTab = ({
 	styleCard,
@@ -778,8 +853,16 @@ const MaxiStyleCardsTab = ({
 	onChangeStyleSettingsSyncStatus,
 }) => {
 	const [quickColorPreset, setQuickColorPreset] = useState(1);
+	const [
+		isStyleSettingsSyncInfoVisible,
+		setIsStyleSettingsSyncInfoVisible,
+	] = useState(false);
 	const lightSC = styleCard?.light;
 	const darkSC = styleCard?.dark;
+	const styleSettingsSyncDescription = __(
+		'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.',
+		'maxi-blocks'
+	);
 	const lightOnChangeValue = (obj, type) =>
 		onChangeValue(obj, type, { SCStyle: 'light' });
 	const darkOnChangeValue = (obj, type) =>
@@ -1266,19 +1349,40 @@ const MaxiStyleCardsTab = ({
 	return (
 		<div className='maxi-tab-content__box'>
 			{onChangeStyleSettingsSyncStatus && (
-				<ToggleSwitch
-					className='maxi-style-cards__sync-style-settings'
-					label={__(
-						'Sync style settings between light and dark tones',
-						'maxi-blocks'
+				<>
+					<div className='maxi-style-cards__sync-style-settings-row'>
+						<ToggleSwitch
+							className='maxi-style-cards__sync-style-settings'
+							label={__(
+								'Sync style settings between light and dark tones',
+								'maxi-blocks'
+							)}
+							selected={isStyleSettingsSyncSelected}
+							onChange={onChangeStyleSettingsSyncStatus}
+						/>
+						<button
+							type='button'
+							className='block-info-icon maxi-style-cards__sync-style-settings-info-button'
+							aria-expanded={isStyleSettingsSyncInfoVisible}
+							aria-label={__(
+								'Show sync style settings help',
+								'maxi-blocks'
+							)}
+							onClick={() =>
+								setIsStyleSettingsSyncInfoVisible(
+									isVisible => !isVisible
+								)
+							}
+						>
+							<span className='block-info-icon-span'>i</span>
+						</button>
+					</div>
+					{isStyleSettingsSyncInfoVisible && (
+						<p className='maxi-style-cards__sync-style-settings-help'>
+							{styleSettingsSyncDescription}
+						</p>
 					)}
-					help={__(
-						'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.',
-						'maxi-blocks'
-					)}
-					selected={isStyleSettingsSyncSelected}
-					onChange={onChangeStyleSettingsSyncStatus}
-				/>
+				</>
 			)}
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -22,7 +22,6 @@ import TypographyControl from '@components/typography-control';
 import ToggleSwitch from '@components/toggle-switch';
 import AdvancedNumberControl from '@components/advanced-number-control';
 import PaddingControl from '@components/padding-control';
-import SelectControl from '@components/select-control';
 import { getStandardPaletteColorLabel } from '@components/color-control/utils';
 import handleDeletedCustomColor from '@extensions/style-cards/customColorsUtils';
 import {
@@ -39,9 +38,11 @@ import getDefaultSCAttribute from './getDefaultSCAttribute';
 import {
 	blockDefaultBlocks,
 	BLOCK_DEFAULTS_GROUP,
+	debugSCBlockDefaults,
 	getBlockDefaultKey,
 	getShippedBlockDefault,
 } from '@extensions/style-cards/blockDefaults';
+import { hasDarkToneStyleOverride } from '@extensions/style-cards/syncTypography';
 
 /**
  * Icons
@@ -457,33 +458,40 @@ const blockDefaultSizeControls = [
 	},
 ];
 
-const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => {
-	const [selectedBlock, setSelectedBlock] = useState('row-maxi');
-
+const BlockDefaultsControls = ({
+	SC,
+	breakpoint,
+	onChangeValue,
+	blockName,
+}) => {
 	const getAttr = target => `${target}-${breakpoint}`;
 	const getUnitAttr = target => `${target}-unit-${breakpoint}`;
 	const getSCAttr = attr =>
 		processSCAttribute(
 			SC,
-			getBlockDefaultKey(selectedBlock, attr),
+			getBlockDefaultKey(blockName, attr),
 			BLOCK_DEFAULTS_GROUP
 		);
-	const getDefaultValue = attr =>
-		getShippedBlockDefault(selectedBlock, attr, '');
+	const getDefaultValue = attr => getShippedBlockDefault(blockName, attr, '');
 	const getDefaultUnit = attr =>
-		getShippedBlockDefault(selectedBlock, attr, 'px');
+		getShippedBlockDefault(blockName, attr, 'px');
+	const updateBlockDefault = (attr, value) => {
+		debugSCBlockDefaults('control change', {
+			blockName,
+			breakpoint,
+			attr,
+			value,
+		});
+		onChangeValue(
+			{
+				[getBlockDefaultKey(blockName, attr)]: value,
+			},
+			BLOCK_DEFAULTS_GROUP
+		);
+	};
 
 	return (
 		<>
-			<SelectControl
-				label={__('Block', 'maxi-blocks')}
-				value={selectedBlock}
-				options={blockDefaultBlocks.map(blockName => ({
-					label: formatBlockLabel(blockName),
-					value: blockName,
-				}))}
-				onChange={setSelectedBlock}
-			/>
 			{blockDefaultSizeControls.map(({ label, target }) => {
 				const attr = getAttr(target);
 				const unitAttr = getUnitAttr(target);
@@ -492,46 +500,36 @@ const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => {
 
 				return (
 					<AdvancedNumberControl
-						key={`${selectedBlock}-${attr}`}
+						key={`${blockName}-${attr}`}
 						label={label}
 						value={getSCAttr(attr) ?? defaultValue}
 						unit={getSCAttr(unitAttr) ?? defaultUnit}
 						defaultValue={defaultValue}
 						enableUnit
 						optionType='string'
-						onChangeValue={value =>
-							onChangeValue(
-								{
-									[getBlockDefaultKey(selectedBlock, attr)]:
-										value,
-								},
-								BLOCK_DEFAULTS_GROUP
-							)
-						}
+						onChangeValue={value => updateBlockDefault(attr, value)}
 						onChangeUnit={unit =>
-							onChangeValue(
-								{
-									[getBlockDefaultKey(
-										selectedBlock,
-										unitAttr
-									)]: unit,
-								},
-								BLOCK_DEFAULTS_GROUP
-							)
+							updateBlockDefault(unitAttr, unit)
 						}
-						onReset={() =>
+						onReset={() => {
+							debugSCBlockDefaults('control reset', {
+								blockName,
+								breakpoint,
+								attr,
+								unitAttr,
+								defaultValue,
+								defaultUnit,
+							});
 							onChangeValue(
 								{
-									[getBlockDefaultKey(selectedBlock, attr)]:
+									[getBlockDefaultKey(blockName, attr)]:
 										defaultValue,
-									[getBlockDefaultKey(
-										selectedBlock,
-										unitAttr
-									)]: defaultUnit,
+									[getBlockDefaultKey(blockName, unitAttr)]:
+										defaultUnit,
 								},
 								BLOCK_DEFAULTS_GROUP
-							)
-						}
+							);
+						}}
 					/>
 				);
 			})}
@@ -539,8 +537,261 @@ const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => {
 	);
 };
 
-const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
+export const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => (
+	<SettingTabsControl
+		className='maxi-style-cards-block-default-tabs'
+		hasBorder
+		items={blockDefaultBlocks.map(blockName => ({
+			label: formatBlockLabel(blockName),
+			key: blockName,
+			content: (
+				<BlockDefaultsControls
+					SC={SC}
+					breakpoint={breakpoint}
+					onChangeValue={onChangeValue}
+					blockName={blockName}
+				/>
+			),
+		}))}
+	/>
+);
+
+const ColourPaletteControls = ({
+	SC,
+	SCStyle,
+	onChangeValue,
+	quickColorPreset,
+	setQuickColorPreset,
+}) => (
+	<>
+		<div className='maxi-style-cards__quick-color-presets'>
+			{[1, 2, 3, 4, 5, 6, 7, 8].map(item => {
+				const colorLabel = getStandardPaletteColorLabel(
+					item,
+					sprintf(
+						// translators: %s: color number.
+						__('Colour %s', 'maxi-blocks'),
+						item
+					)
+				);
+
+				return (
+					<button
+						key={`maxi-style-cards__quick-color-presets__box__${SCStyle}-${item}`}
+						type='button'
+						className={classnames(
+							'maxi-style-cards__quick-color-presets__box',
+							quickColorPreset === item &&
+								'maxi-style-cards__quick-color-presets__box--active'
+						)}
+						data-item={item}
+						title={colorLabel}
+						aria-label={colorLabel}
+						aria-pressed={quickColorPreset === item}
+						onClick={e =>
+							setQuickColorPreset(+e.currentTarget.dataset.item)
+						}
+					>
+						<span
+							className={classnames(
+								'maxi-style-cards__quick-color-presets__box__item',
+								`maxi-style-cards__quick-color-presets__box__item__${item}`
+							)}
+							style={{
+								background: `rgba(${processSCAttribute(
+									SC,
+									item,
+									'color'
+								)}, 1)`,
+							}}
+						/>
+					</button>
+				);
+			})}
+		</div>
+		<ColorControl
+			className={`maxi-style-cards-control__sc__color-${quickColorPreset}-${SCStyle}`}
+			color={`rgba(${processSCAttribute(
+				SC,
+				quickColorPreset,
+				'color'
+			)}, 1)`}
+			defaultColorAttributes={{
+				defaultColor: `rgba(${processSCAttribute(
+					SC,
+					quickColorPreset,
+					'color'
+				)}, 1)`,
+			}}
+			onChange={({ color }) =>
+				onChangeValue(
+					{
+						[`${quickColorPreset}`]: color
+							.replace('rgb(', '')
+							.replace(')', ''),
+					},
+					'color'
+				)
+			}
+			avoidBreakpointForDefault
+			blockStyle={SCStyle}
+			disableColorDisplay
+			disableOpacity
+			disableGradient
+			disablePalette
+		/>
+		<div className='maxi-style-cards__quick-color-presets__reset'>
+			<span
+				className='maxi-style-cards__quick-color-presets__reset-button__preview'
+				style={{
+					background: `rgba(${getDefaultSCAttribute(
+						SC,
+						quickColorPreset,
+						'color'
+					)}, 1)`,
+				}}
+			/>
+			<Button
+				disabled={
+					processSCAttribute(SC, quickColorPreset, 'color') ===
+					SC.defaultStyleCard.color[quickColorPreset]
+				}
+				className='maxi-style-cards__quick-color-presets__reset-button'
+				onClick={() =>
+					onChangeValue(
+						{
+							[`${quickColorPreset}`]:
+								SC.defaultStyleCard.color[quickColorPreset],
+						},
+						'color'
+					)
+				}
+			>
+				<Icon icon={reset} />
+			</Button>
+		</div>
+	</>
+);
+
+export const DarkToneOverrides = ({ enabled, onChange, children }) => (
+	<div className='maxi-style-cards__dark-tone-overrides'>
+		<ToggleSwitch
+			className='maxi-style-cards__dark-tone-overrides-toggle'
+			label={__('Dark tone overrides', 'maxi-blocks')}
+			help={__(
+				'Use different settings for this section in dark mode.',
+				'maxi-blocks'
+			)}
+			selected={enabled}
+			onChange={onChange}
+		/>
+		{enabled && (
+			<div className='maxi-style-cards__dark-tone-overrides-content'>
+				{children}
+			</div>
+		)}
+	</div>
+);
+
+const BlockDefaultsWithOverrides = ({
+	styleCard,
+	breakpoint,
+	onChangeValue,
+	onChangeDarkToneOverride,
+}) => {
+	const lightSC = styleCard?.light;
+	const darkSC = styleCard?.dark;
+	const isDarkOverrideEnabled = hasDarkToneStyleOverride(
+		styleCard,
+		BLOCK_DEFAULTS_GROUP
+	);
+	const lightOnChangeValue = (obj, type) =>
+		onChangeValue(obj, type, { SCStyle: 'light' });
+	const darkOnChangeValue = (obj, type) =>
+		onChangeValue(obj, type, {
+			SCStyle: 'dark',
+			forceToneOnly: true,
+		});
+
+	return (
+		<>
+			<BlockDefaults
+				SC={lightSC}
+				breakpoint={breakpoint}
+				onChangeValue={lightOnChangeValue}
+			/>
+			<DarkToneOverrides
+				enabled={isDarkOverrideEnabled}
+				onChange={value =>
+					onChangeDarkToneOverride(BLOCK_DEFAULTS_GROUP, value)
+				}
+			>
+				<BlockDefaults
+					SC={darkSC}
+					breakpoint={breakpoint}
+					onChangeValue={darkOnChangeValue}
+				/>
+			</DarkToneOverrides>
+		</>
+	);
+};
+
+export const MaxiStyleCardsAdvancedTab = ({
+	styleCard,
+	breakpoint,
+	onChangeValue,
+	onChangeDarkToneOverride,
+}) => (
+	<div className='maxi-tab-content__box maxi-style-cards-advanced-globals'>
+		<AccordionControl
+			key='sc-accordion__advanced-block-defaults'
+			isSecondary
+			isStyleCard
+			items={[
+				{
+					label: __('Block defaults', 'maxi-blocks'),
+					classNameItem: 'maxi-blocks-sc__type--block-defaults',
+					content: (
+						<ResponsiveTabsControl breakpoint={breakpoint}>
+							<BlockDefaultsWithOverrides
+								styleCard={styleCard}
+								breakpoint={breakpoint}
+								onChangeValue={onChangeValue}
+								onChangeDarkToneOverride={
+									onChangeDarkToneOverride
+								}
+							/>
+						</ResponsiveTabsControl>
+					),
+				},
+			]}
+		/>
+	</div>
+);
+
+const MaxiStyleCardsTab = ({
+	styleCard,
+	breakpoint,
+	onChangeValue,
+	onChangeDarkToneOverride,
+	isStyleSettingsSyncSelected = true,
+	onChangeStyleSettingsSyncStatus,
+}) => {
 	const [quickColorPreset, setQuickColorPreset] = useState(1);
+	const lightSC = styleCard?.light;
+	const darkSC = styleCard?.dark;
+	const lightOnChangeValue = (obj, type) =>
+		onChangeValue(obj, type, { SCStyle: 'light' });
+	const darkOnChangeValue = (obj, type) =>
+		onChangeValue(obj, type, {
+			SCStyle: 'dark',
+			forceToneOnly: true,
+		});
+	const colourOnChangeValue = SCStyle => (obj, type) =>
+		onChangeValue(obj, type, {
+			SCStyle,
+			forceToneOnly: true,
+		});
 
 	const getAvailableCustomColors = (styleCard, style) => {
 		if (!styleCard) {
@@ -653,11 +904,11 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 	};
 
 	const [customColors, setCustomColors] = useState(() =>
-		getAvailableCustomColors(SC, SCStyle)
+		getAvailableCustomColors(styleCard, 'light')
 	);
 
 	useEffect(() => {
-		const newAvailableColors = getAvailableCustomColors(SC, SCStyle);
+		const newAvailableColors = getAvailableCustomColors(styleCard, 'light');
 		// Simple stringify check for array of objects might be heavy.
 		// A more performant check might be needed if SC/SCStyle update very frequently.
 		if (
@@ -665,11 +916,11 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 		) {
 			setCustomColors(newAvailableColors);
 		}
-	}, [SC, SCStyle, customColors]); // Added customColors to dep array as per linter suggestion often seen
+	}, [styleCard, customColors]); // Added customColors to dep array as per linter suggestion often seen
 
 	const [selectedCustomColorId, setSelectedCustomColorId] = useState(null);
 
-	const headingItems = () =>
+	const headingItems = (SC, SCStyle, onChangeHandler) =>
 		[1, 2, 3, 4, 5, 6].map(item => {
 			return {
 				label: __(`H${item}`, 'maxi-blocks'),
@@ -690,7 +941,7 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 						breakpoint={breakpoint}
 						SC={SC}
 						SCStyle={SCStyle}
-						onChangeValue={onChangeValue}
+						onChangeValue={onChangeHandler}
 						disableResponsiveTabs
 					/>
 				),
@@ -941,176 +1192,203 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 		],
 	};
 
+	const renderDarkToneOverrides = ({ group, children }) => (
+		<DarkToneOverrides
+			enabled={hasDarkToneStyleOverride(styleCard, group)}
+			onChange={value => onChangeDarkToneOverride?.(group, value)}
+		>
+			{children}
+		</DarkToneOverrides>
+	);
+
+	const renderGlobalSection = ({
+		config,
+		disableTypography = false,
+		disableOpacity = false,
+	}) => (
+		<>
+			<SCAccordion
+				key={`sc-accordion__${config.label}`}
+				{...config}
+				breakpoint={breakpoint}
+				SC={lightSC}
+				SCStyle='light'
+				onChangeValue={lightOnChangeValue}
+				disableTypography={disableTypography}
+				disableOpacity={disableOpacity}
+			/>
+			{renderDarkToneOverrides({
+				group: config.groupAttr,
+				children: (
+					<SCAccordion
+						key={`sc-accordion__${config.label}-dark`}
+						{...config}
+						breakpoint={breakpoint}
+						SC={darkSC}
+						SCStyle='dark'
+						onChangeValue={darkOnChangeValue}
+						disableTypography={disableTypography}
+						disableOpacity={disableOpacity}
+					/>
+				),
+			})}
+		</>
+	);
+
+	const renderHeadingSection = () => (
+		<>
+			<ResponsiveTabsControl breakpoint={breakpoint}>
+				<SettingTabsControl
+					className='maxi-style-cards-headings-tabs'
+					hasBorder
+					items={headingItems(lightSC, 'light', lightOnChangeValue)}
+				/>
+			</ResponsiveTabsControl>
+			{renderDarkToneOverrides({
+				group: 'heading',
+				children: (
+					<ResponsiveTabsControl breakpoint={breakpoint}>
+						<SettingTabsControl
+							className='maxi-style-cards-headings-tabs'
+							hasBorder
+							items={headingItems(
+								darkSC,
+								'dark',
+								darkOnChangeValue
+							)}
+						/>
+					</ResponsiveTabsControl>
+				),
+			})}
+		</>
+	);
+
 	return (
 		<div className='maxi-tab-content__box'>
+			{onChangeStyleSettingsSyncStatus && (
+				<ToggleSwitch
+					className='maxi-style-cards__sync-style-settings'
+					label={__(
+						'Sync style settings between light and dark tones',
+						'maxi-blocks'
+					)}
+					help={__(
+						'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.',
+						'maxi-blocks'
+					)}
+					selected={isStyleSettingsSyncSelected}
+					onChange={onChangeStyleSettingsSyncStatus}
+				/>
+			)}
 			<AccordionControl
 				key='sc-accordion__quick-color-presets'
 				isSecondary
 				isStyleCard
-				items={
-					[
-						{
-							label: __('Colour palette', 'maxi-blocks'),
-							classNameItem:
-								'maxi-blocks-sc__type--quick-color-presets maxi-blocks-sc__type--color',
-							content: (
-								<>
-									<div className='maxi-style-cards__quick-color-presets'>
-										{[1, 2, 3, 4, 5, 6, 7, 8].map(item => {
-											const colorLabel =
-												getStandardPaletteColorLabel(
-													item,
-													sprintf(
-														// translators: %s: color number.
-														__(
-															'Colour %s',
-															'maxi-blocks'
-														),
-														item
-													)
-												);
-
-											return (
-												<button
-													key={`maxi-style-cards__quick-color-presets__box__${item}`}
-													type='button'
-													className={classnames(
-														'maxi-style-cards__quick-color-presets__box',
-														quickColorPreset ===
-															item &&
-															'maxi-style-cards__quick-color-presets__box--active'
-													)}
-													data-item={item}
-													title={colorLabel}
-													aria-label={colorLabel}
-													aria-pressed={
-														quickColorPreset ===
-														item
-													}
-													onClick={e =>
-														setQuickColorPreset(
-															+e.currentTarget
-																.dataset.item
-														)
-													}
-												>
-													<span
-														className={classnames(
-															'maxi-style-cards__quick-color-presets__box__item',
-															`maxi-style-cards__quick-color-presets__box__item__${item}`
-														)}
-														style={{
-															background: `rgba(${processSCAttribute(
-																SC,
-																item,
-																'color'
-															)}, 1)`,
-														}}
-													/>
-												</button>
-											);
-										})}
-									</div>
-									<ColorControl
-										className={`maxi-style-cards-control__sc__color-${quickColorPreset}-${SCStyle}`}
-										color={`rgba(${processSCAttribute(
-											SC,
-											quickColorPreset,
-											'color'
-										)}, 1)`}
-										defaultColorAttributes={{
-											defaultColor: `rgba(${processSCAttribute(
-												SC,
-												quickColorPreset,
-												'color'
-											)}, 1)`,
-										}}
-										onChange={({ color }) =>
-											onChangeValue(
-												{
-													[`${quickColorPreset}`]:
-														color
-															.replace('rgb(', '')
-															.replace(')', ''),
-												},
-												'color'
-											)
-										}
-										avoidBreakpointForDefault
-										blockStyle={SCStyle}
-										disableColorDisplay
-										disableOpacity
-										disableGradient
-										disablePalette
-									/>
-									<div className='maxi-style-cards__quick-color-presets__reset'>
-										<span
-											className='maxi-style-cards__quick-color-presets__reset-button__preview'
-											style={{
-												background: `rgba(${getDefaultSCAttribute(
-													SC,
-													quickColorPreset,
-													'color'
-												)}, 1)`,
-											}}
-										/>
-										<Button
-											disabled={
-												processSCAttribute(
-													SC,
-													quickColorPreset,
-													'color'
-												) ===
-												SC.defaultStyleCard.color[
+				items={[
+					{
+						label: __('Colour palette', 'maxi-blocks'),
+						classNameItem:
+							'maxi-blocks-sc__type--quick-color-presets maxi-blocks-sc__type--color',
+						content: (
+							<SettingTabsControl
+								className='maxi-style-cards-colour-tabs'
+								hasBorder
+								items={[
+									{
+										label: __(
+											'Light colours',
+											'maxi-blocks'
+										),
+										key: 'light',
+										content: (
+											<ColourPaletteControls
+												SC={lightSC}
+												SCStyle='light'
+												onChangeValue={colourOnChangeValue(
+													'light'
+												)}
+												quickColorPreset={
 													quickColorPreset
-												]
-											}
-											className='maxi-style-cards__quick-color-presets__reset-button'
-											onClick={() =>
-												onChangeValue(
-													{
-														[`${quickColorPreset}`]:
-															SC.defaultStyleCard
-																.color[
-																quickColorPreset
-															],
-													},
-													'color'
-												)
+												}
+												setQuickColorPreset={
+													setQuickColorPreset
+												}
+											/>
+										),
+									},
+									{
+										label: __(
+											'Dark colours',
+											'maxi-blocks'
+										),
+										key: 'dark',
+										content: (
+											<ColourPaletteControls
+												SC={darkSC}
+												SCStyle='dark'
+												onChangeValue={colourOnChangeValue(
+													'dark'
+												)}
+												quickColorPreset={
+													quickColorPreset
+												}
+												setQuickColorPreset={
+													setQuickColorPreset
+												}
+											/>
+										),
+									},
+								]}
+							/>
+						),
+					},
+					{
+						label: __('Custom colours (both tones)', 'maxi-blocks'),
+						classNameItem:
+							'maxi-blocks-sc__type--custom-color-presets maxi-blocks-sc__type--color',
+						content: (
+							<>
+								<div className='maxi-style-cards__custom-color-presets'>
+									{customColors.map(colorObj => (
+										<div
+											key={`maxi-style-cards__custom-color-presets__box-${colorObj.id}`}
+											data-color-id={colorObj.id}
+											className={classnames(
+												'maxi-style-cards__custom-color-presets__box',
+												selectedCustomColorId ===
+													colorObj.id &&
+													'maxi-style-cards__custom-color-presets__box--active'
+											)}
+											onClick={() => {
+												setSelectedCustomColorId(
+													colorObj.id
+												);
+											}}
+											title={
+												colorObj.name ||
+												`${__(
+													'Custom Colour',
+													'maxi-blocks'
+												)} ${
+													customColors.findIndex(
+														c =>
+															c.id === colorObj.id
+													) + 1
+												}`
 											}
 										>
-											<Icon icon={reset} />
-										</Button>
-									</div>
-								</>
-							),
-						},
-						{
-							label: __(
-								'Custom colours (both tones)',
-								'maxi-blocks'
-							),
-							classNameItem:
-								'maxi-blocks-sc__type--custom-color-presets maxi-blocks-sc__type--color',
-							content: (
-								<>
-									<div className='maxi-style-cards__custom-color-presets'>
-										{customColors.map(colorObj => (
-											<div
-												key={`maxi-style-cards__custom-color-presets__box-${colorObj.id}`}
-												data-color-id={colorObj.id}
-												className={classnames(
-													'maxi-style-cards__custom-color-presets__box',
-													selectedCustomColorId ===
-														colorObj.id &&
-														'maxi-style-cards__custom-color-presets__box--active'
-												)}
-												onClick={() => {
-													setSelectedCustomColorId(
-														colorObj.id
-													);
+											<span
+												className='maxi-style-cards__custom-color-presets__box__item'
+												style={{
+													background: colorObj.value,
 												}}
-												title={
+											/>
+											<Button
+												className='maxi-style-cards__custom-color-presets__remove-button'
+												title={`${__(
+													'Remove',
+													'maxi-blocks'
+												)} ${
 													colorObj.name ||
 													`${__(
 														'Custom Colour',
@@ -1122,316 +1400,221 @@ const MaxiStyleCardsTab = ({ SC, SCStyle, breakpoint, onChangeValue }) => {
 																colorObj.id
 														) + 1
 													}`
-												}
+												}`}
+												onClick={e => {
+													e.stopPropagation();
+													const newCustomColors =
+														customColors.filter(
+															c =>
+																c.id !==
+																colorObj.id
+														);
+													setCustomColors(
+														newCustomColors
+													);
+
+													// Call the handler for updating blocks
+													handleDeletedCustomColor(
+														colorObj.id
+													);
+
+													propagateCustomColors(
+														styleCard,
+														newCustomColors,
+														onChangeValue
+													);
+
+													if (
+														selectedCustomColorId ===
+														colorObj.id
+													) {
+														setSelectedCustomColorId(
+															null
+														);
+													}
+												}}
 											>
-												<span
-													className='maxi-style-cards__custom-color-presets__box__item'
-													style={{
-														background:
-															colorObj.value,
-													}}
-												/>
-												<Button
-													className='maxi-style-cards__custom-color-presets__remove-button'
-													title={`${__(
-														'Remove',
-														'maxi-blocks'
-													)} ${
-														colorObj.name ||
-														`${__(
-															'Custom Colour',
-															'maxi-blocks'
-														)} ${
-															customColors.findIndex(
-																c =>
-																	c.id ===
-																	colorObj.id
-															) + 1
-														}`
-													}`}
-													onClick={e => {
-														e.stopPropagation();
-														const newCustomColors =
-															customColors.filter(
-																c =>
-																	c.id !==
-																	colorObj.id
-															);
-														setCustomColors(
-															newCustomColors
-														);
+												-
+											</Button>
+										</div>
+									))}
+									<Button
+										className='maxi-style-cards__custom-color-presets__add-button'
+										onClick={() => {
+											const r = Math.floor(
+												Math.random() * 256
+											);
+											const g = Math.floor(
+												Math.random() * 256
+											);
+											const b = Math.floor(
+												Math.random() * 256
+											);
+											const newColorId =
+												generateCustomColorId();
+											const newColor = {
+												id: newColorId,
+												value: `rgba(${r}, ${g}, ${b}, 1)`,
+												name: '',
+											};
+											const newCustomColors = [
+												...customColors,
+												newColor,
+											];
+											setCustomColors(newCustomColors);
+											setSelectedCustomColorId(
+												newColorId
+											);
 
-														// Call the handler for updating blocks
-														handleDeletedCustomColor(
-															colorObj.id
+											propagateCustomColors(
+												styleCard,
+												newCustomColors,
+												onChangeValue
+											);
+										}}
+									>
+										+
+									</Button>
+								</div>
+								{selectedCustomColorId &&
+									customColors.find(
+										c => c.id === selectedCustomColorId
+									) && (
+										<>
+											<ColorControl
+												label={__(
+													'Custom',
+													'maxi-blocks'
+												)}
+												className='maxi-style-cards-control__sc__custom-color'
+												color={
+													customColors.find(
+														c =>
+															c.id ===
+															selectedCustomColorId
+													).value
+												}
+												onChange={({ color }) => {
+													const newCustomColors =
+														customColors.map(c =>
+															c.id ===
+															selectedCustomColorId
+																? {
+																		...c,
+																		value: color,
+																  }
+																: c
 														);
+													setCustomColors(
+														newCustomColors
+													);
 
-														propagateCustomColors(
-															SC,
-															newCustomColors,
-															onChangeValue
+													propagateCustomColors(
+														styleCard,
+														newCustomColors,
+														onChangeValue
+													);
+												}}
+												blockStyle='light'
+												disableOpacity
+												disableGradient
+												disablePalette
+											/>
+											<input
+												type='text'
+												className='maxi-style-cards__custom-color-presets__name-input'
+												value={
+													customColors.find(
+														c =>
+															c.id ===
+															selectedCustomColorId
+													).name
+												}
+												placeholder={__(
+													'Enter colour name',
+													'maxi-blocks'
+												)}
+												onChange={e => {
+													const newCustomColors =
+														customColors.map(c =>
+															c.id ===
+															selectedCustomColorId
+																? {
+																		...c,
+																		name: e
+																			.target
+																			.value,
+																  }
+																: c
 														);
+													setCustomColors(
+														newCustomColors
+													);
 
-														if (
-															selectedCustomColorId ===
-															colorObj.id
-														) {
-															setSelectedCustomColorId(
-																null
-															);
-														}
-													}}
-												>
-													-
-												</Button>
-											</div>
-										))}
-										<Button
-											className='maxi-style-cards__custom-color-presets__add-button'
-											onClick={() => {
-												const r = Math.floor(
-													Math.random() * 256
-												);
-												const g = Math.floor(
-													Math.random() * 256
-												);
-												const b = Math.floor(
-													Math.random() * 256
-												);
-												const newColorId =
-													generateCustomColorId();
-												const newColor = {
-													id: newColorId,
-													value: `rgba(${r}, ${g}, ${b}, 1)`,
-													name: '',
-												};
-												const newCustomColors = [
-													...customColors,
-													newColor,
-												];
-												setCustomColors(
-													newCustomColors
-												);
-												setSelectedCustomColorId(
-													newColorId
-												);
-
-												propagateCustomColors(
-													SC,
-													newCustomColors,
-													onChangeValue
-												);
-											}}
-										>
-											+
-										</Button>
-									</div>
-									{selectedCustomColorId &&
-										customColors.find(
-											c => c.id === selectedCustomColorId
-										) && (
-											<>
-												<ColorControl
-													label={__(
-														'Custom',
-														'maxi-blocks'
-													)}
-													className='maxi-style-cards-control__sc__custom-color'
-													color={
-														customColors.find(
-															c =>
-																c.id ===
-																selectedCustomColorId
-														).value
-													}
-													onChange={({ color }) => {
-														const newCustomColors =
-															customColors.map(
-																c =>
-																	c.id ===
-																	selectedCustomColorId
-																		? {
-																				...c,
-																				value: color,
-																		  }
-																		: c
-															);
-														setCustomColors(
-															newCustomColors
-														);
-
-														propagateCustomColors(
-															SC,
-															newCustomColors,
-															onChangeValue
-														);
-													}}
-													blockStyle={SCStyle}
-													disableOpacity
-													disableGradient
-													disablePalette
-												/>
-												<input
-													type='text'
-													className='maxi-style-cards__custom-color-presets__name-input'
-													value={
-														customColors.find(
-															c =>
-																c.id ===
-																selectedCustomColorId
-														).name
-													}
-													placeholder={__(
-														'Enter colour name',
-														'maxi-blocks'
-													)}
-													onChange={e => {
-														const newCustomColors =
-															customColors.map(
-																c =>
-																	c.id ===
-																	selectedCustomColorId
-																		? {
-																				...c,
-																				name: e
-																					.target
-																					.value,
-																		  }
-																		: c
-															);
-														setCustomColors(
-															newCustomColors
-														);
-
-														propagateCustomColors(
-															SC,
-															newCustomColors,
-															onChangeValue
-														);
-													}}
-												/>
-											</>
-										)}
-								</>
-							),
-						},
-						{
-							label: buttonTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--button',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${buttonTabs.label}`}
-									{...buttonTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-								/>
-							),
-						},
-						{
-							label: pTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--paragraph',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${pTabs.label}`}
-									{...pTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-								/>
-							),
-						},
-						{
-							label: __('Block defaults', 'maxi-blocks'),
-							classNameItem:
-								'maxi-blocks-sc__type--block-defaults',
-							content: (
-								<ResponsiveTabsControl breakpoint={breakpoint}>
-									<BlockDefaults
-										SC={SC}
-										breakpoint={breakpoint}
-										onChangeValue={onChangeValue}
-									/>
-								</ResponsiveTabsControl>
-							),
-						},
-						breakpoint === 'general' && {
-							label: linkTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--link',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${linkTabs.label}`}
-									{...linkTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-									disableTypography
-								/>
-							),
-						},
-						{
-							label: __('Headings globals', 'maxi-blocks'),
-							classNameItem: 'maxi-blocks-sc__type--heading',
-							content: (
-								<ResponsiveTabsControl breakpoint={breakpoint}>
-									<SettingTabsControl
-										className='maxi-style-cards-headings-tabs'
-										hasBorder
-										items={headingItems()}
-									/>
-								</ResponsiveTabsControl>
-							),
-						},
-						breakpoint === 'general' && {
-							label: iconTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--SVG',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${iconTabs.label}`}
-									{...iconTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-									disableTypography
-									disableOpacity
-								/>
-							),
-						},
-						breakpoint === 'general' && {
-							label: dividerTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--divider',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${dividerTabs.label}`}
-									{...dividerTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-									disableTypography
-								/>
-							),
-						},
-						{
-							label: navigationTabs.label,
-							classNameItem: 'maxi-blocks-sc__type--navigation',
-							content: (
-								<SCAccordion
-									key={`sc-accordion__${navigationTabs.label}`}
-									{...navigationTabs}
-									breakpoint={breakpoint}
-									SC={SC}
-									SCStyle={SCStyle}
-									onChangeValue={onChangeValue}
-								/>
-							),
-						},
-					].filter(Boolean) // Filter out any false items from conditional rendering
-				}
+													propagateCustomColors(
+														styleCard,
+														newCustomColors,
+														onChangeValue
+													);
+												}}
+											/>
+										</>
+									)}
+							</>
+						),
+					},
+					{
+						label: buttonTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--button',
+						content: renderGlobalSection({
+							config: buttonTabs,
+						}),
+					},
+					{
+						label: pTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--paragraph',
+						content: renderGlobalSection({
+							config: pTabs,
+						}),
+					},
+					breakpoint === 'general' && {
+						label: linkTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--link',
+						content: renderGlobalSection({
+							config: linkTabs,
+							disableTypography: true,
+						}),
+					},
+					{
+						label: __('Headings globals', 'maxi-blocks'),
+						classNameItem: 'maxi-blocks-sc__type--heading',
+						content: renderHeadingSection(),
+					},
+					breakpoint === 'general' && {
+						label: iconTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--SVG',
+						content: renderGlobalSection({
+							config: iconTabs,
+							disableTypography: true,
+							disableOpacity: true,
+						}),
+					},
+					breakpoint === 'general' && {
+						label: dividerTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--divider',
+						content: renderGlobalSection({
+							config: dividerTabs,
+							disableTypography: true,
+						}),
+					},
+					{
+						label: navigationTabs.label,
+						classNameItem: 'maxi-blocks-sc__type--navigation',
+						content: renderGlobalSection({
+							config: navigationTabs,
+						}),
+					},
+				].filter(Boolean)}
 			/>
 		</div>
 	);

--- a/src/editor/style-cards/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/maxiStyleCardsTab.js
@@ -539,8 +539,8 @@ const BlockDefaultsControls = ({
 
 export const BlockDefaults = ({ SC, breakpoint, onChangeValue }) => (
 	<SettingTabsControl
-		className='maxi-style-cards-block-default-tabs'
-		hasBorder
+		disablePadding
+		className='maxi-style-cards-advanced-globals-tabs'
 		items={blockDefaultBlocks.map(blockName => ({
 			label: formatBlockLabel(blockName),
 			key: blockName,

--- a/src/editor/style-cards/test/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/test/maxiStyleCardsTab.js
@@ -1,0 +1,249 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import MaxiStyleCardsTab, {
+	BlockDefaults,
+	DarkToneOverrides,
+	MaxiStyleCardsAdvancedTab,
+} from '../maxiStyleCardsTab';
+
+const mockAccordionControl = jest.fn(() => null);
+const mockSettingTabsControl = jest.fn(() => null);
+const mockToggleSwitch = jest.fn(({ label, help }) => (
+	<div className='mock-toggle-switch'>
+		<span>{label}</span>
+		{help && <p>{help}</p>}
+	</div>
+));
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@wordpress/i18n', () => ({
+	__: text => text,
+	sprintf: (template, value) => template.replace('%s', value),
+}));
+
+jest.mock(
+	'@components/accordion-control',
+	() => props => mockAccordionControl(props)
+);
+jest.mock('@components/advanced-number-control', () => () => null);
+jest.mock('@components/button', () => ({ children, onClick }) => (
+	<button type='button' onClick={onClick}>
+		{children}
+	</button>
+));
+jest.mock('@components/color-control', () => () => null);
+jest.mock('@components/color-control/utils', () => ({
+	getStandardPaletteColorLabel: (item, fallback) => fallback,
+}));
+jest.mock('@components/icon', () => () => null);
+jest.mock('@components/padding-control', () => () => null);
+jest.mock('@components/responsive-tabs-control', () => ({ children }) => (
+	<div>{children}</div>
+));
+jest.mock('@components/select-control', () => () => null);
+jest.mock(
+	'@components/setting-tabs-control',
+	() => props => mockSettingTabsControl(props)
+);
+jest.mock('@components/toggle-switch', () => props => mockToggleSwitch(props));
+jest.mock('@components/typography-control', () => () => null);
+
+jest.mock('@extensions/style-cards', () => ({
+	getDefaultSCValue: jest.fn(() => undefined),
+	getTypographyFromSC: jest.fn(() => ({})),
+}));
+jest.mock('@extensions/style-cards/blockDefaults', () => ({
+	blockDefaultBlocks: ['row-maxi', 'container-maxi'],
+	BLOCK_DEFAULTS_GROUP: 'blockDefaults',
+	debugSCBlockDefaults: jest.fn(),
+	getBlockDefaultKey: (block, attr) => `${block}-${attr}`,
+	getShippedBlockDefault: jest.fn((block, attr, fallback) => fallback),
+}));
+jest.mock('@extensions/style-cards/customColorsUtils', () => jest.fn());
+jest.mock('@maxi-icons', () => ({
+	reset: 'reset',
+}));
+jest.mock('../getDefaultSCAttribute', () => jest.fn(() => '255,255,255'));
+jest.mock('../utils', () => ({
+	processSCAttribute: jest.fn(() => undefined),
+	processSCAttributes: jest.fn(() => ({})),
+	removeNavigationHoverUnderline: jest.fn(),
+	showHideHamburgerNavigation: jest.fn(),
+}));
+
+const createStyleCardTone = () => ({
+	styleCard: {
+		color: {},
+	},
+	defaultStyleCard: {
+		color: {},
+	},
+});
+
+const createStyleCard = () => ({
+	light: createStyleCardTone(),
+	dark: createStyleCardTone(),
+});
+
+describe('MaxiStyleCardsTab', () => {
+	let container;
+	let root;
+
+	beforeEach(() => {
+		window.wp = {
+			data: {
+				select: jest.fn(() => ({
+					receiveMaxiSelectedStyleCardValue: jest.fn(() => []),
+				})),
+			},
+		};
+
+		container = document.createElement('div');
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		document.body.removeChild(container);
+		jest.clearAllMocks();
+	});
+
+	it('keeps the tone globals list as the existing Style Card sections', () => {
+		const styleCard = createStyleCard();
+
+		act(() => {
+			root.render(
+				<MaxiStyleCardsTab
+					styleCard={styleCard}
+					breakpoint='general'
+					onChangeValue={jest.fn()}
+					onChangeDarkToneOverride={jest.fn()}
+					isStyleSettingsSyncSelected
+					onChangeStyleSettingsSyncStatus={jest.fn()}
+				/>
+			);
+		});
+
+		const toneAccordion = mockAccordionControl.mock.calls
+			.map(([props]) => props)
+			.find(props =>
+				props.items?.some(item => item.label === 'Colour palette')
+			);
+
+		expect(toneAccordion.items.map(item => item.label)).toEqual([
+			'Colour palette',
+			'Custom colours (both tones)',
+			'Button globals',
+			'Paragraph globals',
+			'Link globals',
+			'Headings globals',
+			'Icon globals',
+			'Divider globals',
+			'Navigation menu globals',
+		]);
+		expect(toneAccordion.items.map(item => item.label)).not.toContain(
+			'Block defaults'
+		);
+
+		expect(
+			toneAccordion.items[0].content.props.items.map(item => item.label)
+		).toEqual(['Light colours', 'Dark colours']);
+		expect(mockToggleSwitch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				className: 'maxi-style-cards__sync-style-settings',
+				label: 'Sync style settings between light and dark tones',
+				help: 'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.',
+				selected: true,
+			})
+		);
+	});
+
+	it('moves only Block defaults into the Advanced globals content', () => {
+		act(() => {
+			root.render(
+				<MaxiStyleCardsAdvancedTab
+					styleCard={createStyleCard()}
+					breakpoint='general'
+					onChangeValue={jest.fn()}
+					onChangeDarkToneOverride={jest.fn()}
+				/>
+			);
+		});
+
+		const advancedAccordion = mockAccordionControl.mock.calls
+			.map(([props]) => props)
+			.find(props =>
+				props.items?.some(item => item.label === 'Block defaults')
+			);
+
+		expect(advancedAccordion.items.map(item => item.label)).toEqual([
+			'Block defaults',
+		]);
+		expect(
+			Array.isArray(advancedAccordion.items[0].content.props.children)
+		).toBe(false);
+	});
+
+	it('renders each block default group as its own tab', () => {
+		act(() => {
+			root.render(
+				<BlockDefaults
+					SC={createStyleCardTone()}
+					breakpoint='general'
+					onChangeValue={jest.fn()}
+				/>
+			);
+		});
+
+		const blockTabs = mockSettingTabsControl.mock.calls
+			.map(([props]) => props)
+			.find(
+				props =>
+					props.className === 'maxi-style-cards-block-default-tabs'
+			);
+
+		expect(blockTabs.items.map(item => item.label)).toEqual([
+			'Row',
+			'Container',
+		]);
+	});
+
+	it('uses the compact dark override wording and hides controls while off', () => {
+		const onChange = jest.fn();
+
+		act(() => {
+			root.render(
+				<DarkToneOverrides enabled={false} onChange={onChange}>
+					<div>Dark controls</div>
+				</DarkToneOverrides>
+			);
+		});
+
+		expect(mockToggleSwitch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				className: 'maxi-style-cards__dark-tone-overrides-toggle',
+				label: 'Dark tone overrides',
+				help: 'Use different settings for this section in dark mode.',
+				selected: false,
+				onChange,
+			})
+		);
+		expect(container.textContent).not.toContain('Dark controls');
+
+		act(() => {
+			root.render(
+				<DarkToneOverrides enabled onChange={onChange}>
+					<div>Dark controls</div>
+				</DarkToneOverrides>
+			);
+		});
+
+		expect(container.textContent).toContain('Dark controls');
+	});
+});

--- a/src/editor/style-cards/test/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/test/maxiStyleCardsTab.js
@@ -106,6 +106,11 @@ jest.mock('@extensions/style-cards/blockDefaults', () => ({
 	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES:
 		'scBlockDefaultsExcludedAttributes',
 	debugSCBlockDefaults: jest.fn(),
+	getLayoutDebugValueSummary: jest.fn(values =>
+		Object.entries(values)
+			.map(([key, value]) => `${key}=${value}`)
+			.join(', ')
+	),
 	getBlockDefaultKey: (block, attr) => `${block}-${attr}`,
 	getShippedBlockDefault: jest.fn((block, attr, fallback) => fallback),
 	getUnitAttribute: attr => {

--- a/src/editor/style-cards/test/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/test/maxiStyleCardsTab.js
@@ -3,12 +3,18 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import MaxiStyleCardsTab, {
-	BlockDefaults,
 	DarkToneOverrides,
 	MaxiStyleCardsAdvancedTab,
 } from '../maxiStyleCardsTab';
+import * as utils from '../utils';
+import { debugSCBlockDefaults } from '@extensions/style-cards/blockDefaults';
 
 const mockAccordionControl = jest.fn(() => null);
+const mockFullSizeControl = jest.fn(() => null);
+const mockFlexGapControl = jest.fn(() => null);
+const mockFlexWrapControl = jest.fn(() => null);
+const mockMarginControl = jest.fn(() => null);
+const mockPaddingControl = jest.fn(() => null);
 const mockSettingTabsControl = jest.fn(() => null);
 const mockToggleSwitch = jest.fn(({ label, help }) => (
 	<div className='mock-toggle-switch'>
@@ -26,7 +32,24 @@ jest.mock('@wordpress/i18n', () => ({
 
 jest.mock(
 	'@components/accordion-control',
-	() => props => mockAccordionControl(props)
+	() => props => {
+		mockAccordionControl(props);
+
+		return (
+			props.items?.map(item => item.content) || null
+		);
+	}
+);
+jest.mock(
+	'@components/flex-settings-control/flex-gap-control',
+	() => props => mockFlexGapControl(props)
+);
+jest.mock(
+	'@components/flex-settings-control/flex-wrap-control',
+	() => props => mockFlexWrapControl(props)
+);
+jest.mock('@components/full-size-control', () => props =>
+	mockFullSizeControl(props)
 );
 jest.mock('@components/advanced-number-control', () => () => null);
 jest.mock('@components/button', () => ({ children, onClick }) => (
@@ -39,7 +62,10 @@ jest.mock('@components/color-control/utils', () => ({
 	getStandardPaletteColorLabel: (item, fallback) => fallback,
 }));
 jest.mock('@components/icon', () => () => null);
-jest.mock('@components/padding-control', () => () => null);
+jest.mock('@components/margin-control', () => props => mockMarginControl(props));
+jest.mock('@components/padding-control', () => props =>
+	mockPaddingControl(props)
+);
 jest.mock('@components/responsive-tabs-control', () => ({ children }) => (
 	<div>{children}</div>
 ));
@@ -56,11 +82,38 @@ jest.mock('@extensions/style-cards', () => ({
 	getTypographyFromSC: jest.fn(() => ({})),
 }));
 jest.mock('@extensions/style-cards/blockDefaults', () => ({
-	blockDefaultBlocks: ['row-maxi', 'container-maxi'],
+	blockDefaultBlocks: [
+		'accordion-maxi',
+		'button-maxi',
+		'column-maxi',
+		'container-maxi',
+		'divider-maxi',
+		'group-maxi',
+		'image-maxi',
+		'list-item-maxi',
+		'map-maxi',
+		'number-counter-maxi',
+		'pane-maxi',
+		'row-maxi',
+		'search-maxi',
+		'slide-maxi',
+		'slider-maxi',
+		'svg-icon-maxi',
+		'text-maxi',
+		'video-maxi',
+	],
 	BLOCK_DEFAULTS_GROUP: 'blockDefaults',
+	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES:
+		'scBlockDefaultsExcludedAttributes',
 	debugSCBlockDefaults: jest.fn(),
 	getBlockDefaultKey: (block, attr) => `${block}-${attr}`,
 	getShippedBlockDefault: jest.fn((block, attr, fallback) => fallback),
+	getUnitAttribute: attr => {
+		const match = attr.match(/^(.*)-(general|xxl|xl|l|m|s|xs)$/);
+		return match && !attr.includes('-unit-')
+			? `${match[1]}-unit-${match[2]}`
+			: null;
+	},
 }));
 jest.mock('@extensions/style-cards/customColorsUtils', () => jest.fn());
 jest.mock('@maxi-icons', () => ({
@@ -88,11 +141,44 @@ const createStyleCard = () => ({
 	dark: createStyleCardTone(),
 });
 
+const createStyleCardWithBlockDefaults = ({
+	lightBlockDefaults = {},
+	darkBlockDefaults = {},
+} = {}) => ({
+	light: {
+		...createStyleCardTone(),
+		styleCard: {
+			...createStyleCardTone().styleCard,
+			blockDefaults: {
+				...lightBlockDefaults,
+			},
+		},
+	},
+	dark: {
+		...createStyleCardTone(),
+		styleCard: {
+			...createStyleCardTone().styleCard,
+			blockDefaults: {
+				...darkBlockDefaults,
+			},
+		},
+	},
+});
+
+const getLayoutControlGroups = () =>
+	mockAccordionControl.mock.calls
+		.map(([props]) => props?.items?.map(item => item.label))
+		.filter(Boolean)
+		.filter(items => items.includes('Height / Width'));
+
 describe('MaxiStyleCardsTab', () => {
 	let container;
 	let root;
 
 	beforeEach(() => {
+		utils.processSCAttribute.mockReturnValue(undefined);
+		utils.processSCAttributes.mockReturnValue({});
+
 		window.wp = {
 			data: {
 				select: jest.fn(() => ({
@@ -154,17 +240,86 @@ describe('MaxiStyleCardsTab', () => {
 		expect(
 			toneAccordion.items[0].content.props.items.map(item => item.label)
 		).toEqual(['Light colours', 'Dark colours']);
-		expect(mockToggleSwitch).toHaveBeenCalledWith(
+		const syncToggleProps = mockToggleSwitch.mock.calls.find(
+			([props]) =>
+				props.className ===
+				'maxi-style-cards__sync-style-settings'
+		)?.[0];
+		const syncHelpText =
+			'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.';
+
+		expect(syncToggleProps).toEqual(
 			expect.objectContaining({
 				className: 'maxi-style-cards__sync-style-settings',
 				label: 'Sync style settings between light and dark tones',
-				help: 'Fonts, sizes, spacing and other non-colour settings will be shared between both tones. Colours can still be edited separately.',
 				selected: true,
+			})
+		);
+		expect(syncToggleProps.help).toBeUndefined();
+		expect(container.textContent).not.toContain(syncHelpText);
+
+		const syncInfoButton = container.querySelector(
+			'.maxi-style-cards__sync-style-settings-info-button'
+		);
+
+		expect(syncInfoButton).toBeTruthy();
+		expect(syncInfoButton.getAttribute('aria-expanded')).toBe('false');
+
+		act(() => {
+			syncInfoButton.dispatchEvent(
+				new MouseEvent('click', { bubbles: true })
+			);
+		});
+
+		expect(syncInfoButton.getAttribute('aria-expanded')).toBe('true');
+		expect(container.textContent).toContain(syncHelpText);
+	});
+
+	it('renders only container and row in advanced globals', () => {
+		const onChangeDarkToneOverride = jest.fn();
+		act(() => {
+			root.render(
+				<MaxiStyleCardsAdvancedTab
+					styleCard={createStyleCard()}
+					breakpoint='general'
+					onChangeValue={jest.fn()}
+					onChangeDarkToneOverride={onChangeDarkToneOverride}
+				/>
+			);
+		});
+
+		const advancedAccordion = mockAccordionControl.mock.calls
+			.map(([props]) => props)
+			.find(props => props.items?.some(item => item.label === 'Row layout'));
+
+		expect(advancedAccordion.items.map(item => item.label)).toEqual([
+			'Container layout',
+			'Row layout',
+		]);
+		expect(advancedAccordion.className).toBe(
+			'maxi-style-cards-advanced-globals__blocks'
+		);
+		expect(
+			advancedAccordion.items.map(item => item.label)
+		).not.toContain('Button');
+		expect(
+			advancedAccordion.items.map(item => item.label)
+		).not.toContain('Navigation menu globals');
+		expect(
+			advancedAccordion.items.map(item => item.label)
+		).not.toContain('Block defaults');
+
+		expect(
+			advancedAccordion.items[0].content.props.blockName
+		).toBe('container-maxi');
+		expect(mockToggleSwitch).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				className: 'maxi-style-cards__dark-tone-overrides-toggle',
 			})
 		);
 	});
 
-	it('moves only Block defaults into the Advanced globals content', () => {
+	it('uses sectioned height/width and spacing controls in advanced layouts', () => {
 		act(() => {
 			root.render(
 				<MaxiStyleCardsAdvancedTab
@@ -176,43 +331,30 @@ describe('MaxiStyleCardsTab', () => {
 			);
 		});
 
-		const advancedAccordion = mockAccordionControl.mock.calls
+		const layoutControlGroups = getLayoutControlGroups();
+		const sectionAccordions = mockAccordionControl.mock.calls
 			.map(([props]) => props)
-			.find(props =>
-				props.items?.some(item => item.label === 'Block defaults')
-			);
-
-		expect(advancedAccordion.items.map(item => item.label)).toEqual([
-			'Block defaults',
-		]);
-		expect(
-			Array.isArray(advancedAccordion.items[0].content.props.children)
-		).toBe(false);
-	});
-
-	it('renders each block default group as its own tab', () => {
-		act(() => {
-			root.render(
-				<BlockDefaults
-					SC={createStyleCardTone()}
-					breakpoint='general'
-					onChangeValue={jest.fn()}
-				/>
-			);
-		});
-
-		const blockTabs = mockSettingTabsControl.mock.calls
-			.map(([props]) => props)
-			.find(
+			.filter(
 				props =>
-					props.className === 'maxi-style-cards-advanced-globals-tabs'
+					props.className ===
+					'maxi-style-cards-advanced-globals__sections'
 			);
 
-		expect(blockTabs.items.map(item => item.label)).toEqual([
-			'Row',
-			'Container',
+		expect(layoutControlGroups).toContainEqual([
+			'Height / Width',
+			'Margin / Padding',
 		]);
-		expect(blockTabs.disablePadding).toBe(true);
+		expect(sectionAccordions.length).toBeGreaterThan(0);
+		expect(layoutControlGroups).toContainEqual([
+			'Height / Width',
+			'Margin / Padding',
+			'Row spacing',
+		]);
+		expect(mockFullSizeControl).toHaveBeenCalled();
+		expect(mockMarginControl).toHaveBeenCalled();
+		expect(mockPaddingControl).toHaveBeenCalled();
+		expect(mockFlexGapControl).toHaveBeenCalled();
+		expect(mockFlexWrapControl).toHaveBeenCalled();
 	});
 
 	it('uses the compact dark override wording and hides controls while off', () => {
@@ -246,5 +388,123 @@ describe('MaxiStyleCardsTab', () => {
 		});
 
 		expect(container.textContent).toContain('Dark controls');
+	});
+
+	it('prefixes advanced block-default updates and strips control metadata', () => {
+		const onChangeValue = jest.fn();
+		const styleCard = createStyleCardWithBlockDefaults({
+			lightBlockDefaults: {
+				'container-maxi|width-general': '160',
+				'container-maxi|height-general': '200',
+				'container-maxi|padding-top-general': '20',
+				'container-maxi|padding-bottom-general': '20',
+			},
+		});
+
+		utils.processSCAttributes.mockImplementation((sourceStyleCard, _target, type) =>
+			type === 'blockDefaults'
+				? sourceStyleCard?.styleCard?.blockDefaults ?? {}
+				: {}
+		);
+
+		act(() => {
+			root.render(
+				<MaxiStyleCardsAdvancedTab
+					styleCard={styleCard}
+					breakpoint='general'
+					onChangeValue={onChangeValue}
+					onChangeDarkToneOverride={jest.fn()}
+				/>
+			);
+		});
+
+		const fullSizeProps = mockFullSizeControl.mock.calls.find(
+			([props]) => props?.['width-general'] !== undefined
+		)?.[0];
+		expect(fullSizeProps).toBeTruthy();
+
+		act(() => {
+			fullSizeProps.onChange({
+				'width-general': '190',
+				meta: {
+					inline: {
+						unit: 'px',
+					},
+				},
+				isReset: true,
+				scBlockDefaultsExcludedAttributes: ['full-width-general'],
+			});
+		});
+
+		expect(onChangeValue).toHaveBeenCalledWith(
+			{
+				'container-maxi-width-general': '190',
+				'container-maxi-width-unit-general': 'px',
+			},
+			'blockDefaults',
+			expect.objectContaining({
+				SCStyle: 'light',
+				group: 'container-maxi',
+				forceSyncedTones: true,
+			})
+		);
+		expect(
+			onChangeValue.mock.calls.at(-1)[0]
+		).not.toHaveProperty('container-maxi-meta');
+		expect(
+			onChangeValue.mock.calls.at(-1)[0]
+		).not.toHaveProperty('container-maxi-isReset');
+		expect(
+			onChangeValue.mock.calls.at(-1)[0]
+		).not.toHaveProperty(
+			'container-maxi-scBlockDefaultsExcludedAttributes'
+		);
+		expect(debugSCBlockDefaults).toHaveBeenCalledWith(
+			'advanced globals change',
+			expect.objectContaining({
+				blockName: 'container-maxi',
+				breakpoint: 'general',
+				tone: 'light',
+				values: expect.objectContaining({
+					'width-general': '190',
+				}),
+				prefixedValues: {
+					'container-maxi-width-general': '190',
+					'container-maxi-width-unit-general': 'px',
+				},
+			})
+		);
+
+		const paddingProps = mockPaddingControl.mock.calls.find(
+			([props]) => props?.['padding-top-general'] !== undefined
+		)?.[0];
+		expect(paddingProps).toBeTruthy();
+
+		act(() => {
+			paddingProps.onChange({
+				'padding-top-general': '100',
+				'padding-bottom-general': '100',
+				meta: {
+					inline: {
+						unit: 'px',
+					},
+				},
+			});
+		});
+
+		expect(onChangeValue).toHaveBeenLastCalledWith(
+			{
+				'container-maxi-padding-top-general': '100',
+				'container-maxi-padding-top-unit-general': 'px',
+				'container-maxi-padding-bottom-general': '100',
+				'container-maxi-padding-bottom-unit-general': 'px',
+			},
+			'blockDefaults',
+			expect.objectContaining({
+				SCStyle: 'light',
+				group: 'container-maxi',
+				forceSyncedTones: true,
+			})
+		);
 	});
 });

--- a/src/editor/style-cards/test/maxiStyleCardsTab.js
+++ b/src/editor/style-cards/test/maxiStyleCardsTab.js
@@ -205,13 +205,14 @@ describe('MaxiStyleCardsTab', () => {
 			.map(([props]) => props)
 			.find(
 				props =>
-					props.className === 'maxi-style-cards-block-default-tabs'
+					props.className === 'maxi-style-cards-advanced-globals-tabs'
 			);
 
 		expect(blockTabs.items.map(item => item.label)).toEqual([
 			'Row',
 			'Container',
 		]);
+		expect(blockTabs.disablePadding).toBe(true);
 	});
 
 	it('uses the compact dark override wording and hides controls while off', () => {

--- a/src/extensions/maxi-block/getBlockElementForStyleDebug.js
+++ b/src/extensions/maxi-block/getBlockElementForStyleDebug.js
@@ -1,0 +1,75 @@
+const escapeClassSelector = (doc, value) => {
+	const stringValue = `${value}`;
+	const cssEscape = doc?.defaultView?.CSS?.escape;
+
+	if (typeof cssEscape === 'function') return cssEscape(stringValue);
+
+	return stringValue.replace(/[^a-zA-Z0-9_-]/g, char => `\\${char}`);
+};
+
+const escapeAttributeValue = value =>
+	`${value}`.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+const querySelectorSafely = (doc, selector) => {
+	try {
+		return doc?.querySelector?.(selector) || null;
+	} catch (error) {
+		return null;
+	}
+};
+
+const getBlockElementForStyleDebug = (doc, uniqueID) => {
+	if (!doc || !uniqueID) {
+		return {
+			element: null,
+			method: null,
+		};
+	}
+
+	const idElement = doc.getElementById?.(uniqueID) || null;
+	if (idElement) {
+		return {
+			element: idElement,
+			method: 'id',
+		};
+	}
+
+	const escapedClass = escapeClassSelector(doc, uniqueID);
+	const escapedAttribute = escapeAttributeValue(uniqueID);
+	const lookups = [
+		{
+			method: 'backendClass',
+			selector: `.maxi-block.maxi-block--backend.${escapedClass}`,
+		},
+		{
+			method: 'class',
+			selector: `.${escapedClass}`,
+		},
+		{
+			method: 'uniqueIDAttr',
+			selector: `[uniqueID="${escapedAttribute}"]`,
+		},
+		{
+			method: 'uniqueidAttr',
+			selector: `[uniqueid="${escapedAttribute}"]`,
+		},
+	];
+
+	for (const lookup of lookups) {
+		const element = querySelectorSafely(doc, lookup.selector);
+
+		if (element) {
+			return {
+				element,
+				method: lookup.method,
+			};
+		}
+	}
+
+	return {
+		element: null,
+		method: null,
+	};
+};
+
+export default getBlockElementForStyleDebug;

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -50,6 +50,7 @@ import updateRelationHoverStatus from './updateRelationHoverStatus';
 import propagateNewUniqueID from './propagateNewUniqueID';
 import propsObjectCleaner from './propsObjectCleaner';
 import { addBlockStyles, removeBlockStyles } from './globalStyleManager';
+import getBlockElementForStyleDebug from './getBlockElementForStyleDebug';
 import updateRelationsRemotely from '@extensions/relations/updateRelationsRemotely';
 import getIsUniqueCustomLabelRepeated from './getIsUniqueCustomLabelRepeated';
 import { removeBlockFromColumns } from '@extensions/repeater';
@@ -58,8 +59,11 @@ import compareVersions from './compareVersions';
 import batchBlockDispatcher from './batchBlockDispatcher';
 import {
 	debugSCBlockDefaults,
-	parseBlockDefaultKey,
-	SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+	getAffectedBlockNamesFromBlockDefaults,
+	getLayoutDebugValueSummary,
+	isSCBlockDefaultsDebugEnabled,
+	isSCBlockDefaultsVerboseDebugEnabled,
+	subscribeSCBlockDefaultsUpdate,
 } from '@extensions/style-cards/blockDefaults';
 import {
 	countProfile,
@@ -177,6 +181,7 @@ class MaxiBlockComponent extends Component {
 		this.isPatternsPreview = false;
 		this.xxlStyleCache = null;
 		this.isXxlStyleCacheDirty = false;
+		this.unsubscribeStyleCardBlockDefaultsUpdate = null;
 		this.handleStyleCardBlockDefaultsUpdate =
 			this.handleStyleCardBlockDefaultsUpdate.bind(this);
 
@@ -354,10 +359,18 @@ class MaxiBlockComponent extends Component {
 			return;
 		}
 
-		window.addEventListener(
-			SC_BLOCK_DEFAULTS_UPDATE_EVENT,
-			this.handleStyleCardBlockDefaultsUpdate
-		);
+		const blockName = this.props.name?.replace('maxi-blocks/', '');
+		this.unsubscribeStyleCardBlockDefaultsUpdate =
+			subscribeSCBlockDefaultsUpdate(
+				this.handleStyleCardBlockDefaultsUpdate,
+				blockName
+			);
+		if (['container-maxi', 'row-maxi'].includes(blockName)) {
+			debugSCBlockDefaults('block subscribed to defaults update', {
+				blockName,
+				uniqueID: this.props.attributes?.uniqueID,
+			});
+		}
 
 		// Step 2: FSE iframe styles and observer
 		if (getIsSiteEditor()) {
@@ -804,10 +817,8 @@ class MaxiBlockComponent extends Component {
 
 		// Block cleanup initiated
 
-		window.removeEventListener(
-			SC_BLOCK_DEFAULTS_UPDATE_EVENT,
-			this.handleStyleCardBlockDefaultsUpdate
-		);
+		this.unsubscribeStyleCardBlockDefaultsUpdate?.();
+		this.unsubscribeStyleCardBlockDefaultsUpdate = null;
 
 		// Return early checks
 		if (
@@ -979,28 +990,67 @@ class MaxiBlockComponent extends Component {
 	}
 
 	handleStyleCardBlockDefaultsUpdate(event) {
-		if (this.isPatternsPreview || this.templateModal) return;
-
 		const blockName = this.props.name?.replace('maxi-blocks/', '');
+		const uniqueID = this.props.attributes?.uniqueID;
+		const isLayoutBlock = ['container-maxi', 'row-maxi'].includes(
+			blockName
+		);
+
+		if (this.isPatternsPreview || this.templateModal) {
+			if (isLayoutBlock) {
+				debugSCBlockDefaults('block defaults update skipped', {
+					blockName,
+					uniqueID,
+					reason: 'preview-or-template',
+					isPatternsPreview: this.isPatternsPreview,
+					hasTemplateModal: Boolean(this.templateModal),
+				});
+			}
+
+			return;
+		}
+
 		const blockDefaults = event?.detail?.blockDefaults ?? {};
-		const affectedBlockNames = [
-			...new Set(
-				Object.keys(blockDefaults)
-					.map(key => parseBlockDefaultKey(key)?.blockName)
-					.filter(Boolean)
-			),
-		];
+		const affectedBlockNames =
+			getAffectedBlockNamesFromBlockDefaults(blockDefaults);
+		const blockDefaultsSummary = getLayoutDebugValueSummary(
+			blockDefaults,
+			blockName
+		);
+
+		if (isLayoutBlock) {
+			debugSCBlockDefaults('block defaults update handler invoked', {
+				blockName,
+				uniqueID,
+				eventType: event?.type,
+				hasBlockDefaults: Object.keys(blockDefaults).length > 0,
+				affectedBlockNames,
+				blockDefaultsSummary,
+			});
+		}
 
 		if (
 			affectedBlockNames.length > 0 &&
 			!affectedBlockNames.includes(blockName)
-		)
+		) {
+			if (isLayoutBlock) {
+				debugSCBlockDefaults('block defaults update skipped', {
+					blockName,
+					uniqueID,
+					reason: 'unaffected-block',
+					affectedBlockNames,
+					blockDefaultsSummary,
+				});
+			}
+
 			return;
+		}
 
 		debugSCBlockDefaults('block refresh from defaults update', {
 			blockName,
-			uniqueID: this.props.attributes?.uniqueID,
+			uniqueID,
 			affectedBlockNames,
+			blockDefaultsSummary,
 		});
 
 		this.invalidateAttributeCaches();
@@ -1297,7 +1347,96 @@ class MaxiBlockComponent extends Component {
 
 		const target = this.getStyleTarget(isSiteEditor, this.editorIframe);
 		addBlockStyles(uniqueID, styleContent, target);
+		this.debugComputedLayoutAfterStyleApply(
+			uniqueID,
+			styleContent,
+			breakpoint,
+			target
+		);
 		this.updateResponsiveClasses(this.editorIframe, breakpoint);
+	}
+
+	debugComputedLayoutAfterStyleApply(
+		uniqueID,
+		styleContent,
+		breakpoint,
+		targetDocument
+	) {
+		if (
+			!isSCBlockDefaultsDebugEnabled() ||
+			!isSCBlockDefaultsVerboseDebugEnabled()
+		)
+			return;
+
+		const blockName = this.props.name?.replace('maxi-blocks/', '');
+		if (!['container-maxi', 'row-maxi'].includes(blockName)) return;
+
+		const target = targetDocument || document;
+		const requestFrame =
+			target?.defaultView?.requestAnimationFrame ||
+			(typeof requestAnimationFrame === 'function'
+				? requestAnimationFrame
+				: callback => setTimeout(callback, 0));
+
+		requestFrame(() => {
+			const {
+				element: blockElement,
+				method: blockLookupMethod,
+			} = getBlockElementForStyleDebug(target, uniqueID);
+			const styleElement = target?.getElementById?.(
+				'maxi-blocks__consolidated-styles'
+			);
+			const computed =
+				blockElement && target?.defaultView?.getComputedStyle
+					? target.defaultView.getComputedStyle(blockElement)
+					: null;
+			const blockStyle = this.props.attributes?.blockStyle;
+			const cssVarPrefix = `--maxi-${blockStyle}-block-default-${blockName}`;
+			const getComputedVar = suffix =>
+				computed?.getPropertyValue?.(`${cssVarPrefix}-${suffix}`)?.trim();
+			const cssVarPaddingTop =
+				getComputedVar(`padding-top-${breakpoint}`) ||
+				getComputedVar('padding-top-general');
+			const cssVarPaddingBottom =
+				getComputedVar(`padding-bottom-${breakpoint}`) ||
+				getComputedVar('padding-bottom-general');
+
+			debugSCBlockDefaults('block computed layout after style apply', {
+				blockName,
+				uniqueID,
+				breakpoint,
+				blockStyle,
+				foundBlockElement: Boolean(blockElement),
+				blockLookupMethod,
+				foundConsolidatedStyle: Boolean(styleElement),
+				consolidatedStyleIncludesBlock: Boolean(
+					styleElement?.textContent?.includes(uniqueID)
+				),
+				styleContentIncludesBlockDefault:
+					styleContent?.includes('block-default'),
+				styleContentIncludesIndicator:
+					styleContent?.includes('maxi-block-indicators'),
+				computedLayoutSummary: [
+					`lookup=${blockLookupMethod || 'missing'}`,
+					`paddingTop=${computed?.paddingTop || 'n/a'}`,
+					`paddingBottom=${computed?.paddingBottom || 'n/a'}`,
+					`paddingLeft=${computed?.paddingLeft || 'n/a'}`,
+					`paddingRight=${computed?.paddingRight || 'n/a'}`,
+					`marginTop=${computed?.marginTop || 'n/a'}`,
+					`marginBottom=${computed?.marginBottom || 'n/a'}`,
+					`cssVarPaddingTop=${cssVarPaddingTop || 'n/a'}`,
+					`cssVarPaddingBottom=${cssVarPaddingBottom || 'n/a'}`,
+				].join(', '),
+				computedPaddingTop: computed?.paddingTop,
+				computedPaddingBottom: computed?.paddingBottom,
+				computedPaddingLeft: computed?.paddingLeft,
+				computedPaddingRight: computed?.paddingRight,
+				computedMarginTop: computed?.marginTop,
+				computedMarginBottom: computed?.marginBottom,
+				cssVarPaddingTop,
+				cssVarPaddingBottom,
+			});
+		});
 	}
 
 	// eslint-disable-next-line class-methods-use-this
@@ -2132,6 +2271,12 @@ class MaxiBlockComponent extends Component {
 				isSiteEditor
 			);
 			addBlockStyles(uniqueID, styleContent, target);
+			this.debugComputedLayoutAfterStyleApply(
+				uniqueID,
+				styleContent,
+				currentBreakpoint,
+				target
+			);
 		}
 	}
 
@@ -2413,6 +2558,73 @@ class MaxiBlockComponent extends Component {
 				WHITE_SPACE_REGEX,
 				'white-space: nowrap !important'
 			);
+			if (isSCBlockDefaultsVerboseDebugEnabled()) {
+				const blockName = this.props.name?.replace('maxi-blocks/', '');
+				const isLayoutBlock = ['container-maxi', 'row-maxi'].includes(
+					blockName
+				);
+				const relevantStyleIndexes = [
+					'block-default',
+					'padding-top',
+					'padding-bottom',
+					'margin-top',
+					'margin-bottom',
+					'max-width',
+					'row-gap',
+					'column-gap',
+				]
+					.map(target => styleContent.indexOf(target))
+					.filter(index => index >= 0);
+				const firstRelevantStyleIndex = relevantStyleIndexes.length
+					? Math.min(...relevantStyleIndexes)
+					: -1;
+
+				if (
+					styleContent.includes('block-default') ||
+					(isLayoutBlock && firstRelevantStyleIndex >= 0)
+				) {
+					const snippetIndex = styleContent.includes('block-default')
+						? styleContent.indexOf('block-default')
+						: firstRelevantStyleIndex;
+					const getDeclaration = property =>
+						styleContent.match(
+							new RegExp(`${property}:\\s*([^;]+);`)
+						)?.[1] || 'n/a';
+
+					debugSCBlockDefaults('block style content generated', {
+						blockName,
+						uniqueID,
+						currentBreakpoint,
+						styleContentSummary: [
+							`hasUniqueID=${styleContent.includes(uniqueID)}`,
+							`containsBlockDefault=${styleContent.includes(
+								'block-default'
+							)}`,
+							`containsIndicatorSelector=${styleContent.includes(
+								'maxi-block-indicators'
+							)}`,
+							`paddingTop=${getDeclaration('padding-top')}`,
+							`paddingBottom=${getDeclaration(
+								'padding-bottom'
+							)}`,
+							`marginTop=${getDeclaration('margin-top')}`,
+							`marginBottom=${getDeclaration('margin-bottom')}`,
+						].join(', '),
+						isIframe: !!iframe,
+						isSiteEditor,
+						styleLength: styleContent.length,
+						containsBlockDefault:
+							styleContent.includes('block-default'),
+						containsIndicatorSelector: styleContent.includes(
+							'maxi-block-indicators'
+						),
+						styleSnippet: styleContent.slice(
+							Math.max(0, snippetIndex - 180),
+							snippetIndex + 420
+						),
+					});
+				}
+			}
 			if (currentBreakpoint === 'xxl') {
 				this.xxlStyleCache = styleContent;
 				this.isXxlStyleCacheDirty = false;

--- a/src/extensions/maxi-block/maxiBlockComponent.js
+++ b/src/extensions/maxi-block/maxiBlockComponent.js
@@ -57,6 +57,11 @@ import processRelations from '@extensions/relations/processRelations';
 import compareVersions from './compareVersions';
 import batchBlockDispatcher from './batchBlockDispatcher';
 import {
+	debugSCBlockDefaults,
+	parseBlockDefaultKey,
+	SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+} from '@extensions/style-cards/blockDefaults';
+import {
 	countProfile,
 	getProfileStart,
 	recordProfile,
@@ -172,6 +177,8 @@ class MaxiBlockComponent extends Component {
 		this.isPatternsPreview = false;
 		this.xxlStyleCache = null;
 		this.isXxlStyleCacheDirty = false;
+		this.handleStyleCardBlockDefaultsUpdate =
+			this.handleStyleCardBlockDefaultsUpdate.bind(this);
 
 		const previewIframes = getSiteEditorPreviewIframes();
 
@@ -346,6 +353,11 @@ class MaxiBlockComponent extends Component {
 		if (this.isPatternsPreview || this.templateModal) {
 			return;
 		}
+
+		window.addEventListener(
+			SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+			this.handleStyleCardBlockDefaultsUpdate
+		);
 
 		// Step 2: FSE iframe styles and observer
 		if (getIsSiteEditor()) {
@@ -785,13 +797,17 @@ class MaxiBlockComponent extends Component {
 		if (this.maxiBlockDidUpdate) {
 			this.maxiBlockDidUpdate(prevProps, prevState, shouldDisplayStyles);
 		}
-
 	}
 
 	componentWillUnmount() {
 		const { uniqueID } = this.props.attributes;
 
 		// Block cleanup initiated
+
+		window.removeEventListener(
+			SC_BLOCK_DEFAULTS_UPDATE_EVENT,
+			this.handleStyleCardBlockDefaultsUpdate
+		);
 
 		// Return early checks
 		if (
@@ -891,9 +907,7 @@ class MaxiBlockComponent extends Component {
 		if (!keepStylesOnEditor && !keepStylesOnCloning) {
 			try {
 				const allClientIds =
-					select(
-						'core/block-editor'
-					).getClientIdsWithDescendants();
+					select('core/block-editor').getClientIdsWithDescendants();
 				keepStylesOnStorePresence = allClientIds.includes(
 					this.props.clientId
 				);
@@ -914,9 +928,8 @@ class MaxiBlockComponent extends Component {
 			const batchStyleOperations = () => {
 				// Double-check: the block might have been re-added (reconciliation)
 				// between unmount and this rAF callback firing
-				const stillGone = !select('core/block-editor').getBlock(
-					clientId
-				);
+				const stillGone =
+					!select('core/block-editor').getBlock(clientId);
 				if (!stillGone) {
 					return;
 				}
@@ -963,6 +976,37 @@ class MaxiBlockComponent extends Component {
 		if (this.maxiBlockWillUnmount) {
 			this.maxiBlockWillUnmount(isBlockBeingRemoved);
 		}
+	}
+
+	handleStyleCardBlockDefaultsUpdate(event) {
+		if (this.isPatternsPreview || this.templateModal) return;
+
+		const blockName = this.props.name?.replace('maxi-blocks/', '');
+		const blockDefaults = event?.detail?.blockDefaults ?? {};
+		const affectedBlockNames = [
+			...new Set(
+				Object.keys(blockDefaults)
+					.map(key => parseBlockDefaultKey(key)?.blockName)
+					.filter(Boolean)
+			),
+		];
+
+		if (
+			affectedBlockNames.length > 0 &&
+			!affectedBlockNames.includes(blockName)
+		)
+			return;
+
+		debugSCBlockDefaults('block refresh from defaults update', {
+			blockName,
+			uniqueID: this.props.attributes?.uniqueID,
+			affectedBlockNames,
+		});
+
+		this.invalidateAttributeCaches();
+		this.isXxlStyleCacheDirty = true;
+		this.displayStyles(false, false, false, false);
+		this.forceUpdate();
 	}
 
 	// Add new helper method for repeater cleanup
@@ -1727,10 +1771,7 @@ class MaxiBlockComponent extends Component {
 					'maxiBlockComponent breakpoint cache ineligible viewport'
 				);
 			} else {
-				if (
-					currentBreakpoint === 'xxl' &&
-					this.isXxlStyleCacheDirty
-				) {
+				if (currentBreakpoint === 'xxl' && this.isXxlStyleCacheDirty) {
 					countProfile(
 						'maxiBlockComponent breakpoint cache dirty xxl'
 					);
@@ -1827,8 +1868,12 @@ class MaxiBlockComponent extends Component {
 			shouldGenerateNewStyles = true;
 		}
 
-		const breakpoints = shouldGenerateNewStyles ? this.getBreakpoints : null;
-		const isSiteEditor = shouldGenerateNewStyles ? getIsSiteEditor() : false;
+		const breakpoints = shouldGenerateNewStyles
+			? this.getBreakpoints
+			: null;
+		const isSiteEditor = shouldGenerateNewStyles
+			? getIsSiteEditor()
+			: false;
 		let obj;
 		let customDataRelations;
 		if (shouldGenerateNewStyles) {

--- a/src/extensions/maxi-block/test/getBlockElementForStyleDebug.js
+++ b/src/extensions/maxi-block/test/getBlockElementForStyleDebug.js
@@ -1,0 +1,53 @@
+import getBlockElementForStyleDebug from '@extensions/maxi-block/getBlockElementForStyleDebug';
+
+describe('getBlockElementForStyleDebug', () => {
+	const uniqueID = 'container-maxi-c474f294-u';
+
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('finds frontend blocks by id first', () => {
+		const frontendBlock = document.createElement('div');
+		frontendBlock.id = uniqueID;
+		document.body.appendChild(frontendBlock);
+
+		const editorBlock = document.createElement('div');
+		editorBlock.className = `maxi-block maxi-block--backend ${uniqueID}`;
+		document.body.appendChild(editorBlock);
+
+		expect(getBlockElementForStyleDebug(document, uniqueID)).toEqual({
+			element: frontendBlock,
+			method: 'id',
+		});
+	});
+
+	it('finds editor blocks by the generated backend class', () => {
+		const editorBlock = document.createElement('div');
+		editorBlock.className = `wp-block maxi-block maxi-block--backend ${uniqueID}`;
+		document.body.appendChild(editorBlock);
+
+		expect(getBlockElementForStyleDebug(document, uniqueID)).toEqual({
+			element: editorBlock,
+			method: 'backendClass',
+		});
+	});
+
+	it('falls back to uniqueID attributes', () => {
+		const block = document.createElement('div');
+		block.setAttribute('uniqueID', uniqueID);
+		document.body.appendChild(block);
+
+		expect(getBlockElementForStyleDebug(document, uniqueID)).toEqual({
+			element: block,
+			method: 'uniqueIDAttr',
+		});
+	});
+
+	it('returns an empty lookup when the block is missing', () => {
+		expect(getBlockElementForStyleDebug(document, uniqueID)).toEqual({
+			element: null,
+			method: null,
+		});
+	});
+});

--- a/src/extensions/maxi-block/test/handleSetAttributes.js
+++ b/src/extensions/maxi-block/test/handleSetAttributes.js
@@ -417,4 +417,24 @@ describe('handleSetAttributes', () => {
 
 		expect(handleSetAttributes(args)).toStrictEqual(expectedAttrs);
 	});
+
+	it('preserves Style Card block-default keys that use the block separator', () => {
+		const result = handleSetAttributes({
+			obj: {
+				'container-maxi|padding-top-xl': '20',
+				'container-maxi|padding-top-unit-xl': 'px',
+			},
+			attributes: {},
+			defaultAttributes: {},
+			onChange,
+			isStyleCard: true,
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				'container-maxi|padding-top-xl': '20',
+				'container-maxi|padding-top-unit-xl': 'px',
+			})
+		);
+	});
 });

--- a/src/extensions/style-cards/blockDefaults.js
+++ b/src/extensions/style-cards/blockDefaults.js
@@ -1,0 +1,400 @@
+import { select } from '@wordpress/data';
+
+import getActiveStyleCard from './getActiveStyleCard';
+
+export const BLOCK_DEFAULTS_GROUP = 'blockDefaults';
+const BLOCK_DEFAULT_KEY_SEPARATOR = '|';
+const SC_BLOCK_DEFAULTS_META_KEY = '__scBlockDefaults';
+
+export const blockDefaultBlocks = [
+	'accordion-maxi',
+	'button-maxi',
+	'column-maxi',
+	'container-maxi',
+	'divider-maxi',
+	'group-maxi',
+	'image-maxi',
+	'list-item-maxi',
+	'map-maxi',
+	'number-counter-maxi',
+	'pane-maxi',
+	'row-maxi',
+	'search-maxi',
+	'slide-maxi',
+	'slider-maxi',
+	'svg-icon-maxi',
+	'text-maxi',
+	'video-maxi',
+];
+
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+const styles = ['light', 'dark'];
+
+const shippedBlockDefaults = {
+	'container-maxi': {
+		'max-width-xxl': '1690',
+		'max-width-xl': '1170',
+		'max-width-l': '90',
+		'max-width-unit-xxl': 'px',
+		'max-width-unit-xl': 'px',
+		'max-width-unit-l': '%',
+		'width-l': '1170',
+		'width-m': '1000',
+		'width-s': '700',
+		'width-xs': '460',
+		'width-unit-l': 'px',
+		'width-unit-m': 'px',
+		'width-unit-s': 'px',
+		'width-unit-xs': 'px',
+	},
+	'row-maxi': {
+		'max-width-xxl': '1690',
+		'max-width-xl': '1170',
+		'max-width-l': '90',
+		'max-width-unit-xxl': 'px',
+		'max-width-unit-xl': 'px',
+		'max-width-unit-l': '%',
+	},
+};
+
+const cssLengthTargets = [
+	'max-width',
+	'min-width',
+	'width',
+	'max-height',
+	'min-height',
+	'height',
+	'margin-top',
+	'margin-right',
+	'margin-bottom',
+	'margin-left',
+	'padding-top',
+	'padding-right',
+	'padding-bottom',
+	'padding-left',
+	'border-top-width',
+	'border-right-width',
+	'border-bottom-width',
+	'border-left-width',
+	'border-top-left-radius',
+	'border-top-right-radius',
+	'border-bottom-right-radius',
+	'border-bottom-left-radius',
+	'row-gap',
+	'column-gap',
+];
+
+export const getBlockDefaultKey = (blockName, attr) =>
+	`${blockName}${BLOCK_DEFAULT_KEY_SEPARATOR}${attr}`;
+
+export const parseBlockDefaultKey = key => {
+	const separatorIndex = key.indexOf(BLOCK_DEFAULT_KEY_SEPARATOR);
+
+	if (separatorIndex === -1) return null;
+
+	return {
+		blockName: key.slice(0, separatorIndex),
+		attr: key.slice(separatorIndex + 1),
+	};
+};
+
+const isValidValue = value =>
+	value !== undefined && value !== null && value !== '';
+
+const stringify = value => (isValidValue(value) ? `${value}` : value);
+
+const getBreakpoint = attr =>
+	breakpoints.find(breakpoint => attr.endsWith(`-${breakpoint}`));
+
+const withoutBreakpoint = attr => {
+	const breakpoint = getBreakpoint(attr);
+	return breakpoint ? attr.slice(0, -breakpoint.length - 1) : attr;
+};
+
+export const getUnitAttribute = attr => {
+	if (attr.includes('-unit-')) return null;
+
+	const breakpoint = getBreakpoint(attr);
+	const baseAttr = withoutBreakpoint(attr);
+
+	if (!breakpoint || !cssLengthTargets.includes(baseAttr)) return null;
+
+	return `${baseAttr}-unit-${breakpoint}`;
+};
+
+const getResponsiveValue = (attributes, target, breakpoint) => {
+	const breakpointPosition = breakpoints.indexOf(breakpoint);
+
+	if (breakpointPosition === -1) return undefined;
+
+	for (let i = breakpointPosition; i >= 0; i -= 1) {
+		const value = attributes?.[`${target}-${breakpoints[i]}`];
+		if (isValidValue(value)) return value;
+	}
+
+	return undefined;
+};
+
+const shouldRespectSizeToggle = (attr, attributes) => {
+	const breakpoint = getBreakpoint(attr);
+	const baseAttr = withoutBreakpoint(attr);
+
+	if (!breakpoint) return false;
+
+	const isWidthTarget = ['width', 'max-width', 'min-width'].includes(
+		baseAttr
+	);
+
+	if (!isWidthTarget) return false;
+
+	const fullWidth = getResponsiveValue(attributes, 'full-width', breakpoint);
+	const fitContent = getResponsiveValue(
+		attributes,
+		'width-fit-content',
+		breakpoint
+	);
+
+	return Boolean(fullWidth || fitContent);
+};
+
+export const normalizeBlockName = value => {
+	if (!value) return null;
+
+	const normalizedValue = value.replace('maxi-blocks/', '');
+	if (blockDefaultBlocks.includes(normalizedValue)) return normalizedValue;
+
+	return (
+		blockDefaultBlocks.find(blockName =>
+			normalizedValue.startsWith(`${blockName}-`)
+		) || null
+	);
+};
+
+const sanitizeCssPart = value => value.replace(/[^a-zA-Z0-9-]/g, '-');
+
+export const getBlockDefaultCssVarName = (blockStyle, blockName, attr) =>
+	`--maxi-${blockStyle}-block-default-${sanitizeCssPart(
+		blockName
+	)}-${sanitizeCssPart(attr)}`;
+
+const getBlockDefaults = (styleCard, blockStyle) => ({
+	...(styleCard?.[blockStyle]?.defaultStyleCard?.[BLOCK_DEFAULTS_GROUP] ??
+		{}),
+	...(styleCard?.[blockStyle]?.styleCard?.[BLOCK_DEFAULTS_GROUP] ?? {}),
+});
+
+const getBlockDefaultValue = ({ styleCard, blockStyle, blockName, attr }) =>
+	getBlockDefaults(styleCard, blockStyle)?.[
+		getBlockDefaultKey(blockName, attr)
+	];
+
+const getActiveStyleCardValue = () => {
+	let store = null;
+
+	try {
+		store = select('maxiBlocks/style-cards');
+	} catch {
+		return null;
+	}
+
+	const styleCards = store?.receiveMaxiStyleCards?.();
+
+	if (!styleCards) return null;
+
+	const activeStyleCard = getActiveStyleCard(styleCards);
+
+	return activeStyleCard?.value;
+};
+
+const getShippedDefaultValue = ({ blockName, attr, defaultAttributes }) => {
+	if (Object.prototype.hasOwnProperty.call(shippedBlockDefaults, blockName)) {
+		const blockDefaults = shippedBlockDefaults[blockName];
+		if (Object.prototype.hasOwnProperty.call(blockDefaults, attr))
+			return blockDefaults[attr];
+	}
+
+	return defaultAttributes?.[attr]?.default;
+};
+
+export const getShippedBlockDefault = (blockName, attr, fallback = '') => {
+	const value = getShippedDefaultValue({ blockName, attr });
+
+	return isValidValue(value) ? value : fallback;
+};
+
+const getFallback = ({ blockName, attr, unitAttr, defaultAttributes }) => {
+	const value = getShippedDefaultValue({
+		blockName,
+		attr,
+		defaultAttributes,
+	});
+	const unit = unitAttr
+		? getShippedDefaultValue({
+				blockName,
+				attr: unitAttr,
+				defaultAttributes,
+		  })
+		: undefined;
+
+	if (!isValidValue(value)) return undefined;
+
+	return `${value}${unit ?? ''}`;
+};
+
+const isAttributeChanged = ({
+	attr,
+	unitAttr,
+	blockName,
+	attributes,
+	defaultAttributes,
+}) => {
+	const currentValue = attributes?.[attr];
+	const shippedValue = getShippedDefaultValue({
+		blockName,
+		attr,
+		defaultAttributes,
+	});
+
+	if (
+		isValidValue(currentValue) &&
+		isValidValue(shippedValue) &&
+		stringify(currentValue) !== stringify(shippedValue)
+	)
+		return true;
+
+	if (unitAttr) {
+		const currentUnit = attributes?.[unitAttr];
+		const shippedUnit = getShippedDefaultValue({
+			blockName,
+			attr: unitAttr,
+			defaultAttributes,
+		});
+
+		if (
+			isValidValue(currentUnit) &&
+			isValidValue(shippedUnit) &&
+			stringify(currentUnit) !== stringify(shippedUnit)
+		)
+			return true;
+	}
+
+	return false;
+};
+
+export const applySCBlockDefaultsToAttributes = ({
+	response,
+	attributes,
+	defaultAttributes,
+	styleCard: rawStyleCard,
+}) => {
+	const blockName = normalizeBlockName(
+		attributes?.blockName || attributes?.uniqueID
+	);
+	const blockStyle = ['light', 'dark'].includes(attributes?.blockStyle)
+		? attributes.blockStyle
+		: null;
+
+	if (!blockName || !blockStyle) return response;
+
+	const styleCard = rawStyleCard || getActiveStyleCardValue();
+	if (!styleCard) return response;
+
+	const blockDefaults = getBlockDefaults(styleCard, blockStyle);
+
+	const nextResponse = { ...response };
+
+	Object.keys(defaultAttributes).forEach(attr => {
+		if (attr.includes('-unit-')) return;
+		if (shouldRespectSizeToggle(attr, attributes)) return;
+
+		const unitAttr = getUnitAttribute(attr);
+		const attributeChanged = isAttributeChanged({
+			attr,
+			unitAttr,
+			blockName,
+			attributes,
+			defaultAttributes,
+		});
+
+		if (attributeChanged) return;
+
+		const scValue = getBlockDefaultValue({
+			styleCard,
+			blockStyle,
+			blockName,
+			attr,
+		});
+		const currentValue = attributes?.[attr];
+		const hasDefaultLikeCurrentValue = isValidValue(currentValue);
+		const value = isValidValue(scValue) ? scValue : currentValue;
+
+		if (!isValidValue(value)) return;
+
+		if (isValidValue(scValue)) nextResponse[attr] = scValue;
+
+		const scUnit = unitAttr
+			? getBlockDefaultValue({
+					styleCard,
+					blockStyle,
+					blockName,
+					attr: unitAttr,
+			  })
+			: undefined;
+
+		if (unitAttr && isValidValue(scUnit)) nextResponse[unitAttr] = scUnit;
+		if (!isValidValue(scValue) && !hasDefaultLikeCurrentValue) return;
+
+		const fallback =
+			getFallback({
+				blockName,
+				attr,
+				unitAttr,
+				defaultAttributes,
+			}) || `${value}${unitAttr ? attributes?.[unitAttr] ?? '' : ''}`;
+
+		nextResponse[SC_BLOCK_DEFAULTS_META_KEY] = {
+			...nextResponse[SC_BLOCK_DEFAULTS_META_KEY],
+			[attr]: {
+				blockName,
+				blockStyle,
+				cssVar: getBlockDefaultCssVarName(blockStyle, blockName, attr),
+				fallback,
+			},
+		};
+	});
+
+	return nextResponse;
+};
+
+export const getStyleCardBlockDefaultVariables = styleCard => {
+	const response = {};
+
+	styles.forEach(blockStyle => {
+		const blockDefaults = {
+			...(styleCard?.[blockStyle]?.defaultStyleCard?.[
+				BLOCK_DEFAULTS_GROUP
+			] ?? {}),
+			...(styleCard?.[blockStyle]?.styleCard?.[BLOCK_DEFAULTS_GROUP] ??
+				{}),
+		};
+
+		Object.entries(blockDefaults).forEach(([key, value]) => {
+			const parsedKey = parseBlockDefaultKey(key);
+			if (!parsedKey || !isValidValue(value)) return;
+
+			const { blockName, attr } = parsedKey;
+			if (attr.includes('-unit-')) return;
+
+			const unitAttr = getUnitAttribute(attr);
+			const unit = unitAttr
+				? blockDefaults[getBlockDefaultKey(blockName, unitAttr)]
+				: '';
+
+			response[
+				getBlockDefaultCssVarName(blockStyle, blockName, attr)
+			] = `${value}${unit ?? ''}`;
+		});
+	});
+
+	return response;
+};

--- a/src/extensions/style-cards/blockDefaults.js
+++ b/src/extensions/style-cards/blockDefaults.js
@@ -3,8 +3,38 @@ import { select } from '@wordpress/data';
 import getActiveStyleCard from './getActiveStyleCard';
 
 export const BLOCK_DEFAULTS_GROUP = 'blockDefaults';
+export const SC_BLOCK_DEFAULTS_UPDATE_EVENT =
+	'maxi-blocks:style-card-block-defaults-update';
+export const SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES =
+	'scBlockDefaultsExcludedAttributes';
 const BLOCK_DEFAULT_KEY_SEPARATOR = '|';
 const SC_BLOCK_DEFAULTS_META_KEY = '__scBlockDefaults';
+
+export const isSCBlockDefaultsDebugEnabled = () => {
+	try {
+		const isLocalWampEditor =
+			typeof window !== 'undefined' &&
+			window.location?.hostname === 'localhost' &&
+			window.location?.pathname?.includes('/maxi-blocks-local/');
+
+		return (
+			typeof window !== 'undefined' &&
+			(isLocalWampEditor ||
+				window.maxiDebugSCBlockDefaults === true ||
+				window.localStorage?.getItem('maxiDebugSCBlockDefaults') ===
+					'1')
+		);
+	} catch {
+		return false;
+	}
+};
+
+export const debugSCBlockDefaults = (label, payload = {}) => {
+	if (!isSCBlockDefaultsDebugEnabled()) return;
+
+	// eslint-disable-next-line no-console
+	console.info(`[SC block defaults] ${label}`, payload);
+};
 
 export const blockDefaultBlocks = [
 	'accordion-maxi',
@@ -157,6 +187,31 @@ const shouldRespectSizeToggle = (attr, attributes) => {
 	return Boolean(fullWidth || fitContent);
 };
 
+export const getSCBlockDefaultsExcludedAttributes = attributes => {
+	const value = attributes?.[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES];
+
+	return Array.isArray(value) ? value : [];
+};
+
+export const getSCBlockDefaultsExcludedAttributesUpdate = ({
+	attributes,
+	attr,
+	exclude,
+}) => {
+	const currentExclusions = getSCBlockDefaultsExcludedAttributes(attributes);
+	const nextExclusions = exclude
+		? Array.from(new Set([...currentExclusions, attr]))
+		: currentExclusions.filter(excludedAttr => excludedAttr !== attr);
+
+	return {
+		[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]:
+			nextExclusions.length > 0 ? nextExclusions : undefined,
+	};
+};
+
+const isSCBlockDefaultExcluded = (attributes, attr) =>
+	getSCBlockDefaultsExcludedAttributes(attributes).includes(attr);
+
 export const normalizeBlockName = value => {
 	if (!value) return null;
 
@@ -198,6 +253,12 @@ const getActiveStyleCardValue = () => {
 	}
 
 	const styleCards = store?.receiveMaxiStyleCards?.();
+
+	debugSCBlockDefaults('active style card lookup', {
+		hasStore: Boolean(store),
+		hasStyleCards: Boolean(styleCards),
+		styleCardKeys: styleCards ? Object.keys(styleCards) : [],
+	});
 
 	if (!styleCards) return null;
 
@@ -294,6 +355,13 @@ export const applySCBlockDefaultsToAttributes = ({
 		? attributes.blockStyle
 		: null;
 
+	debugSCBlockDefaults('apply start', {
+		blockName,
+		blockStyle,
+		uniqueID: attributes?.uniqueID,
+		defaultAttributeKeys: Object.keys(defaultAttributes ?? {}),
+	});
+
 	if (!blockName || !blockStyle) return response;
 
 	const styleCard = rawStyleCard || getActiveStyleCardValue();
@@ -301,11 +369,35 @@ export const applySCBlockDefaultsToAttributes = ({
 
 	const blockDefaults = getBlockDefaults(styleCard, blockStyle);
 
+	debugSCBlockDefaults('style card values', {
+		blockName,
+		blockStyle,
+		blockDefaultKeys: Object.keys(blockDefaults),
+	});
+
 	const nextResponse = { ...response };
 
 	Object.keys(defaultAttributes).forEach(attr => {
 		if (attr.includes('-unit-')) return;
-		if (shouldRespectSizeToggle(attr, attributes)) return;
+		if (isSCBlockDefaultExcluded(attributes, attr)) {
+			debugSCBlockDefaults('skip explicit block default opt-out', {
+				blockName,
+				blockStyle,
+				attr,
+			});
+			return;
+		}
+		if (shouldRespectSizeToggle(attr, attributes)) {
+			debugSCBlockDefaults('skip size toggle', {
+				blockName,
+				blockStyle,
+				attr,
+				fullWidth: attributes?.[`full-width-${getBreakpoint(attr)}`],
+				fitContent:
+					attributes?.[`width-fit-content-${getBreakpoint(attr)}`],
+			});
+			return;
+		}
 
 		const unitAttr = getUnitAttribute(attr);
 		const attributeChanged = isAttributeChanged({
@@ -316,7 +408,16 @@ export const applySCBlockDefaultsToAttributes = ({
 			defaultAttributes,
 		});
 
-		if (attributeChanged) return;
+		if (attributeChanged) {
+			debugSCBlockDefaults('skip custom value', {
+				blockName,
+				blockStyle,
+				attr,
+				currentValue: attributes?.[attr],
+				currentUnit: unitAttr ? attributes?.[unitAttr] : undefined,
+			});
+			return;
+		}
 
 		const scValue = getBlockDefaultValue({
 			styleCard,
@@ -361,6 +462,25 @@ export const applySCBlockDefaultsToAttributes = ({
 				fallback,
 			},
 		};
+
+		debugSCBlockDefaults('apply value', {
+			blockName,
+			blockStyle,
+			attr,
+			unitAttr,
+			scValue,
+			value,
+			scUnit,
+			fallback,
+			cssVar: nextResponse[SC_BLOCK_DEFAULTS_META_KEY][attr].cssVar,
+		});
+	});
+
+	debugSCBlockDefaults('apply result', {
+		blockName,
+		blockStyle,
+		response,
+		nextResponse,
 	});
 
 	return nextResponse;
@@ -395,6 +515,8 @@ export const getStyleCardBlockDefaultVariables = styleCard => {
 			] = `${value}${unit ?? ''}`;
 		});
 	});
+
+	debugSCBlockDefaults('generated variables', response);
 
 	return response;
 };

--- a/src/extensions/style-cards/blockDefaults.js
+++ b/src/extensions/style-cards/blockDefaults.js
@@ -9,28 +9,113 @@ export const SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES =
 	'scBlockDefaultsExcludedAttributes';
 const BLOCK_DEFAULT_KEY_SEPARATOR = '|';
 const SC_BLOCK_DEFAULTS_META_KEY = '__scBlockDefaults';
+const SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY = 'maxiSCBlockDefaultsDebugLog';
+const SC_BLOCK_DEFAULTS_DEBUG_LOG_LIMIT = 500;
+let latestEditorStyleCardValue = null;
+const debugLayoutBlocks = ['container-maxi', 'row-maxi'];
+const focusedDebugLabels = [
+	'advanced globals change',
+	'editor onChangeValue result',
+	'editor dispatch block defaults update',
+	'block refresh from defaults update',
+	'library layout sequence matched',
+	'library layout sequence not matched',
+];
+const layoutDebugAttributePattern =
+	/(^|\|)(padding|margin|row-gap|column-gap|flex-wrap|max-width|width|min-width|max-height|height|min-height|full-width|width-fit-content|size-advanced-options)-/;
+
+const isSCBlockDefaultsLocalWampEditor = () =>
+	typeof window !== 'undefined' &&
+	window.location?.hostname === 'localhost' &&
+	window.location?.pathname?.includes('/maxi-blocks-local/');
+
+const isSCBlockDefaultsExplicitDebugEnabled = () =>
+	typeof window !== 'undefined' &&
+	(window.maxiDebugSCBlockDefaults === true ||
+		window.localStorage?.getItem('maxiDebugSCBlockDefaults') === '1');
+
+const isSCBlockDefaultsVerboseDebugEnabled = () =>
+	typeof window !== 'undefined' &&
+	(isSCBlockDefaultsExplicitDebugEnabled() ||
+		window.maxiDebugSCBlockDefaultsVerbose === true ||
+		window.localStorage?.getItem('maxiDebugSCBlockDefaultsVerbose') ===
+			'1');
 
 export const isSCBlockDefaultsDebugEnabled = () => {
 	try {
-		const isLocalWampEditor =
-			typeof window !== 'undefined' &&
-			window.location?.hostname === 'localhost' &&
-			window.location?.pathname?.includes('/maxi-blocks-local/');
-
 		return (
 			typeof window !== 'undefined' &&
-			(isLocalWampEditor ||
-				window.maxiDebugSCBlockDefaults === true ||
-				window.localStorage?.getItem('maxiDebugSCBlockDefaults') ===
-					'1')
+			(isSCBlockDefaultsLocalWampEditor() ||
+				isSCBlockDefaultsExplicitDebugEnabled() ||
+				isSCBlockDefaultsVerboseDebugEnabled())
 		);
 	} catch {
 		return false;
 	}
 };
 
+const hasLayoutBlockReference = value => {
+	if (!value) return false;
+	if (typeof value === 'string')
+		return debugLayoutBlocks.some(blockName => value.includes(blockName));
+	if (Array.isArray(value)) return value.some(hasLayoutBlockReference);
+	if (typeof value === 'object')
+		return Object.values(value).some(hasLayoutBlockReference);
+
+	return false;
+};
+
+const hasLayoutAttributeReference = value => {
+	if (!value) return false;
+	if (typeof value === 'string')
+		return layoutDebugAttributePattern.test(value);
+	if (Array.isArray(value)) return value.some(hasLayoutAttributeReference);
+	if (typeof value === 'object')
+		return Object.entries(value).some(
+			([key, nestedValue]) =>
+				hasLayoutAttributeReference(key) ||
+				hasLayoutAttributeReference(nestedValue)
+		);
+
+	return false;
+};
+
+const isFocusedDebugEntry = (label, payload) =>
+	focusedDebugLabels.includes(label) ||
+	(hasLayoutAttributeReference(payload) &&
+		(debugLayoutBlocks.includes(payload?.blockName) ||
+			debugLayoutBlocks.includes(payload?.meta?.blockName) ||
+			hasLayoutBlockReference(payload?.availableMetaBlocks) ||
+			hasLayoutBlockReference(payload?.prefixedValues) ||
+			hasLayoutBlockReference(payload?.response)));
+
 export const debugSCBlockDefaults = (label, payload = {}) => {
 	if (!isSCBlockDefaultsDebugEnabled()) return;
+	if (
+		!isSCBlockDefaultsVerboseDebugEnabled() &&
+		!isFocusedDebugEntry(label, payload)
+	)
+		return;
+
+	try {
+		const entry = {
+			label,
+			payload,
+			time: new Date().toISOString(),
+		};
+		const currentLog = Array.isArray(window[SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY])
+			? window[SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY]
+			: [];
+
+		window[SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY] = [
+			...currentLog,
+			entry,
+		].slice(-SC_BLOCK_DEFAULTS_DEBUG_LOG_LIMIT);
+		window.getMaxiSCBlockDefaultsDebugLog = () =>
+			window[SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY];
+	} catch {
+		// Keep console debugging available even when window helpers are blocked.
+	}
 
 	// eslint-disable-next-line no-console
 	console.info(`[SC block defaults] ${label}`, payload);
@@ -87,6 +172,183 @@ const shippedBlockDefaults = {
 	},
 };
 
+const libraryLayoutDefaultSequences = {
+	'container-maxi': [
+		...['padding-top', 'padding-bottom'].flatMap(target => [
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '100',
+					xxl: '150',
+					xl: '100',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '100',
+					xxl: '150',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+					xl: '150',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+					xl: '150',
+					s: '60',
+					xs: '40',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+					xl: '150',
+					l: '120',
+					m: '100',
+					s: '60',
+					xs: '40',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					l: '120',
+					m: '100',
+					s: '80',
+					xs: '60',
+				},
+			},
+		]),
+		...['margin-top', 'margin-bottom'].map(target => ({
+			target,
+			unit: 'px',
+			values: {
+				general: '100',
+			},
+		})),
+	],
+	'row-maxi': [
+		...['padding-top', 'padding-bottom'].flatMap(target => [
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '100',
+					xxl: '150',
+					s: '0',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+					s: '0',
+				},
+			},
+			{
+				target,
+				unit: 'px',
+				values: {
+					general: '150',
+					xxl: '200',
+					xl: '150',
+					s: '0',
+				},
+			},
+		]),
+		{
+			target: 'row-gap',
+			unit: 'px',
+			values: {
+				general: '20',
+				xs: '10',
+			},
+		},
+		{
+			target: 'column-gap',
+			unit: '%',
+			values: {
+				general: '0',
+			},
+		},
+		{
+			target: 'column-gap',
+			unit: '%',
+			values: {
+				m: '2.5',
+				s: '2.5',
+				xs: '2.5',
+			},
+		},
+		{
+			target: 'column-gap',
+			unit: '%',
+			values: {
+				m: '2.5',
+				s: '2.5',
+			},
+		},
+		{
+			target: 'flex-wrap',
+			values: {
+				general: 'nowrap',
+				xs: 'wrap',
+			},
+		},
+		{
+			target: 'flex-wrap',
+			values: {
+				general: 'wrap',
+			},
+		},
+		{
+			target: 'flex-wrap',
+			values: {
+				general: 'wrap',
+				m: 'wrap',
+				s: 'wrap',
+				xs: 'wrap',
+			},
+		},
+		{
+			target: 'flex-wrap',
+			values: {
+				general: 'wrap',
+				m: 'wrap',
+				s: 'wrap',
+			},
+		},
+	],
+};
+
 const cssLengthTargets = [
 	'max-width',
 	'min-width',
@@ -114,6 +376,20 @@ const cssLengthTargets = [
 	'column-gap',
 ];
 
+const libraryLayoutSequenceTargets = [
+	'margin-top',
+	'margin-right',
+	'margin-bottom',
+	'margin-left',
+	'padding-top',
+	'padding-right',
+	'padding-bottom',
+	'padding-left',
+	'row-gap',
+	'column-gap',
+	'flex-wrap',
+];
+
 export const getBlockDefaultKey = (blockName, attr) =>
 	`${blockName}${BLOCK_DEFAULT_KEY_SEPARATOR}${attr}`;
 
@@ -132,6 +408,19 @@ const isValidValue = value =>
 	value !== undefined && value !== null && value !== '';
 
 const stringify = value => (isValidValue(value) ? `${value}` : value);
+
+const getDebugBlockDefaultSummary = (blockDefaults, blockName) =>
+	Object.entries(blockDefaults ?? {})
+		.filter(([key]) => {
+			const parsedKey = parseBlockDefaultKey(key);
+
+			return (
+				parsedKey?.blockName === blockName &&
+				layoutDebugAttributePattern.test(key)
+			);
+		})
+		.slice(0, 40)
+		.map(([key, value]) => `${key}=${stringify(value)}`);
 
 const getBreakpoint = attr =>
 	breakpoints.find(breakpoint => attr.endsWith(`-${breakpoint}`));
@@ -163,6 +452,140 @@ const getResponsiveValue = (attributes, target, breakpoint) => {
 	}
 
 	return undefined;
+};
+
+const getResponsiveSequenceSnapshot = (attributes, target) =>
+	breakpoints.reduce((acc, breakpoint) => {
+		const attr = `${target}-${breakpoint}`;
+		const unitAttr = getUnitAttribute(attr);
+		const value = attributes?.[attr];
+		const unit = unitAttr ? attributes?.[unitAttr] : undefined;
+
+		if (isValidValue(value) || isValidValue(unit)) {
+			acc[breakpoint] = {
+				value,
+				unit,
+			};
+		}
+
+		return acc;
+	}, {});
+
+const getLibraryLayoutDefaultSequenceMatch = ({
+	blockName,
+	attr,
+	attributes,
+}) => {
+	const target = withoutBreakpoint(attr);
+	const breakpoint = getBreakpoint(attr);
+
+	if (!target || !breakpoint)
+		return {
+			matched: false,
+			reason: 'missing target or breakpoint',
+			target,
+			breakpoint,
+		};
+
+	const candidateSequences = (
+		libraryLayoutDefaultSequences[blockName] || []
+	).filter(
+		({ target: sequenceTarget, values }) =>
+			sequenceTarget === target &&
+			Object.prototype.hasOwnProperty.call(values, breakpoint)
+	);
+
+	const actualValues = getResponsiveSequenceSnapshot(attributes, target);
+	let closestCandidate = null;
+
+	for (const candidate of candidateSequences) {
+		const { unit, values } = candidate;
+		const mismatches = breakpoints.reduce((acc, currentBreakpoint) => {
+			const currentAttr = `${target}-${currentBreakpoint}`;
+			const currentValue = attributes?.[currentAttr];
+			const expectedValue = values[currentBreakpoint];
+			const unitAttr = getUnitAttribute(currentAttr);
+			const currentUnit = unitAttr ? attributes?.[unitAttr] : null;
+
+			if (expectedValue === undefined) {
+				if (isValidValue(currentValue)) {
+					acc.push({
+						breakpoint: currentBreakpoint,
+						actual: currentValue,
+						expected: undefined,
+						reason: 'unexpected breakpoint value',
+					});
+				}
+
+				return acc;
+			}
+
+			if (
+				!isValidValue(currentValue) ||
+				stringify(currentValue) !== stringify(expectedValue)
+			) {
+				acc.push({
+					breakpoint: currentBreakpoint,
+					actual: currentValue,
+					expected: expectedValue,
+					reason: 'value mismatch',
+				});
+
+				return acc;
+			}
+
+			if (
+				unit &&
+				isValidValue(currentUnit) &&
+				stringify(currentUnit) !== stringify(unit)
+			) {
+				acc.push({
+					breakpoint: currentBreakpoint,
+					actual: currentUnit,
+					expected: unit,
+					reason: 'unit mismatch',
+				});
+			}
+
+			return acc;
+		}, []);
+
+		const candidateDetails = {
+			unit,
+			values,
+			mismatches,
+		};
+
+		if (!mismatches.length) {
+			return {
+				...candidateDetails,
+				actualValues,
+				breakpoint,
+				matched: true,
+				reason: 'matched library layout sequence',
+				target,
+			};
+		}
+
+		if (
+			!closestCandidate ||
+			mismatches.length < closestCandidate.mismatches.length
+		) {
+			closestCandidate = candidateDetails;
+		}
+	}
+
+	return {
+		...(closestCandidate || {}),
+		actualValues,
+		breakpoint,
+		candidateCount: candidateSequences.length,
+		matched: false,
+		reason: candidateSequences.length
+			? 'no library layout sequence matched'
+			: 'no library layout sequence configured for attr',
+		target,
+	};
 };
 
 const shouldRespectSizeToggle = (attr, attributes) => {
@@ -243,7 +666,26 @@ const getBlockDefaultValue = ({ styleCard, blockStyle, blockName, attr }) =>
 		getBlockDefaultKey(blockName, attr)
 	];
 
+export const setActiveStyleCardValueForBlockDefaults = styleCard => {
+	latestEditorStyleCardValue = styleCard || null;
+
+	debugSCBlockDefaults('active style card snapshot set', {
+		hasStyleCard: Boolean(latestEditorStyleCardValue),
+		blockDefaultKeys: styles.reduce(
+			(acc, blockStyle) => ({
+				...acc,
+				[blockStyle]: Object.keys(
+					getBlockDefaults(latestEditorStyleCardValue, blockStyle)
+				),
+			}),
+			{}
+		),
+	});
+};
+
 const getActiveStyleCardValue = () => {
+	if (latestEditorStyleCardValue) return latestEditorStyleCardValue;
+
 	let store = null;
 
 	try {
@@ -302,6 +744,56 @@ const getFallback = ({ blockName, attr, unitAttr, defaultAttributes }) => {
 	return `${value}${unit ?? ''}`;
 };
 
+const getFallbackValue = ({
+	blockName,
+	attr,
+	unitAttr,
+	currentValue,
+	value,
+	attributes,
+	defaultAttributes,
+	scUnit,
+}) => {
+	const fallbackValue = isValidValue(currentValue) ? currentValue : value;
+	const fallbackUnit = unitAttr
+		? attributes?.[unitAttr] ??
+		  getShippedDefaultValue({
+				blockName,
+				attr: unitAttr,
+				defaultAttributes,
+		  }) ??
+		  scUnit ??
+		  ''
+		: '';
+
+	return fallbackValue === 'auto'
+		? fallbackValue
+		: `${fallbackValue}${fallbackUnit}`;
+};
+
+const getStyleCardFallbackValue = ({
+	blockName,
+	attr,
+	unitAttr,
+	value,
+	attributes,
+	defaultAttributes,
+	scUnit,
+}) => {
+	const fallbackUnit = unitAttr
+		? scUnit ??
+		  attributes?.[unitAttr] ??
+		  getShippedDefaultValue({
+				blockName,
+				attr: unitAttr,
+				defaultAttributes,
+		  }) ??
+		  ''
+		: '';
+
+	return value === 'auto' ? value : `${value}${fallbackUnit}`;
+};
+
 const isAttributeChanged = ({
 	attr,
 	unitAttr,
@@ -315,10 +807,50 @@ const isAttributeChanged = ({
 		attr,
 		defaultAttributes,
 	});
+	const hasCurrentValue = isValidValue(currentValue);
+	const hasShippedValue = isValidValue(shippedValue);
+	const hasLibraryLayoutDefaultSequences = Boolean(
+		libraryLayoutDefaultSequences[blockName]?.length
+	);
+	const isLayoutSequenceTarget = libraryLayoutSequenceTargets.includes(
+		withoutBreakpoint(attr)
+	) && hasLibraryLayoutDefaultSequences;
+	const librarySequenceMatch = isLayoutSequenceTarget
+		? getLibraryLayoutDefaultSequenceMatch({
+				blockName,
+				attr,
+				attributes,
+		  })
+		: null;
+
+	if (hasCurrentValue && librarySequenceMatch?.matched) {
+		debugSCBlockDefaults('library layout sequence matched', {
+			blockName,
+			attr,
+			currentValue,
+			currentUnit: unitAttr ? attributes?.[unitAttr] : undefined,
+			...librarySequenceMatch,
+		});
+
+		return false;
+	}
+
+	if (hasCurrentValue && isLayoutSequenceTarget) {
+		debugSCBlockDefaults('library layout sequence not matched', {
+			blockName,
+			attr,
+			currentValue,
+			currentUnit: unitAttr ? attributes?.[unitAttr] : undefined,
+			...librarySequenceMatch,
+		});
+	}
+
+	if (hasCurrentValue && !hasShippedValue && isLayoutSequenceTarget)
+		return true;
 
 	if (
-		isValidValue(currentValue) &&
-		isValidValue(shippedValue) &&
+		hasCurrentValue &&
+		hasShippedValue &&
 		stringify(currentValue) !== stringify(shippedValue)
 	)
 		return true;
@@ -330,6 +862,13 @@ const isAttributeChanged = ({
 			attr: unitAttr,
 			defaultAttributes,
 		});
+
+		if (
+			isValidValue(currentUnit) &&
+			!isValidValue(shippedUnit) &&
+			isLayoutSequenceTarget
+		)
+			return true;
 
 		if (
 			isValidValue(currentUnit) &&
@@ -373,6 +912,10 @@ export const applySCBlockDefaultsToAttributes = ({
 		blockName,
 		blockStyle,
 		blockDefaultKeys: Object.keys(blockDefaults),
+		blockDefaultSummary: getDebugBlockDefaultSummary(
+			blockDefaults,
+			blockName
+		),
 	});
 
 	const nextResponse = { ...response };
@@ -445,13 +988,32 @@ export const applySCBlockDefaultsToAttributes = ({
 		if (unitAttr && isValidValue(scUnit)) nextResponse[unitAttr] = scUnit;
 		if (!isValidValue(scValue) && !hasDefaultLikeCurrentValue) return;
 
-		const fallback =
-			getFallback({
-				blockName,
-				attr,
-				unitAttr,
-				defaultAttributes,
-			}) || `${value}${unitAttr ? attributes?.[unitAttr] ?? '' : ''}`;
+		const fallback = isValidValue(scValue)
+			? getStyleCardFallbackValue({
+					blockName,
+					attr,
+					unitAttr,
+					value: scValue,
+					attributes,
+					defaultAttributes,
+					scUnit,
+			  })
+			: getFallback({
+					blockName,
+					attr,
+					unitAttr,
+					defaultAttributes,
+			  }) ||
+			  getFallbackValue({
+					blockName,
+					attr,
+					unitAttr,
+					currentValue,
+					value,
+					attributes,
+					defaultAttributes,
+					scUnit,
+			  });
 
 		nextResponse[SC_BLOCK_DEFAULTS_META_KEY] = {
 			...nextResponse[SC_BLOCK_DEFAULTS_META_KEY],
@@ -484,6 +1046,50 @@ export const applySCBlockDefaultsToAttributes = ({
 	});
 
 	return nextResponse;
+};
+
+export const getSCBlockDefaultStyleValue = ({
+	scBlockDefaults = {},
+	prefix = '',
+	target,
+	breakpoint,
+	fallbackValue,
+}) => {
+	const meta = scBlockDefaults[`${prefix}${target}-${breakpoint}`];
+	const availableMetaBlocks = Array.from(
+		new Set(
+			Object.values(scBlockDefaults)
+				.map(value => value?.blockName)
+				.filter(Boolean)
+		)
+	);
+
+	if (!meta?.cssVar) {
+		debugSCBlockDefaults('style fallback', {
+			target,
+			breakpoint,
+			fallbackValue,
+			prefix,
+			meta,
+			availableMetaBlocks,
+			availableMetaKeys: Object.keys(scBlockDefaults),
+		});
+
+		return fallbackValue;
+	}
+
+	const value = `var(${meta.cssVar}, ${meta.fallback || fallbackValue})`;
+
+	debugSCBlockDefaults('style css var', {
+		target,
+		breakpoint,
+		fallbackValue,
+		prefix,
+		meta,
+		value,
+	});
+
+	return value;
 };
 
 export const getStyleCardBlockDefaultVariables = styleCard => {

--- a/src/extensions/style-cards/blockDefaults.js
+++ b/src/extensions/style-cards/blockDefaults.js
@@ -11,13 +11,29 @@ const BLOCK_DEFAULT_KEY_SEPARATOR = '|';
 const SC_BLOCK_DEFAULTS_META_KEY = '__scBlockDefaults';
 const SC_BLOCK_DEFAULTS_DEBUG_LOG_KEY = 'maxiSCBlockDefaultsDebugLog';
 const SC_BLOCK_DEFAULTS_DEBUG_LOG_LIMIT = 500;
+const SC_BLOCK_DEFAULTS_SUBSCRIBERS_KEY =
+	'maxiSCBlockDefaultsUpdateSubscribers';
 let latestEditorStyleCardValue = null;
 const debugLayoutBlocks = ['container-maxi', 'row-maxi'];
 const focusedDebugLabels = [
 	'advanced globals change',
 	'editor onChangeValue result',
 	'editor dispatch block defaults update',
+	'editor dispatch block defaults update targets',
+	'block subscribed to defaults update',
+	'block defaults update handler invoked',
+	'block defaults update skipped',
 	'block refresh from defaults update',
+];
+const verboseDebugLabels = [
+	'apply start',
+	'style card values',
+	'apply value',
+	'apply result',
+	'skip custom value',
+	'style fallback',
+	'block style content generated',
+	'block computed layout after style apply',
 	'library layout sequence matched',
 	'library layout sequence not matched',
 ];
@@ -34,10 +50,9 @@ const isSCBlockDefaultsExplicitDebugEnabled = () =>
 	(window.maxiDebugSCBlockDefaults === true ||
 		window.localStorage?.getItem('maxiDebugSCBlockDefaults') === '1');
 
-const isSCBlockDefaultsVerboseDebugEnabled = () =>
+export const isSCBlockDefaultsVerboseDebugEnabled = () =>
 	typeof window !== 'undefined' &&
-	(isSCBlockDefaultsExplicitDebugEnabled() ||
-		window.maxiDebugSCBlockDefaultsVerbose === true ||
+	(window.maxiDebugSCBlockDefaultsVerbose === true ||
 		window.localStorage?.getItem('maxiDebugSCBlockDefaultsVerbose') ===
 			'1');
 
@@ -80,6 +95,24 @@ const hasLayoutAttributeReference = value => {
 	return false;
 };
 
+export const getLayoutDebugValueSummary = (values, blockName) => {
+	if (!values || typeof values !== 'object') return '';
+
+	const blockPrefix = blockName ? `${blockName}|` : null;
+
+	return Object.entries(values)
+		.filter(([key]) => hasLayoutAttributeReference(key))
+		.filter(
+			([key]) =>
+				!blockPrefix || key.startsWith(blockPrefix) || !key.includes('|')
+		)
+		.sort(([firstKey], [secondKey]) =>
+			firstKey.localeCompare(secondKey)
+		)
+		.map(([key, value]) => `${key}=${String(value)}`)
+		.join(', ');
+};
+
 const isFocusedDebugEntry = (label, payload) =>
 	focusedDebugLabels.includes(label) ||
 	(hasLayoutAttributeReference(payload) &&
@@ -91,8 +124,17 @@ const isFocusedDebugEntry = (label, payload) =>
 
 export const debugSCBlockDefaults = (label, payload = {}) => {
 	if (!isSCBlockDefaultsDebugEnabled()) return;
+	const isExplicitDebug = isSCBlockDefaultsExplicitDebugEnabled();
+	const isVerboseDebug = isSCBlockDefaultsVerboseDebugEnabled();
+
 	if (
-		!isSCBlockDefaultsVerboseDebugEnabled() &&
+		!isVerboseDebug &&
+		verboseDebugLabels.includes(label)
+	)
+		return;
+	if (
+		!isExplicitDebug &&
+		!isVerboseDebug &&
 		!isFocusedDebugEntry(label, payload)
 	)
 		return;
@@ -119,6 +161,144 @@ export const debugSCBlockDefaults = (label, payload = {}) => {
 
 	// eslint-disable-next-line no-console
 	console.info(`[SC block defaults] ${label}`, payload);
+};
+
+const addDispatchTarget = (targets, target) => {
+	if (target && typeof target.dispatchEvent === 'function') {
+		targets.add(target);
+	}
+};
+
+const getWindowBlockDefaultsSubscribers = target => {
+	if (!target) return null;
+
+	if (!target[SC_BLOCK_DEFAULTS_SUBSCRIBERS_KEY]) {
+		target[SC_BLOCK_DEFAULTS_SUBSCRIBERS_KEY] = new Set();
+	}
+
+	return target[SC_BLOCK_DEFAULTS_SUBSCRIBERS_KEY];
+};
+
+const getSCBlockDefaultsDispatchTargets = () => {
+	const targets = new Set();
+
+	if (typeof window === 'undefined') return targets;
+
+	addDispatchTarget(targets, window);
+
+	try {
+		document
+			.querySelectorAll('iframe[name="editor-canvas"]')
+			.forEach(iframe => {
+				addDispatchTarget(targets, iframe.contentWindow);
+			});
+	} catch {
+		// Iframe access can fail during editor teardown; parent dispatch remains.
+	}
+
+	return targets;
+};
+
+const createBlockDefaultsUpdateEvent = (target, detail) => {
+	const EventConstructor =
+		target?.CustomEvent ||
+		target?.document?.defaultView?.CustomEvent ||
+		window.CustomEvent;
+
+	return new EventConstructor(SC_BLOCK_DEFAULTS_UPDATE_EVENT, {
+		detail,
+	});
+};
+
+const getAffectedSubscriberBlockNames = blockDefaults =>
+	Array.from(
+		new Set(
+			Object.keys(blockDefaults ?? {})
+				.map(key => {
+					const separatorIndex = key.indexOf(
+						BLOCK_DEFAULT_KEY_SEPARATOR
+					);
+
+					return separatorIndex === -1
+						? null
+						: key.slice(0, separatorIndex);
+				})
+				.filter(Boolean)
+		)
+	);
+
+const getSubscriberRecord = subscriber =>
+	typeof subscriber === 'function'
+		? {
+				callback: subscriber,
+				blockName: null,
+		  }
+		: subscriber;
+
+const notifySCBlockDefaultsSubscribers = (target, event) => {
+	const subscribers = target?.[SC_BLOCK_DEFAULTS_SUBSCRIBERS_KEY];
+	let notifyCount = 0;
+
+	if (!subscribers || typeof subscribers.forEach !== 'function') {
+		return notifyCount;
+	}
+
+	subscribers.forEach(subscriber => {
+		const { callback } = getSubscriberRecord(subscriber) ?? {};
+
+		if (typeof callback !== 'function') return;
+
+		try {
+			callback(event);
+			notifyCount += 1;
+		} catch {
+			// Keep the remaining mounted blocks refreshing if one listener fails.
+		}
+	});
+
+	return notifyCount;
+};
+
+export const subscribeSCBlockDefaultsUpdate = (callback, blockName = null) => {
+	if (typeof window === 'undefined' || typeof callback !== 'function') {
+		return () => {};
+	}
+
+	const subscribers = getWindowBlockDefaultsSubscribers(window);
+	const subscriber = {
+		callback,
+		blockName: blockName?.replace('maxi-blocks/', '') ?? null,
+	};
+	subscribers.add(subscriber);
+
+	return () => {
+		subscribers.delete(subscriber);
+	};
+};
+
+export const dispatchSCBlockDefaultsUpdate = detail => {
+	const targets = getSCBlockDefaultsDispatchTargets();
+	let dispatchCount = 0;
+	let subscriberCount = 0;
+
+	targets.forEach(target => {
+		try {
+			const event = createBlockDefaultsUpdateEvent(target, detail);
+			target.dispatchEvent(event);
+			dispatchCount += 1;
+			subscriberCount += notifySCBlockDefaultsSubscribers(target, event);
+		} catch {
+			// Keep the remaining targets alive if one iframe is not ready.
+		}
+	});
+
+	debugSCBlockDefaults('editor dispatch block defaults update targets', {
+		dispatchCount,
+		subscriberCount,
+		hasIframeTarget: dispatchCount > 1,
+	});
+
+	return dispatchCount;
 };
 
 export const blockDefaultBlocks = [
@@ -389,6 +569,7 @@ const libraryLayoutSequenceTargets = [
 	'column-gap',
 	'flex-wrap',
 ];
+const internalBlockDefaultAttributes = ['size-advanced-options'];
 
 export const getBlockDefaultKey = (blockName, attr) =>
 	`${blockName}${BLOCK_DEFAULT_KEY_SEPARATOR}${attr}`;
@@ -403,6 +584,9 @@ export const parseBlockDefaultKey = key => {
 		attr: key.slice(separatorIndex + 1),
 	};
 };
+
+export const getAffectedBlockNamesFromBlockDefaults = blockDefaults =>
+	getAffectedSubscriberBlockNames(blockDefaults);
 
 const isValidValue = value =>
 	value !== undefined && value !== null && value !== '';
@@ -429,6 +613,9 @@ const withoutBreakpoint = attr => {
 	const breakpoint = getBreakpoint(attr);
 	return breakpoint ? attr.slice(0, -breakpoint.length - 1) : attr;
 };
+
+const isInternalBlockDefaultAttribute = attr =>
+	internalBlockDefaultAttributes.includes(withoutBreakpoint(attr));
 
 export const getUnitAttribute = attr => {
 	if (attr.includes('-unit-')) return null;
@@ -646,6 +833,22 @@ export const normalizeBlockName = value => {
 			normalizedValue.startsWith(`${blockName}-`)
 		) || null
 	);
+};
+
+const blockDefaultControlBlocks = ['container-maxi', 'row-maxi'];
+
+export const shouldApplySCBlockDefaultsToControl = ({
+	name,
+	attributes,
+	prefix = '',
+}) => {
+	if (prefix) return false;
+
+	const blockName = normalizeBlockName(
+		name || attributes?.blockName || attributes?.uniqueID
+	);
+
+	return blockDefaultControlBlocks.includes(blockName);
 };
 
 const sanitizeCssPart = value => value.replace(/[^a-zA-Z0-9-]/g, '-');
@@ -922,6 +1125,14 @@ export const applySCBlockDefaultsToAttributes = ({
 
 	Object.keys(defaultAttributes).forEach(attr => {
 		if (attr.includes('-unit-')) return;
+		if (isInternalBlockDefaultAttribute(attr)) {
+			debugSCBlockDefaults('skip internal block default attribute', {
+				blockName,
+				blockStyle,
+				attr,
+			});
+			return;
+		}
 		if (isSCBlockDefaultExcluded(attributes, attr)) {
 			debugSCBlockDefaults('skip explicit block default opt-out', {
 				blockName,
@@ -1109,6 +1320,7 @@ export const getStyleCardBlockDefaultVariables = styleCard => {
 			if (!parsedKey || !isValidValue(value)) return;
 
 			const { blockName, attr } = parsedKey;
+			if (isInternalBlockDefaultAttribute(attr)) return;
 			if (attr.includes('-unit-')) return;
 
 			const unitAttr = getUnitAttribute(attr);

--- a/src/extensions/style-cards/getSCVariablesObject.js
+++ b/src/extensions/style-cards/getSCVariablesObject.js
@@ -10,7 +10,10 @@ import { getActiveColourFromSC } from '@editor/style-cards/utils';
 import getTypographyStyles from '@extensions/styles/helpers/getTypographyStyles';
 import replaceUndefinedWithNull from './utils';
 import extractRGBValues from './extractRGBValues';
-import { getStyleCardBlockDefaultVariables } from './blockDefaults';
+import {
+	debugSCBlockDefaults,
+	getStyleCardBlockDefaultVariables,
+} from './blockDefaults';
 
 /**
  * External dependencies
@@ -420,7 +423,12 @@ const getSCVariablesObject = (
 
 	response['--maxi-active-sc-color'] = activeSCColour;
 
-	Object.assign(response, getStyleCardBlockDefaultVariables(styleCards));
+	const blockDefaultVariables = getStyleCardBlockDefaultVariables(styleCards);
+	debugSCBlockDefaults('variables object block defaults', {
+		cleanResponse,
+		blockDefaultVariables,
+	});
+	Object.assign(response, blockDefaultVariables);
 
 	return response;
 };

--- a/src/extensions/style-cards/getSCVariablesObject.js
+++ b/src/extensions/style-cards/getSCVariablesObject.js
@@ -10,6 +10,7 @@ import { getActiveColourFromSC } from '@editor/style-cards/utils';
 import getTypographyStyles from '@extensions/styles/helpers/getTypographyStyles';
 import replaceUndefinedWithNull from './utils';
 import extractRGBValues from './extractRGBValues';
+import { getStyleCardBlockDefaultVariables } from './blockDefaults';
 
 /**
  * External dependencies
@@ -418,6 +419,8 @@ const getSCVariablesObject = (
 	});
 
 	response['--maxi-active-sc-color'] = activeSCColour;
+
+	Object.assign(response, getStyleCardBlockDefaultVariables(styleCards));
 
 	return response;
 };

--- a/src/extensions/style-cards/store/resolvers.js
+++ b/src/extensions/style-cards/store/resolvers.js
@@ -2,6 +2,11 @@ import updateSCOnEditor from '@extensions/style-cards/updateSCOnEditor';
 import getActiveStyleCard from '@extensions/style-cards/getActiveStyleCard';
 import { receiveMaxiStyleCards, sendMaxiStyleCards } from './actions';
 import { getActiveColourFromSC } from '@editor/style-cards/utils';
+import {
+	DARK_TONE_STYLE_OVERRIDES,
+	SYNC_STYLE_SETTINGS_TONES_STATUS,
+	SYNC_TYPOGRAPHY_TONES_STATUS,
+} from '@extensions/style-cards/syncTypography';
 
 import { isEmpty } from 'lodash';
 
@@ -14,16 +19,32 @@ const resolvers = {
 		if (maxiStyleCards && !isEmpty(maxiStyleCards)) {
 			for (const key in maxiStyleCards) {
 				if (Object.prototype.hasOwnProperty.call(maxiStyleCards, key)) {
-					const styleCard = maxiStyleCards[key];
+					let styleCard = maxiStyleCards[key];
 					if (!('gutenberg_blocks_status' in styleCard)) {
 						shouldSCMigratorRun = true;
-						updatedMaxiStyleCards[key] = {
+						styleCard = {
 							...styleCard,
 							gutenberg_blocks_status: true,
 						};
-					} else {
-						updatedMaxiStyleCards[key] = styleCard;
 					}
+					if (!(SYNC_STYLE_SETTINGS_TONES_STATUS in styleCard)) {
+						shouldSCMigratorRun = true;
+						styleCard = {
+							...styleCard,
+							[SYNC_STYLE_SETTINGS_TONES_STATUS]:
+								SYNC_TYPOGRAPHY_TONES_STATUS in styleCard
+									? styleCard[SYNC_TYPOGRAPHY_TONES_STATUS]
+									: true,
+						};
+					}
+					if (!(DARK_TONE_STYLE_OVERRIDES in styleCard)) {
+						shouldSCMigratorRun = true;
+						styleCard = {
+							...styleCard,
+							[DARK_TONE_STYLE_OVERRIDES]: [],
+						};
+					}
+					updatedMaxiStyleCards[key] = styleCard;
 				}
 			}
 

--- a/src/extensions/style-cards/store/test/resolvers.js
+++ b/src/extensions/style-cards/store/test/resolvers.js
@@ -6,6 +6,10 @@ import resolvers from '@extensions/style-cards/store/resolvers';
 import updateSCOnEditor from '@extensions/style-cards/updateSCOnEditor';
 import getActiveStyleCard from '@extensions/style-cards/getActiveStyleCard';
 import { getActiveColourFromSC } from '@editor/style-cards/utils';
+import {
+	DARK_TONE_STYLE_OVERRIDES,
+	SYNC_STYLE_SETTINGS_TONES_STATUS,
+} from '@extensions/style-cards/syncTypography';
 import { isEmpty } from 'lodash';
 
 jest.mock('@extensions/style-cards/store/actions', () => ({
@@ -33,8 +37,15 @@ describe('style-cards store resolvers', () => {
 					name: 'Maxi',
 					status: 'active',
 					gutenberg_blocks_status: true,
+					[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+					[DARK_TONE_STYLE_OVERRIDES]: [],
 				},
-				sc_custom: { name: 'Custom', gutenberg_blocks_status: true },
+				sc_custom: {
+					name: 'Custom',
+					gutenberg_blocks_status: true,
+					[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+					[DARK_TONE_STYLE_OVERRIDES]: [],
+				},
 			};
 
 			receiveMaxiStyleCards.mockReturnValue(mockStyleCards);
@@ -76,7 +87,7 @@ describe('style-cards store resolvers', () => {
 			expect(sendMaxiStyleCards).toHaveBeenCalledWith(mockStyleCards);
 		});
 
-		it('Migrates style cards without gutenberg_blocks_status', async () => {
+		it('Migrates style cards without default status flags', async () => {
 			const mockStyleCards = {
 				sc_maxi: { name: 'Maxi', status: 'active' },
 				sc_custom: { name: 'Custom' },
@@ -87,10 +98,14 @@ describe('style-cards store resolvers', () => {
 					name: 'Maxi',
 					status: 'active',
 					gutenberg_blocks_status: true,
+					[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+					[DARK_TONE_STYLE_OVERRIDES]: [],
 				},
 				sc_custom: {
 					name: 'Custom',
 					gutenberg_blocks_status: true,
+					[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+					[DARK_TONE_STYLE_OVERRIDES]: [],
 				},
 			};
 
@@ -129,9 +144,13 @@ describe('style-cards store resolvers', () => {
 				expect.objectContaining({
 					sc_maxi: expect.objectContaining({
 						gutenberg_blocks_status: true,
+						[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+						[DARK_TONE_STYLE_OVERRIDES]: [],
 					}),
 					sc_custom: expect.objectContaining({
 						gutenberg_blocks_status: true,
+						[SYNC_STYLE_SETTINGS_TONES_STATUS]: true,
+						[DARK_TONE_STYLE_OVERRIDES]: [],
 					}),
 				})
 			);

--- a/src/extensions/style-cards/syncTypography.js
+++ b/src/extensions/style-cards/syncTypography.js
@@ -44,15 +44,25 @@ export const getDarkToneStyleOverridesUpdate = ({
 export const getStyleCardToneKeysForChange = ({
 	currentSCStyle,
 	forceToneOnly = false,
+	forceSyncedTones = false,
 	type,
 	styleCard,
+	group,
 }) => {
+	const toneGroup = group || type;
+
 	if (
 		forceToneOnly ||
 		currentSCStyle !== 'light' ||
-		type === 'color' ||
+		type === 'color'
+	)
+		return [currentSCStyle];
+
+	if (forceSyncedTones) return STYLE_CARD_TONE_KEYS;
+
+	if (
 		!isStyleSettingsSyncEnabled(styleCard) ||
-		hasDarkToneStyleOverride(styleCard, type)
+		hasDarkToneStyleOverride(styleCard, toneGroup)
 	)
 		return [currentSCStyle];
 

--- a/src/extensions/style-cards/syncTypography.js
+++ b/src/extensions/style-cards/syncTypography.js
@@ -1,0 +1,90 @@
+export const SYNC_TYPOGRAPHY_TONES_STATUS = 'sync_typography_tones_status';
+export const SYNC_STYLE_SETTINGS_TONES_STATUS =
+	'sync_style_settings_tones_status';
+export const DARK_TONE_STYLE_OVERRIDES = 'dark_tone_style_overrides';
+
+export const STYLE_CARD_TONE_KEYS = ['light', 'dark'];
+
+const getOverrideKey = group => (/^h[1-6]$/.test(group) ? 'heading' : group);
+
+export const isStyleSettingsSyncEnabled = styleCard => {
+	if (SYNC_STYLE_SETTINGS_TONES_STATUS in (styleCard ?? {}))
+		return styleCard?.[SYNC_STYLE_SETTINGS_TONES_STATUS] !== false;
+
+	return styleCard?.[SYNC_TYPOGRAPHY_TONES_STATUS] !== false;
+};
+
+export const isTypographySyncEnabled = isStyleSettingsSyncEnabled;
+
+export const getDarkToneStyleOverrides = styleCard => {
+	const overrides = styleCard?.[DARK_TONE_STYLE_OVERRIDES];
+
+	return Array.isArray(overrides) ? overrides : [];
+};
+
+export const hasDarkToneStyleOverride = (styleCard, group) =>
+	getDarkToneStyleOverrides(styleCard).includes(getOverrideKey(group));
+
+export const getDarkToneStyleOverridesUpdate = ({
+	styleCard,
+	group,
+	enabled,
+}) => {
+	const overrideKey = getOverrideKey(group);
+	const currentOverrides = getDarkToneStyleOverrides(styleCard);
+	const nextOverrides = enabled
+		? Array.from(new Set([...currentOverrides, overrideKey]))
+		: currentOverrides.filter(currentGroup => currentGroup !== overrideKey);
+
+	return {
+		[DARK_TONE_STYLE_OVERRIDES]: nextOverrides,
+	};
+};
+
+export const getStyleCardToneKeysForChange = ({
+	currentSCStyle,
+	forceToneOnly = false,
+	type,
+	styleCard,
+}) => {
+	if (
+		forceToneOnly ||
+		currentSCStyle !== 'light' ||
+		type === 'color' ||
+		!isStyleSettingsSyncEnabled(styleCard) ||
+		hasDarkToneStyleOverride(styleCard, type)
+	)
+		return [currentSCStyle];
+
+	return STYLE_CARD_TONE_KEYS;
+};
+
+export const applyStyleCardTypeChange = ({
+	styleCard,
+	tone,
+	type,
+	prop,
+	value,
+	shouldDeleteNilValue = false,
+}) => {
+	const toneValue = styleCard?.[tone] ?? {};
+	const styleCardValues = toneValue?.styleCard ?? {};
+	const typeValues = { ...(styleCardValues?.[type] ?? {}) };
+
+	if (shouldDeleteNilValue && (value === null || value === undefined)) {
+		delete typeValues[prop];
+	} else {
+		typeValues[prop] = value;
+	}
+
+	return {
+		...styleCard,
+		[tone]: {
+			...toneValue,
+			styleCard: {
+				...styleCardValues,
+				[type]: typeValues,
+			},
+		},
+	};
+};

--- a/src/extensions/style-cards/test/blockDefaults.js
+++ b/src/extensions/style-cards/test/blockDefaults.js
@@ -6,6 +6,7 @@ import {
 	getStyleCardBlockDefaultVariables,
 	isSCBlockDefaultsDebugEnabled,
 	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES,
+	setActiveStyleCardValueForBlockDefaults,
 } from '@extensions/style-cards/blockDefaults';
 
 const sizeDefaults = {
@@ -23,6 +24,75 @@ const sizeDefaults = {
 	'width-unit-xl': {
 		default: 'px',
 	},
+};
+
+const layoutDefaults = {
+	...sizeDefaults,
+	'padding-top-general': {},
+	'padding-top-unit-general': {
+		default: 'px',
+	},
+	'padding-top-xxl': {},
+	'padding-top-unit-xxl': {
+		default: 'px',
+	},
+	'padding-top-xl': {},
+	'padding-top-unit-xl': {
+		default: 'px',
+	},
+	'padding-top-s': {},
+	'padding-top-unit-s': {
+		default: 'px',
+	},
+	'padding-top-xs': {},
+	'padding-top-unit-xs': {
+		default: 'px',
+	},
+	'padding-bottom-general': {},
+	'padding-bottom-unit-general': {
+		default: 'px',
+	},
+	'padding-bottom-xxl': {},
+	'padding-bottom-unit-xxl': {
+		default: 'px',
+	},
+	'padding-bottom-xl': {},
+	'padding-bottom-unit-xl': {
+		default: 'px',
+	},
+	'padding-bottom-s': {},
+	'padding-bottom-unit-s': {
+		default: 'px',
+	},
+	'padding-bottom-xs': {},
+	'padding-bottom-unit-xs': {
+		default: 'px',
+	},
+	'column-gap-m': {},
+	'column-gap-unit-m': {
+		default: '%',
+	},
+	'row-gap-general': {},
+	'row-gap-unit-general': {
+		default: 'px',
+	},
+	'row-gap-xs': {},
+	'row-gap-unit-xs': {
+		default: 'px',
+	},
+	'column-gap-general': {},
+	'column-gap-unit-general': {
+		default: '%',
+	},
+	'column-gap-s': {},
+	'column-gap-unit-s': {
+		default: '%',
+	},
+	'column-gap-xs': {},
+	'column-gap-unit-xs': {
+		default: '%',
+	},
+	'flex-wrap-general': {},
 };
 
 const getStyleCard = blockDefaults => ({
@@ -46,8 +116,13 @@ const getStyleCard = blockDefaults => ({
 
 describe('Style Card block defaults', () => {
 	afterEach(() => {
+		setActiveStyleCardValueForBlockDefaults(null);
 		delete window.maxiDebugSCBlockDefaults;
+		delete window.maxiDebugSCBlockDefaultsVerbose;
+		delete window.maxiSCBlockDefaultsDebugLog;
+		delete window.getMaxiSCBlockDefaultsDebugLog;
 		window.localStorage?.removeItem('maxiDebugSCBlockDefaults');
+		window.localStorage?.removeItem('maxiDebugSCBlockDefaultsVerbose');
 		window.history.pushState({}, '', '/');
 	});
 
@@ -63,6 +138,17 @@ describe('Style Card block defaults', () => {
 		expect(console).toHaveInformedWith('[SC block defaults] test', {
 			value: 1,
 		});
+		expect(window.maxiSCBlockDefaultsDebugLog).toEqual([
+			expect.objectContaining({
+				label: 'test',
+				payload: {
+					value: 1,
+				},
+			}),
+		]);
+		expect(window.getMaxiSCBlockDefaultsDebugLog()).toBe(
+			window.maxiSCBlockDefaultsDebugLog
+		);
 	});
 
 	it('enables debug logging automatically for the local WAMP site', () => {
@@ -73,6 +159,61 @@ describe('Style Card block defaults', () => {
 		);
 
 		expect(isSCBlockDefaultsDebugEnabled()).toBe(true);
+	});
+
+	it('keeps automatic local debug focused on layout defaults', () => {
+		window.history.pushState(
+			{},
+			'',
+			'/maxi-blocks-local/wp-admin/post.php'
+		);
+
+		debugSCBlockDefaults('apply value', {
+			blockName: 'text-maxi',
+			attr: 'font-weight-general',
+		});
+
+		expect(console).not.toHaveInformed();
+		expect(window.maxiSCBlockDefaultsDebugLog).toBeUndefined();
+
+		debugSCBlockDefaults('style card values', {
+			blockName: 'text-maxi',
+			blockStyle: 'dark',
+			blockDefaultKeys: [
+				'container-maxi|padding-top-general',
+				'container-maxi|padding-top-unit-general',
+			],
+		});
+
+		expect(console).not.toHaveInformed();
+		expect(window.maxiSCBlockDefaultsDebugLog).toBeUndefined();
+
+		debugSCBlockDefaults('apply value', {
+			blockName: 'container-maxi',
+			attr: 'border-width-general',
+		});
+
+		expect(console).not.toHaveInformed();
+		expect(window.maxiSCBlockDefaultsDebugLog).toBeUndefined();
+
+		debugSCBlockDefaults('apply value', {
+			blockName: 'container-maxi',
+			attr: 'padding-top-xl',
+		});
+
+		expect(console).toHaveInformedWith('[SC block defaults] apply value', {
+			blockName: 'container-maxi',
+			attr: 'padding-top-xl',
+		});
+		expect(window.maxiSCBlockDefaultsDebugLog).toEqual([
+			expect.objectContaining({
+				label: 'apply value',
+				payload: {
+					blockName: 'container-maxi',
+					attr: 'padding-top-xl',
+				},
+			}),
+		]);
 	});
 
 	it('tracks explicit block default opt-outs without duplicating entries', () => {
@@ -124,7 +265,7 @@ describe('Style Card block defaults', () => {
 			blockName: 'row-maxi',
 			blockStyle: 'light',
 			cssVar: '--maxi-light-block-default-row-maxi-max-width-xl',
-			fallback: '1170px',
+			fallback: '1280px',
 		});
 	});
 
@@ -273,6 +414,331 @@ describe('Style Card block defaults', () => {
 
 		expect(result['width-xl']).toBe('500');
 		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('applies Style Card container padding to recognized library spacing sequences', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'padding-top-general': '100',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '150',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '100',
+				'padding-top-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'container-maxi-test-u',
+				blockStyle: 'light',
+				'padding-top-general': '100',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '150',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '100',
+				'padding-top-unit-xl': 'px',
+			},
+			defaultAttributes: layoutDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('container-maxi', 'padding-top-general')]:
+					'80',
+				[getBlockDefaultKey(
+					'container-maxi',
+					'padding-top-unit-general'
+				)]: 'px',
+			}),
+		});
+
+		expect(result['padding-top-general']).toBe('80');
+		expect(result.__scBlockDefaults['padding-top-general']).toEqual({
+			blockName: 'container-maxi',
+			blockStyle: 'light',
+			cssVar:
+				'--maxi-light-block-default-container-maxi-padding-top-general',
+			fallback: '80px',
+		});
+		expect(result.__scBlockDefaults['padding-top-xxl']).toEqual({
+			blockName: 'container-maxi',
+			blockStyle: 'light',
+			cssVar:
+				'--maxi-light-block-default-container-maxi-padding-top-xxl',
+			fallback: '150px',
+		});
+	});
+
+	it('uses the latest editor Style Card snapshot when the store has not refreshed yet', () => {
+		setActiveStyleCardValueForBlockDefaults(
+			getStyleCard({
+				[getBlockDefaultKey('container-maxi', 'padding-top-xl')]:
+					'120',
+				[getBlockDefaultKey(
+					'container-maxi',
+					'padding-top-unit-xl'
+				)]: 'px',
+			})
+		);
+
+		const result = applySCBlockDefaultsToAttributes({
+			response: {},
+			attributes: {
+				uniqueID: 'container-maxi-test-u',
+				blockStyle: 'light',
+			},
+			defaultAttributes: layoutDefaults,
+		});
+
+		expect(result['padding-top-xl']).toBe('120');
+		expect(result['padding-top-unit-xl']).toBe('px');
+		expect(result.__scBlockDefaults['padding-top-xl']).toEqual({
+			blockName: 'container-maxi',
+			blockStyle: 'light',
+			cssVar: '--maxi-light-block-default-container-maxi-padding-top-xl',
+			fallback: '120px',
+		});
+	});
+
+	it('applies Style Card container padding to the compact 150/200/150/60/40 library sequence', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'padding-top-general': '150',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '200',
+				'padding-top-xl': '150',
+				'padding-top-s': '60',
+				'padding-top-xs': '40',
+				'padding-bottom-general': '150',
+				'padding-bottom-unit-general': 'px',
+				'padding-bottom-xxl': '200',
+				'padding-bottom-xl': '150',
+				'padding-bottom-s': '60',
+				'padding-bottom-xs': '40',
+			},
+			attributes: {
+				uniqueID: 'container-maxi-test-u',
+				blockStyle: 'dark',
+				'padding-top-general': '150',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '200',
+				'padding-top-xl': '150',
+				'padding-top-s': '60',
+				'padding-top-xs': '40',
+				'padding-bottom-general': '150',
+				'padding-bottom-unit-general': 'px',
+				'padding-bottom-xxl': '200',
+				'padding-bottom-xl': '150',
+				'padding-bottom-s': '60',
+				'padding-bottom-xs': '40',
+			},
+			defaultAttributes: layoutDefaults,
+			styleCard: {
+				...getStyleCard({}),
+				dark: {
+					defaultStyleCard: {
+						blockDefaults: {},
+					},
+					styleCard: {
+						blockDefaults: {
+							[getBlockDefaultKey(
+								'container-maxi',
+								'padding-top-general'
+							)]: '100',
+							[getBlockDefaultKey(
+								'container-maxi',
+								'padding-top-unit-general'
+							)]: 'px',
+							[getBlockDefaultKey(
+								'container-maxi',
+								'padding-bottom-general'
+							)]: '100',
+							[getBlockDefaultKey(
+								'container-maxi',
+								'padding-bottom-unit-general'
+							)]: 'px',
+						},
+					},
+				},
+			},
+		});
+
+		expect(result['padding-top-general']).toBe('100');
+		expect(result['padding-bottom-general']).toBe('100');
+		expect(result.__scBlockDefaults['padding-top-general']).toEqual({
+			blockName: 'container-maxi',
+			blockStyle: 'dark',
+			cssVar:
+				'--maxi-dark-block-default-container-maxi-padding-top-general',
+			fallback: '100px',
+		});
+	});
+
+	it('keeps custom container padding sequences explicit', () => {
+		window.maxiDebugSCBlockDefaults = true;
+
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'padding-top-general': '110',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '150',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '100',
+				'padding-top-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'container-maxi-test-u',
+				blockStyle: 'light',
+				'padding-top-general': '110',
+				'padding-top-unit-general': 'px',
+				'padding-top-xxl': '150',
+				'padding-top-unit-xxl': 'px',
+				'padding-top-xl': '100',
+				'padding-top-unit-xl': 'px',
+			},
+			defaultAttributes: layoutDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('container-maxi', 'padding-top-general')]:
+					'80',
+				[getBlockDefaultKey(
+					'container-maxi',
+					'padding-top-unit-general'
+				)]: 'px',
+			}),
+		});
+
+		expect(result['padding-top-general']).toBe('110');
+		expect(result.__scBlockDefaults).toBeUndefined();
+
+		const mismatchLog = window.maxiSCBlockDefaultsDebugLog.find(
+			({ label, payload }) =>
+				label === 'library layout sequence not matched' &&
+				payload.attr === 'padding-top-general'
+		);
+
+		expect(mismatchLog.payload).toEqual(
+			expect.objectContaining({
+				blockName: 'container-maxi',
+				currentValue: '110',
+				target: 'padding-top',
+				reason: 'no library layout sequence matched',
+				mismatches: expect.arrayContaining([
+					expect.objectContaining({
+						breakpoint: 'general',
+						actual: '110',
+						expected: '100',
+						reason: 'value mismatch',
+					}),
+				]),
+			})
+		);
+		expect(console).toHaveInformed();
+	});
+
+	it('applies responsive row column gap defaults only for recognized library mobile sequences', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'column-gap-m': '2.5',
+				'column-gap-unit-m': '%',
+				'column-gap-s': '2.5',
+				'column-gap-unit-s': '%',
+				'column-gap-xs': '2.5',
+				'column-gap-unit-xs': '%',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'column-gap-m': '2.5',
+				'column-gap-unit-m': '%',
+				'column-gap-s': '2.5',
+				'column-gap-unit-s': '%',
+				'column-gap-xs': '2.5',
+				'column-gap-unit-xs': '%',
+			},
+			defaultAttributes: layoutDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'column-gap-m')]: '4',
+				[getBlockDefaultKey('row-maxi', 'column-gap-unit-m')]: '%',
+			}),
+		});
+
+		expect(result['column-gap-m']).toBe('4');
+		expect(result['column-gap-s']).toBe('2.5');
+		expect(result.__scBlockDefaults['column-gap-m']).toEqual({
+			blockName: 'row-maxi',
+			blockStyle: 'light',
+			cssVar: '--maxi-light-block-default-row-maxi-column-gap-m',
+			fallback: '4%',
+		});
+		expect(result.__scBlockDefaults['column-gap-xs']).toEqual({
+			blockName: 'row-maxi',
+			blockStyle: 'light',
+			cssVar: '--maxi-light-block-default-row-maxi-column-gap-xs',
+			fallback: '2.5%',
+		});
+	});
+
+	it('applies Style Card row spacing to recognized library row spacing defaults', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'row-gap-general': 20,
+				'row-gap-unit-general': 'px',
+				'row-gap-xs': 10,
+				'column-gap-general': 0,
+				'column-gap-unit-general': '%',
+				'flex-wrap-general': 'nowrap',
+				'flex-wrap-xs': 'wrap',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'dark',
+				'row-gap-general': 20,
+				'row-gap-unit-general': 'px',
+				'row-gap-xs': 10,
+				'column-gap-general': 0,
+				'column-gap-unit-general': '%',
+				'flex-wrap-general': 'nowrap',
+				'flex-wrap-xs': 'wrap',
+			},
+			defaultAttributes: layoutDefaults,
+			styleCard: {
+				...getStyleCard({}),
+				dark: {
+					defaultStyleCard: {
+						blockDefaults: {},
+					},
+					styleCard: {
+						blockDefaults: {
+							[getBlockDefaultKey(
+								'row-maxi',
+								'row-gap-general'
+							)]: 30,
+							[getBlockDefaultKey(
+								'row-maxi',
+								'row-gap-unit-general'
+							)]: 'px',
+							[getBlockDefaultKey(
+								'row-maxi',
+								'column-gap-general'
+							)]: 4,
+							[getBlockDefaultKey(
+								'row-maxi',
+								'column-gap-unit-general'
+							)]: '%',
+							[getBlockDefaultKey(
+								'row-maxi',
+								'flex-wrap-general'
+							)]: 'wrap',
+						},
+					},
+				},
+			},
+		});
+
+		expect(result['row-gap-general']).toBe(30);
+		expect(result['column-gap-general']).toBe(4);
+		expect(result['flex-wrap-general']).toBe('wrap');
+		expect(result.__scBlockDefaults['row-gap-general']).toEqual({
+			blockName: 'row-maxi',
+			blockStyle: 'dark',
+			cssVar: '--maxi-dark-block-default-row-maxi-row-gap-general',
+			fallback: '30px',
+		});
 	});
 
 	it('keeps a block-level fit-content opt-out when Style Card default is true', () => {

--- a/src/extensions/style-cards/test/blockDefaults.js
+++ b/src/extensions/style-cards/test/blockDefaults.js
@@ -1,0 +1,186 @@
+import {
+	applySCBlockDefaultsToAttributes,
+	getBlockDefaultKey,
+	getStyleCardBlockDefaultVariables,
+} from '@extensions/style-cards/blockDefaults';
+
+const sizeDefaults = {
+	'max-width-xl': {},
+	'max-width-unit-xl': {
+		default: 'px',
+	},
+	'full-width-xl': {
+		default: false,
+	},
+	'width-fit-content-xl': {
+		default: false,
+	},
+	'width-xl': {},
+	'width-unit-xl': {
+		default: 'px',
+	},
+};
+
+const getStyleCard = blockDefaults => ({
+	light: {
+		defaultStyleCard: {
+			blockDefaults: {},
+		},
+		styleCard: {
+			blockDefaults,
+		},
+	},
+	dark: {
+		defaultStyleCard: {
+			blockDefaults: {},
+		},
+		styleCard: {
+			blockDefaults: {},
+		},
+	},
+});
+
+describe('Style Card block defaults', () => {
+	it('applies Style Card row max-width when the block still has shipped defaults', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: '1280',
+				[getBlockDefaultKey('row-maxi', 'max-width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['max-width-xl']).toBe('1280');
+		expect(result['max-width-unit-xl']).toBe('px');
+		expect(result.__scBlockDefaults['max-width-xl']).toEqual({
+			blockName: 'row-maxi',
+			blockStyle: 'light',
+			cssVar: '--maxi-light-block-default-row-maxi-max-width-xl',
+			fallback: '1170px',
+		});
+	});
+
+	it('keeps custom row max-width values', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'max-width-xl': '900',
+				'max-width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'max-width-xl': '900',
+				'max-width-unit-xl': 'px',
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: '1280',
+				[getBlockDefaultKey('row-maxi', 'max-width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['max-width-xl']).toBe('900');
+		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('marks shipped defaults with CSS variable metadata before an override exists', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({}),
+		});
+
+		expect(result['max-width-xl']).toBe('1170');
+		expect(result.__scBlockDefaults['max-width-xl']).toEqual({
+			blockName: 'row-maxi',
+			blockStyle: 'light',
+			cssVar: '--maxi-light-block-default-row-maxi-max-width-xl',
+			fallback: '1170px',
+		});
+	});
+
+	it('does not override full-width rows', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+				'full-width-xl': true,
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+				'full-width-xl': true,
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: '1280',
+				[getBlockDefaultKey('row-maxi', 'max-width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['max-width-xl']).toBe('1170');
+		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('does not override fit-content width settings', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'width-xl': '500',
+				'width-unit-xl': 'px',
+				'width-fit-content-xl': true,
+			},
+			attributes: {
+				uniqueID: 'button-maxi-test-u',
+				blockStyle: 'light',
+				'width-xl': '500',
+				'width-unit-xl': 'px',
+				'width-fit-content-xl': true,
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('button-maxi', 'width-xl')]: '620',
+				[getBlockDefaultKey('button-maxi', 'width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['width-xl']).toBe('500');
+		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('generates CSS variables for stored block defaults', () => {
+		const result = getStyleCardBlockDefaultVariables(
+			getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: '1280',
+				[getBlockDefaultKey('row-maxi', 'max-width-unit-xl')]: 'px',
+			})
+		);
+
+		expect(result['--maxi-light-block-default-row-maxi-max-width-xl']).toBe(
+			'1280px'
+		);
+		expect(
+			result['--maxi-light-block-default-row-maxi-max-width-unit-xl']
+		).toBeUndefined();
+	});
+});

--- a/src/extensions/style-cards/test/blockDefaults.js
+++ b/src/extensions/style-cards/test/blockDefaults.js
@@ -1,15 +1,24 @@
 import {
 	applySCBlockDefaultsToAttributes,
 	debugSCBlockDefaults,
+	dispatchSCBlockDefaultsUpdate,
+	getAffectedBlockNamesFromBlockDefaults,
 	getBlockDefaultKey,
+	getLayoutDebugValueSummary,
 	getSCBlockDefaultsExcludedAttributesUpdate,
 	getStyleCardBlockDefaultVariables,
 	isSCBlockDefaultsDebugEnabled,
+	isSCBlockDefaultsVerboseDebugEnabled,
 	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES,
 	setActiveStyleCardValueForBlockDefaults,
+	shouldApplySCBlockDefaultsToControl,
+	subscribeSCBlockDefaultsUpdate,
 } from '@extensions/style-cards/blockDefaults';
 
 const sizeDefaults = {
+	'size-advanced-options': {
+		default: true,
+	},
 	'max-width-xl': {},
 	'max-width-unit-xl': {
 		default: 'px',
@@ -116,13 +125,13 @@ const getStyleCard = blockDefaults => ({
 
 describe('Style Card block defaults', () => {
 	afterEach(() => {
-		setActiveStyleCardValueForBlockDefaults(null);
 		delete window.maxiDebugSCBlockDefaults;
 		delete window.maxiDebugSCBlockDefaultsVerbose;
 		delete window.maxiSCBlockDefaultsDebugLog;
 		delete window.getMaxiSCBlockDefaultsDebugLog;
 		window.localStorage?.removeItem('maxiDebugSCBlockDefaults');
 		window.localStorage?.removeItem('maxiDebugSCBlockDefaultsVerbose');
+		setActiveStyleCardValueForBlockDefaults(null);
 		window.history.pushState({}, '', '/');
 	});
 
@@ -201,6 +210,56 @@ describe('Style Card block defaults', () => {
 			attr: 'padding-top-xl',
 		});
 
+		expect(console).not.toHaveInformed();
+		expect(window.maxiSCBlockDefaultsDebugLog).toBeUndefined();
+
+		debugSCBlockDefaults('advanced globals change', {
+			blockName: 'container-maxi',
+			attr: 'padding-top-xl',
+		});
+
+		expect(console).toHaveInformedWith(
+			'[SC block defaults] advanced globals change',
+			{
+				blockName: 'container-maxi',
+				attr: 'padding-top-xl',
+			}
+		);
+		expect(window.maxiSCBlockDefaultsDebugLog).toEqual([
+			expect.objectContaining({
+				label: 'advanced globals change',
+				payload: {
+					blockName: 'container-maxi',
+					attr: 'padding-top-xl',
+				},
+			}),
+		]);
+	});
+
+	it('keeps detailed automatic local debug behind the verbose flag', () => {
+		window.history.pushState(
+			{},
+			'',
+			'/maxi-blocks-local/wp-admin/post.php'
+		);
+
+		expect(isSCBlockDefaultsVerboseDebugEnabled()).toBe(false);
+		debugSCBlockDefaults('apply value', {
+			blockName: 'container-maxi',
+			attr: 'padding-top-xl',
+		});
+
+		expect(console).not.toHaveInformed();
+		expect(window.maxiSCBlockDefaultsDebugLog).toBeUndefined();
+
+		window.localStorage?.setItem('maxiDebugSCBlockDefaultsVerbose', '1');
+
+		expect(isSCBlockDefaultsVerboseDebugEnabled()).toBe(true);
+		debugSCBlockDefaults('apply value', {
+			blockName: 'container-maxi',
+			attr: 'padding-top-xl',
+		});
+
 		expect(console).toHaveInformedWith('[SC block defaults] apply value', {
 			blockName: 'container-maxi',
 			attr: 'padding-top-xl',
@@ -214,6 +273,177 @@ describe('Style Card block defaults', () => {
 				},
 			}),
 		]);
+	});
+
+	it('summarises layout debug values for copy-pasted console output', () => {
+		expect(
+			getLayoutDebugValueSummary(
+				{
+					'container-maxi|padding-top-general': 20,
+					'container-maxi|padding-top-unit-general': 'px',
+					'container-maxi|padding-bottom-xl': 30,
+					'container-maxi|padding-bottom-unit-xl': 'px',
+					'button-maxi|font-size-general': 18,
+					random: 'ignored',
+				},
+				'container-maxi'
+			)
+		).toBe(
+			'container-maxi|padding-bottom-unit-xl=px, container-maxi|padding-bottom-xl=30, container-maxi|padding-top-general=20, container-maxi|padding-top-unit-general=px'
+		);
+	});
+
+	it('extracts affected block names from Style Card block defaults', () => {
+		expect(
+			getAffectedBlockNamesFromBlockDefaults({
+				[getBlockDefaultKey(
+					'container-maxi',
+					'padding-top-general'
+				)]: 21,
+				[getBlockDefaultKey(
+					'container-maxi',
+					'padding-bottom-general'
+				)]: 21,
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: 900,
+				invalid: 1,
+			})
+		).toEqual(['container-maxi', 'row-maxi']);
+	});
+
+	it('limits effective block default controls to unprefixed Container and Row layout controls', () => {
+		expect(
+			shouldApplySCBlockDefaultsToControl({
+				name: 'maxi-blocks/container-maxi',
+				attributes: {},
+			})
+		).toBe(true);
+		expect(
+			shouldApplySCBlockDefaultsToControl({
+				name: 'maxi-blocks/row-maxi',
+				attributes: {},
+			})
+		).toBe(true);
+		expect(
+			shouldApplySCBlockDefaultsToControl({
+				attributes: {
+					uniqueID: 'container-maxi-test-u',
+				},
+			})
+		).toBe(true);
+		expect(
+			shouldApplySCBlockDefaultsToControl({
+				name: 'maxi-blocks/container-maxi',
+				attributes: {},
+				prefix: 'image-',
+			})
+		).toBe(false);
+		expect(
+			shouldApplySCBlockDefaultsToControl({
+				name: 'maxi-blocks/button-maxi',
+				attributes: {},
+			})
+		).toBe(false);
+	});
+
+	it('dispatches block default updates to the parent window and editor iframe', () => {
+		const iframe = document.createElement('iframe');
+		iframe.setAttribute('name', 'editor-canvas');
+		document.body.appendChild(iframe);
+
+		const parentListener = jest.fn();
+		const iframeListener = jest.fn();
+		window.addEventListener(
+			'maxi-blocks:style-card-block-defaults-update',
+			parentListener
+		);
+		iframe.contentWindow.addEventListener(
+			'maxi-blocks:style-card-block-defaults-update',
+			iframeListener
+		);
+
+		const detail = {
+			currentSCStyle: 'light',
+			blockDefaults: {
+				'container-maxi|padding-top-general': 50,
+			},
+		};
+
+		expect(dispatchSCBlockDefaultsUpdate(detail)).toBe(2);
+		expect(parentListener).toHaveBeenCalledWith(
+			expect.objectContaining({ detail })
+		);
+		expect(iframeListener).toHaveBeenCalledWith(
+			expect.objectContaining({ detail })
+		);
+
+		window.removeEventListener(
+			'maxi-blocks:style-card-block-defaults-update',
+			parentListener
+		);
+	});
+
+	it('notifies in-process block default update subscribers', () => {
+		const subscriber = jest.fn();
+		const unsubscribe = subscribeSCBlockDefaultsUpdate(subscriber);
+		const detail = {
+			currentSCStyle: 'light',
+			blockDefaults: {
+				'container-maxi|padding-top-general': 22,
+			},
+		};
+
+		dispatchSCBlockDefaultsUpdate(detail);
+
+		expect(subscriber).toHaveBeenCalledWith(
+			expect.objectContaining({ detail })
+		);
+
+		unsubscribe();
+		dispatchSCBlockDefaultsUpdate(detail);
+
+		expect(subscriber).toHaveBeenCalledTimes(1);
+	});
+
+	it('notifies all in-process subscribers for scoped block default updates', () => {
+		const containerSubscriber = jest.fn();
+		const rowSubscriber = jest.fn();
+		const genericSubscriber = jest.fn();
+		const unsubscribeContainer = subscribeSCBlockDefaultsUpdate(
+			containerSubscriber,
+			'container-maxi'
+		);
+		const unsubscribeRow = subscribeSCBlockDefaultsUpdate(
+			rowSubscriber,
+			'row-maxi'
+		);
+		const unsubscribeGeneric =
+			subscribeSCBlockDefaultsUpdate(genericSubscriber);
+
+		dispatchSCBlockDefaultsUpdate({
+			currentSCStyle: 'light',
+			blockDefaults: {
+				'container-maxi|padding-top-general': 22,
+			},
+		});
+
+		expect(containerSubscriber).toHaveBeenCalledTimes(1);
+		expect(rowSubscriber).toHaveBeenCalledTimes(1);
+		expect(genericSubscriber).toHaveBeenCalledTimes(1);
+
+		dispatchSCBlockDefaultsUpdate({
+			currentSCStyle: 'light',
+			blockDefaults: {
+				'row-maxi|row-gap-general': 30,
+			},
+		});
+
+		expect(containerSubscriber).toHaveBeenCalledTimes(2);
+		expect(rowSubscriber).toHaveBeenCalledTimes(2);
+		expect(genericSubscriber).toHaveBeenCalledTimes(2);
+
+		unsubscribeContainer();
+		unsubscribeRow();
+		unsubscribeGeneric();
 	});
 
 	it('tracks explicit block default opt-outs without duplicating entries', () => {
@@ -290,6 +520,43 @@ describe('Style Card block defaults', () => {
 
 		expect(result['max-width-xl']).toBe('900');
 		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('does not let saved Style Card size toggle values disable container max-width defaults', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'size-advanced-options': true,
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'container-maxi-test-u',
+				blockStyle: 'light',
+				'size-advanced-options': true,
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey(
+					'container-maxi',
+					'size-advanced-options'
+				)]: false,
+				[getBlockDefaultKey('container-maxi', 'max-width-xl')]:
+					'1280',
+				[getBlockDefaultKey('container-maxi', 'max-width-unit-xl')]:
+					'px',
+			}),
+		});
+
+		expect(result['size-advanced-options']).toBe(true);
+		expect(result['max-width-xl']).toBe('1280');
+		expect(result.__scBlockDefaults['size-advanced-options']).toBe(
+			undefined
+		);
+		expect(result.__scBlockDefaults['max-width-xl'].cssVar).toBe(
+			'--maxi-light-block-default-container-maxi-max-width-xl'
+		);
 	});
 
 	it('marks shipped defaults with CSS variable metadata before an override exists', () => {
@@ -570,7 +837,7 @@ describe('Style Card block defaults', () => {
 	});
 
 	it('keeps custom container padding sequences explicit', () => {
-		window.maxiDebugSCBlockDefaults = true;
+		window.maxiDebugSCBlockDefaultsVerbose = true;
 
 		const result = applySCBlockDefaultsToAttributes({
 			response: {

--- a/src/extensions/style-cards/test/blockDefaults.js
+++ b/src/extensions/style-cards/test/blockDefaults.js
@@ -1,7 +1,11 @@
 import {
 	applySCBlockDefaultsToAttributes,
+	debugSCBlockDefaults,
 	getBlockDefaultKey,
+	getSCBlockDefaultsExcludedAttributesUpdate,
 	getStyleCardBlockDefaultVariables,
+	isSCBlockDefaultsDebugEnabled,
+	SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES,
 } from '@extensions/style-cards/blockDefaults';
 
 const sizeDefaults = {
@@ -41,6 +45,60 @@ const getStyleCard = blockDefaults => ({
 });
 
 describe('Style Card block defaults', () => {
+	afterEach(() => {
+		delete window.maxiDebugSCBlockDefaults;
+		window.localStorage?.removeItem('maxiDebugSCBlockDefaults');
+		window.history.pushState({}, '', '/');
+	});
+
+	it('keeps debug logging opt-in', () => {
+		expect(isSCBlockDefaultsDebugEnabled()).toBe(false);
+		debugSCBlockDefaults('test', { value: 1 });
+		expect(console).not.toHaveInformed();
+
+		window.maxiDebugSCBlockDefaults = true;
+
+		expect(isSCBlockDefaultsDebugEnabled()).toBe(true);
+		debugSCBlockDefaults('test', { value: 1 });
+		expect(console).toHaveInformedWith('[SC block defaults] test', {
+			value: 1,
+		});
+	});
+
+	it('enables debug logging automatically for the local WAMP site', () => {
+		window.history.pushState(
+			{},
+			'',
+			'/maxi-blocks-local/wp-admin/post.php'
+		);
+
+		expect(isSCBlockDefaultsDebugEnabled()).toBe(true);
+	});
+
+	it('tracks explicit block default opt-outs without duplicating entries', () => {
+		const added = getSCBlockDefaultsExcludedAttributesUpdate({
+			attributes: {
+				[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]: ['full-width-xl'],
+			},
+			attr: 'full-width-xl',
+			exclude: true,
+		});
+
+		expect(added).toEqual({
+			[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]: ['full-width-xl'],
+		});
+
+		const removed = getSCBlockDefaultsExcludedAttributesUpdate({
+			attributes: added,
+			attr: 'full-width-xl',
+			exclude: false,
+		});
+
+		expect(removed).toEqual({
+			[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]: undefined,
+		});
+	});
+
 	it('applies Style Card row max-width when the block still has shipped defaults', () => {
 		const result = applySCBlockDefaultsToAttributes({
 			response: {
@@ -143,6 +201,55 @@ describe('Style Card block defaults', () => {
 		expect(result.__scBlockDefaults).toBeUndefined();
 	});
 
+	it('applies Style Card full-width defaults when the block has not opted out', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'full-width-xl': false,
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'full-width-xl': false,
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'full-width-xl')]: true,
+			}),
+		});
+
+		expect(result['full-width-xl']).toBe(true);
+	});
+
+	it('keeps a block-level full-width opt-out when Style Card default is true', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'full-width-xl': false,
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'row-maxi-test-u',
+				blockStyle: 'light',
+				'full-width-xl': false,
+				'max-width-xl': '1170',
+				'max-width-unit-xl': 'px',
+				[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]: ['full-width-xl'],
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey('row-maxi', 'full-width-xl')]: true,
+				[getBlockDefaultKey('row-maxi', 'max-width-xl')]: '1280',
+				[getBlockDefaultKey('row-maxi', 'max-width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['full-width-xl']).toBe(false);
+		expect(result['max-width-xl']).toBe('1280');
+		expect(result.__scBlockDefaults['max-width-xl'].cssVar).toBe(
+			'--maxi-light-block-default-row-maxi-max-width-xl'
+		);
+	});
+
 	it('does not override fit-content width settings', () => {
 		const result = applySCBlockDefaultsToAttributes({
 			response: {
@@ -166,6 +273,41 @@ describe('Style Card block defaults', () => {
 
 		expect(result['width-xl']).toBe('500');
 		expect(result.__scBlockDefaults).toBeUndefined();
+	});
+
+	it('keeps a block-level fit-content opt-out when Style Card default is true', () => {
+		const result = applySCBlockDefaultsToAttributes({
+			response: {
+				'width-fit-content-xl': false,
+				'width-xl': '500',
+				'width-unit-xl': 'px',
+			},
+			attributes: {
+				uniqueID: 'button-maxi-test-u',
+				blockStyle: 'light',
+				'width-fit-content-xl': false,
+				'width-xl': '500',
+				'width-unit-xl': 'px',
+				[SC_BLOCK_DEFAULTS_EXCLUDED_ATTRIBUTES]: [
+					'width-fit-content-xl',
+				],
+			},
+			defaultAttributes: sizeDefaults,
+			styleCard: getStyleCard({
+				[getBlockDefaultKey(
+					'button-maxi',
+					'width-fit-content-xl'
+				)]: true,
+				[getBlockDefaultKey('button-maxi', 'width-xl')]: '620',
+				[getBlockDefaultKey('button-maxi', 'width-unit-xl')]: 'px',
+			}),
+		});
+
+		expect(result['width-fit-content-xl']).toBe(false);
+		expect(result['width-xl']).toBe('620');
+		expect(result.__scBlockDefaults['width-xl'].cssVar).toBe(
+			'--maxi-light-block-default-button-maxi-width-xl'
+		);
 	});
 
 	it('generates CSS variables for stored block defaults', () => {

--- a/src/extensions/style-cards/test/getSCVariablesObject.js
+++ b/src/extensions/style-cards/test/getSCVariablesObject.js
@@ -12,6 +12,38 @@ describe('getSCVariablesObject', () => {
 		expect(cleanVarSC).toMatchSnapshot();
 	});
 
+	it('includes block default CSS variables', () => {
+		const cleanVarSC = getSCVariablesObject(
+			{
+				light: {
+					defaultStyleCard: {
+						blockDefaults: {},
+					},
+					styleCard: {
+						blockDefaults: {
+							'row-maxi|max-width-xl': '1280',
+							'row-maxi|max-width-unit-xl': 'px',
+						},
+					},
+				},
+				dark: {
+					defaultStyleCard: {
+						blockDefaults: {},
+					},
+					styleCard: {
+						blockDefaults: {},
+					},
+				},
+			},
+			null,
+			true
+		);
+
+		expect(
+			cleanVarSC['--maxi-light-block-default-row-maxi-max-width-xl']
+		).toBe('1280px');
+	});
+
 	it('Returns the correct object', () => {
 		const styleCard = {
 			name: 'Maxi (Default) - test',

--- a/src/extensions/style-cards/test/syncTypography.js
+++ b/src/extensions/style-cards/test/syncTypography.js
@@ -1,0 +1,165 @@
+import {
+	DARK_TONE_STYLE_OVERRIDES,
+	SYNC_STYLE_SETTINGS_TONES_STATUS,
+	SYNC_TYPOGRAPHY_TONES_STATUS,
+	applyStyleCardTypeChange,
+	getDarkToneStyleOverridesUpdate,
+	getStyleCardToneKeysForChange,
+	hasDarkToneStyleOverride,
+	isStyleSettingsSyncEnabled,
+	isTypographySyncEnabled,
+} from '../syncTypography';
+
+const baseStyleCard = {
+	light: {
+		styleCard: {
+			p: {
+				'font-size-general': 16,
+				'palette-color-general': 4,
+			},
+		},
+	},
+	dark: {
+		styleCard: {
+			p: {
+				'font-size-general': 18,
+				'palette-color-general': 6,
+			},
+		},
+	},
+};
+
+describe('Style Card style settings sync', () => {
+	it('syncs non-colour style setting changes across tones by default', () => {
+		expect(isTypographySyncEnabled(baseStyleCard)).toBe(true);
+		expect(isStyleSettingsSyncEnabled(baseStyleCard)).toBe(true);
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'button',
+				styleCard: baseStyleCard,
+			})
+		).toEqual(['light', 'dark']);
+	});
+
+	it('keeps palette changes on the selected tone', () => {
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'dark',
+				forceToneOnly: true,
+				type: 'color',
+				styleCard: baseStyleCard,
+			})
+		).toEqual(['dark']);
+	});
+
+	it('keeps shared section changes on the current tone when sync is disabled', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[SYNC_STYLE_SETTINGS_TONES_STATUS]: false,
+		};
+
+		expect(isTypographySyncEnabled(styleCard)).toBe(false);
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'p',
+				styleCard,
+			})
+		).toEqual(['light']);
+	});
+
+	it('uses the old typography sync flag as a fallback for stored cards', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[SYNC_TYPOGRAPHY_TONES_STATUS]: false,
+		};
+
+		expect(isStyleSettingsSyncEnabled(styleCard)).toBe(false);
+	});
+
+	it('keeps section changes on light when a dark override is enabled', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[DARK_TONE_STYLE_OVERRIDES]: ['button'],
+		};
+
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'button',
+				styleCard,
+			})
+		).toEqual(['light']);
+	});
+
+	it('treats heading overrides as a single section override', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[DARK_TONE_STYLE_OVERRIDES]: ['heading'],
+		};
+
+		expect(hasDarkToneStyleOverride(styleCard, 'h2')).toBe(true);
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'h2',
+				styleCard,
+			})
+		).toEqual(['light']);
+	});
+
+	it('tracks dark tone overrides without duplicating entries', () => {
+		const added = getDarkToneStyleOverridesUpdate({
+			styleCard: {
+				[DARK_TONE_STYLE_OVERRIDES]: ['button'],
+			},
+			group: 'button',
+			enabled: true,
+		});
+
+		expect(added).toEqual({
+			[DARK_TONE_STYLE_OVERRIDES]: ['button'],
+		});
+
+		expect(
+			getDarkToneStyleOverridesUpdate({
+				styleCard: added,
+				group: 'button',
+				enabled: false,
+			})
+		).toEqual({
+			[DARK_TONE_STYLE_OVERRIDES]: [],
+		});
+	});
+
+	it('applies synced updates to each target tone without touching colours', () => {
+		const updatedStyleCard = getStyleCardToneKeysForChange({
+			currentSCStyle: 'light',
+			styleCard: baseStyleCard,
+			type: 'p',
+		}).reduce(
+			(styleCard, tone) =>
+				applyStyleCardTypeChange({
+					styleCard,
+					tone,
+					type: 'p',
+					prop: 'font-size-general',
+					value: 20,
+					shouldDeleteNilValue: true,
+				}),
+			baseStyleCard
+		);
+
+		expect(updatedStyleCard.light.styleCard.p['font-size-general']).toBe(
+			20
+		);
+		expect(updatedStyleCard.dark.styleCard.p['font-size-general']).toBe(20);
+		expect(
+			updatedStyleCard.light.styleCard.p['palette-color-general']
+		).toBe(4);
+		expect(updatedStyleCard.dark.styleCard.p['palette-color-general']).toBe(
+			6
+		);
+	});
+});

--- a/src/extensions/style-cards/test/syncTypography.js
+++ b/src/extensions/style-cards/test/syncTypography.js
@@ -109,6 +109,47 @@ describe('Style Card style settings sync', () => {
 		).toEqual(['light']);
 	});
 
+	it('supports block-level override grouping for block defaults', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[DARK_TONE_STYLE_OVERRIDES]: ['container-maxi'],
+		};
+
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'blockDefaults',
+				group: 'container-maxi',
+				styleCard,
+			})
+		).toEqual(['light']);
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'blockDefaults',
+				styleCard,
+			})
+		).toEqual(['light', 'dark']);
+	});
+
+	it('can force shared updates for UI sections without dark controls', () => {
+		const styleCard = {
+			...baseStyleCard,
+			[SYNC_STYLE_SETTINGS_TONES_STATUS]: false,
+			[DARK_TONE_STYLE_OVERRIDES]: ['container-maxi'],
+		};
+
+		expect(
+			getStyleCardToneKeysForChange({
+				currentSCStyle: 'light',
+				type: 'blockDefaults',
+				group: 'container-maxi',
+				forceSyncedTones: true,
+				styleCard,
+			})
+		).toEqual(['light', 'dark']);
+	});
+
 	it('tracks dark tone overrides without duplicating entries', () => {
 		const added = getDarkToneStyleOverridesUpdate({
 			styleCard: {

--- a/src/extensions/style-cards/test/updateSCOnEditor.js
+++ b/src/extensions/style-cards/test/updateSCOnEditor.js
@@ -10,6 +10,7 @@ import {
 	createSCStyleString,
 	getSCFontsData,
 } from '@extensions/style-cards/updateSCOnEditor';
+import updateSCOnEditor from '@extensions/style-cards/updateSCOnEditor';
 import standardSC from '@maxi-core/defaults/defaultSC.json';
 import getSCVariablesObject from '@extensions/style-cards/getSCVariablesObject';
 
@@ -25,6 +26,13 @@ jest.mock('@extensions/styles/transitions/getTransitionData.js', () =>
 jest.mock('@extensions/attributes/getBlockData.js', () => jest.fn());
 jest.mock('src/components/transform-control/utils.js', () => jest.fn());
 jest.mock('src/extensions/DC/constants.js', () => ({}));
+jest.mock('@extensions/text/fonts', () => ({
+	loadFonts: jest.fn(),
+}));
+jest.mock('@extensions/fse', () => ({
+	getSiteEditorIframe: jest.fn(() => null),
+	getSiteEditorPreviewIframes: jest.fn(() => []),
+}));
 
 const styleCards = {
 	name: 'Maxi (Default)',
@@ -635,6 +643,56 @@ describe('getSCVariablesObject', () => {
 		const parsedSC = createSCStyleString(varSC);
 
 		expect(parsedSC).toMatchSnapshot();
+	});
+});
+
+describe('updateSCOnEditor', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+	});
+
+	it('updates block default CSS variables in the editor canvas iframe', () => {
+		const iframe = document.createElement('iframe');
+		iframe.setAttribute('name', 'editor-canvas');
+		document.body.appendChild(iframe);
+
+		const blockDefaultStyleCards = {
+			light: {
+				defaultStyleCard: {},
+				styleCard: {
+					blockDefaults: {
+						'container-maxi|padding-top-xl': 21,
+						'container-maxi|padding-top-unit-xl': 'px',
+					},
+				},
+			},
+			dark: {
+				defaultStyleCard: {},
+				styleCard: {
+					blockDefaults: {
+						'container-maxi|padding-top-xl': 42,
+						'container-maxi|padding-top-unit-xl': 'px',
+					},
+				},
+			},
+		};
+
+		updateSCOnEditor(blockDefaultStyleCards, null, [document]);
+
+		const parentStyle = document.getElementById(
+			'maxi-blocks-sc-vars-inline-css'
+		);
+		const iframeStyle = iframe.contentDocument.getElementById(
+			'maxi-blocks-sc-vars-inline-css'
+		);
+
+		expect(parentStyle.innerHTML).toContain(
+			'--maxi-light-block-default-container-maxi-padding-top-xl:21px'
+		);
+		expect(iframeStyle.innerHTML).toContain(
+			'--maxi-light-block-default-container-maxi-padding-top-xl:21px'
+		);
 	});
 });
 

--- a/src/extensions/style-cards/updateSCOnEditor.js
+++ b/src/extensions/style-cards/updateSCOnEditor.js
@@ -11,6 +11,7 @@ import {
 	getSiteEditorIframe,
 	getSiteEditorPreviewIframes,
 } from '@extensions/fse';
+import { debugSCBlockDefaults } from './blockDefaults';
 import getSCVariablesObject from './getSCVariablesObject';
 import getSCStyles from './getSCStyles';
 
@@ -122,6 +123,19 @@ const updateSCOnEditor = (
 	const allSCFonts = getSCFontsData(SCObject);
 	const SCVariableString = createSCStyleString(SCObject);
 	const siteEditorPreviewIframes = getSiteEditorPreviewIframes();
+	const blockDefaultVariables = Object.fromEntries(
+		Object.entries(SCObject).filter(([key]) =>
+			key.includes('block-default')
+		)
+	);
+
+	debugSCBlockDefaults('editor update prepared', {
+		activeSCColour,
+		blockDefaultVariables,
+		hasBlockDefaultVariables: !isEmpty(blockDefaultVariables),
+		isPreview,
+		targetCount: isArray(rawElements) ? rawElements.length : 1,
+	});
 
 	// FSE editor patterns previews - handle white overlay
 	if (siteEditorPreviewIframes.length > 0) {
@@ -155,6 +169,18 @@ const updateSCOnEditor = (
 		if (!element) return;
 
 		let SCVarEl = element.getElementById('maxi-blocks-sc-vars-inline-css');
+		const existingSCVarsText = SCVarEl?.innerHTML || '';
+
+		debugSCBlockDefaults('editor update target', {
+			hasElement: Boolean(element),
+			elementURL: element.URL,
+			hadSCVarsElement: Boolean(SCVarEl),
+			previousContainsBlockDefaults:
+				existingSCVarsText.includes('block-default'),
+			nextContainsBlockDefaults:
+				SCVariableString.includes('block-default'),
+			nextLength: SCVariableString.length,
+		});
 
 		if (!SCVarEl) {
 			SCVarEl = element.createElement('style');
@@ -176,6 +202,14 @@ const updateSCOnEditor = (
 				styleCards.gutenberg_blocks_status
 			);
 		}
+
+		debugSCBlockDefaults('editor update target complete', {
+			elementURL: element.URL,
+			hasSCVarsElement: Boolean(SCVarEl),
+			currentContainsBlockDefaults:
+				SCVarEl?.innerHTML?.includes('block-default'),
+			currentLength: SCVarEl?.innerHTML?.length,
+		});
 
 		if (!isEmpty(allSCFonts)) {
 			loadFonts(allSCFonts, false, element);

--- a/src/extensions/style-cards/updateSCOnEditor.js
+++ b/src/extensions/style-cards/updateSCOnEditor.js
@@ -86,6 +86,40 @@ const updateSCStyles = async (element, SCObject, gutenbergBlocksStatus) => {
 	}
 };
 
+const getEditorCanvasDocuments = () => {
+	const iframeDocuments = [];
+
+	if (typeof document === 'undefined' || !document.querySelectorAll) {
+		return iframeDocuments;
+	}
+
+	try {
+		document
+			.querySelectorAll('iframe[name="editor-canvas"]')
+			.forEach(iframe => {
+				try {
+					if (iframe?.contentDocument) {
+						iframeDocuments.push(iframe.contentDocument);
+					}
+				} catch {
+					// Iframe access can fail while Gutenberg is replacing the canvas.
+				}
+			});
+	} catch {
+		// Keep Style Card updates working in non-browser test/runtime contexts.
+	}
+
+	return iframeDocuments;
+};
+
+const getStyleCardUpdateTargets = rawElements =>
+	Array.from(
+		new Set([
+			...(isArray(rawElements) ? rawElements : [rawElements]),
+			...getEditorCanvasDocuments(),
+		])
+	).filter(Boolean);
+
 const updateSCOnEditor = (
 	styleCards,
 	activeSCColour,
@@ -127,6 +161,7 @@ const updateSCOnEditor = (
 	const allSCFonts = getSCFontsData(SCObject);
 	const SCVariableString = createSCStyleString(SCObject);
 	const siteEditorPreviewIframes = getSiteEditorPreviewIframes();
+	const elements = getStyleCardUpdateTargets(rawElements);
 	const blockDefaultVariables = Object.fromEntries(
 		Object.entries(SCObject).filter(([key]) =>
 			key.includes('block-default')
@@ -138,7 +173,7 @@ const updateSCOnEditor = (
 		blockDefaultVariables,
 		hasBlockDefaultVariables: !isEmpty(blockDefaultVariables),
 		isPreview,
-		targetCount: isArray(rawElements) ? rawElements.length : 1,
+		targetCount: elements.length,
 	});
 
 	// FSE editor patterns previews - handle white overlay
@@ -165,9 +200,6 @@ const updateSCOnEditor = (
 			}
 		});
 	}
-
-	// Always update SC variables in the main elements (even if preview iframes exist)
-	const elements = isArray(rawElements) ? rawElements : [rawElements];
 
 	elements.forEach(element => {
 		if (!element) return;

--- a/src/extensions/style-cards/updateSCOnEditor.js
+++ b/src/extensions/style-cards/updateSCOnEditor.js
@@ -11,7 +11,10 @@ import {
 	getSiteEditorIframe,
 	getSiteEditorPreviewIframes,
 } from '@extensions/fse';
-import { debugSCBlockDefaults } from './blockDefaults';
+import {
+	debugSCBlockDefaults,
+	setActiveStyleCardValueForBlockDefaults,
+} from './blockDefaults';
 import getSCVariablesObject from './getSCVariablesObject';
 import getSCStyles from './getSCStyles';
 
@@ -120,6 +123,7 @@ const updateSCOnEditor = (
 	}
 
 	const SCObject = getSCVariablesObject(clonedStyleCards, activeSCColour);
+	setActiveStyleCardValueForBlockDefaults(clonedStyleCards);
 	const allSCFonts = getSCFontsData(SCObject);
 	const SCVariableString = createSCStyleString(SCObject);
 	const siteEditorPreviewIframes = getSiteEditorPreviewIframes();

--- a/src/extensions/styles/defaults/global.js
+++ b/src/extensions/styles/defaults/global.js
@@ -32,6 +32,9 @@ const global = {
 	relations: {
 		type: 'array',
 	},
+	scBlockDefaultsExcludedAttributes: {
+		type: 'array',
+	},
 	preview: { type: 'boolean', default: false },
 	ariaLabels: {
 		type: 'object',

--- a/src/extensions/styles/getDefaultAttribute.js
+++ b/src/extensions/styles/getDefaultAttribute.js
@@ -10,6 +10,7 @@ import { getBlockAttributes } from '@wordpress/blocks';
 import * as defaults from './defaults/index';
 import { getIsValid, getBreakpointFromAttribute } from './utils';
 import { getBlockData } from '@extensions/attributes';
+import { debugSCBlockDefaults } from '@extensions/style-cards/blockDefaults';
 
 /**
  * External dependencies
@@ -59,8 +60,23 @@ const getDefaultAttribute = (
 		blockName = blockNameProp || getBlocksName(getSelectedBlockClientIds());
 	}
 
+	const debugDefaultAttribute = (stage, value, extra = {}) => {
+		if (!prop.includes('width') && !prop.includes('height')) return;
+
+		debugSCBlockDefaults('sidebar default attribute', {
+			stage,
+			prop,
+			blockName,
+			value,
+			...extra,
+		});
+	};
+
 	const isMaxiBlock = blockName && blockName.includes('maxi-blocks');
-	if (!isMaxiBlock) return null;
+	if (!isMaxiBlock) {
+		debugDefaultAttribute('non-maxi-block', null);
+		return null;
+	}
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const maxiBlocksStore = select('maxiBlocks');
@@ -72,7 +88,10 @@ const getDefaultAttribute = (
 	}
 
 	const isGeneral = getBreakpointFromAttribute(prop) === 'general';
-	if (getIsValid(response, true)) return response;
+	if (getIsValid(response, true)) {
+		debugDefaultAttribute('block attribute default', response);
+		return response;
+	}
 	if (isGeneral) {
 		if (avoidBaseBreakpoint) return response;
 
@@ -82,7 +101,12 @@ const getDefaultAttribute = (
 				prop.replace('general', baseBreakpoint)
 			];
 
-		if (getIsValid(baseAttribute, true)) return baseAttribute;
+		if (getIsValid(baseAttribute, true)) {
+			debugDefaultAttribute('base breakpoint default', baseAttribute, {
+				baseBreakpoint,
+			});
+			return baseAttribute;
+		}
 	}
 
 	// Check default value
@@ -96,6 +120,8 @@ const getDefaultAttribute = (
 			prop.replace('general', baseBreakpoint, clientIds)
 		);
 	}
+
+	debugDefaultAttribute('resolved default', response);
 
 	return response;
 };

--- a/src/extensions/styles/getGroupAttributes.js
+++ b/src/extensions/styles/getGroupAttributes.js
@@ -3,6 +3,7 @@
  */
 import { getIsValid } from './utils';
 import * as defaults from './defaults/index';
+import { applySCBlockDefaultsToAttributes } from '@extensions/style-cards/blockDefaults';
 
 // WeakMap-based cache: keyed by the attributes object reference.
 // Cache validation uses two-layer approach:
@@ -53,7 +54,9 @@ const getGroupAttributes = (
 	const enableCache = cleaned;
 
 	// Build cache key from the non-object arguments
-	const cacheKey = `${Array.isArray(target) ? target.join(',') : target}|${isHover ? 1 : 0}|${prefix}|${cleaned ? 1 : 0}`;
+	const cacheKey = `${Array.isArray(target) ? target.join(',') : target}|${
+		isHover ? 1 : 0
+	}|${prefix}|${cleaned ? 1 : 0}`;
 
 	// Get default attributes to use for validation
 	const targets = Array.isArray(target) ? target : [target];
@@ -72,7 +75,11 @@ const getGroupAttributes = (
 			const cached = attrCache.get(cacheKey);
 			if (cached) {
 				// Validate the cache is still accurate
-				const currentValidation = createValidationKey(attributes, allDefaultKeys, prefix);
+				const currentValidation = createValidationKey(
+					attributes,
+					allDefaultKeys,
+					prefix
+				);
 				if (currentValidation === cached.validation) {
 					return cached.result;
 				}
@@ -118,11 +125,27 @@ const getGroupAttributes = (
 			attrCache = new Map();
 			_cache.set(attributes, attrCache);
 		}
-		const validation = createValidationKey(attributes, allDefaultKeys, prefix);
+		const validation = createValidationKey(
+			attributes,
+			allDefaultKeys,
+			prefix
+		);
 		attrCache.set(cacheKey, { result: response, validation });
 	}
 
-	return response;
+	return applySCBlockDefaultsToAttributes({
+		response,
+		attributes,
+		defaultAttributes: targets.reduce((acc, el) => {
+			const defaultAttributes =
+				defaults[`${el}${isHover ? 'Hover' : ''}`] || defaults[el];
+
+			return {
+				...acc,
+				...(defaultAttributes || {}),
+			};
+		}, {}),
+	});
 };
 
 export default getGroupAttributes;

--- a/src/extensions/styles/getGroupAttributes.js
+++ b/src/extensions/styles/getGroupAttributes.js
@@ -43,7 +43,8 @@ const getGroupAttributes = (
 	target,
 	isHover = false,
 	prefix = '',
-	cleaned = false
+	cleaned = false,
+	applyStyleCardDefaults = false
 ) => {
 	if (!target) return null;
 
@@ -96,7 +97,14 @@ const getGroupAttributes = (
 	if (isHover) {
 		Object.assign(
 			response,
-			getGroupAttributes(attributes, target, false, prefix, cleaned)
+			getGroupAttributes(
+				attributes,
+				target,
+				false,
+				prefix,
+				cleaned,
+				applyStyleCardDefaults
+			)
 		);
 	}
 
@@ -132,6 +140,8 @@ const getGroupAttributes = (
 		);
 		attrCache.set(cacheKey, { result: response, validation });
 	}
+
+	if (!applyStyleCardDefaults) return response;
 
 	return applySCBlockDefaultsToAttributes({
 		response,

--- a/src/extensions/styles/helpers/getFlexStyles.js
+++ b/src/extensions/styles/helpers/getFlexStyles.js
@@ -6,6 +6,7 @@ import { isNil, isEmpty } from 'lodash';
  * Internal dependencies
  */
 import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttribute';
+import { getSCBlockDefaultStyleValue } from '@extensions/style-cards/blockDefaults';
 
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
@@ -14,6 +15,7 @@ const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
  */
 const getFlexStyles = (obj, prefix = '') => {
 	const response = {};
+	const scBlockDefaults = obj.__scBlockDefaults || {};
 	breakpoints.forEach(breakpoint => {
 		let flexBasis = getLastBreakpointAttribute({
 			target: `${prefix}flex-basis`,
@@ -86,6 +88,17 @@ const getFlexStyles = (obj, prefix = '') => {
 			attributes: obj,
 		});
 
+		const rowGapUnit = getLastBreakpointAttribute({
+			target: `${prefix}row-gap-unit`,
+			breakpoint,
+			attributes: obj,
+		});
+		const columnGapUnit = getLastBreakpointAttribute({
+			target: `${prefix}column-gap-unit`,
+			breakpoint,
+			attributes: obj,
+		});
+
 		response[breakpoint] = {
 			...((flexBasis || flexGrow || flexShrink) && {
 				flex: `${flexGrow || 0} ${flexShrink || 1} ${
@@ -93,7 +106,13 @@ const getFlexStyles = (obj, prefix = '') => {
 				}`,
 			}),
 			...(!isNil(flexWrap) && {
-				'flex-wrap': flexWrap,
+				'flex-wrap': getSCBlockDefaultStyleValue({
+					scBlockDefaults,
+					prefix,
+					target: 'flex-wrap',
+					breakpoint,
+					fallbackValue: flexWrap,
+				}),
 			}),
 			...(!isNil(flexOrder) && {
 				order: flexOrder,
@@ -111,18 +130,22 @@ const getFlexStyles = (obj, prefix = '') => {
 				'align-content': alignContent,
 			}),
 			...(!isNil(rowGapProps) && {
-				'row-gap': `${rowGapProps}${getLastBreakpointAttribute({
-					target: `${prefix}row-gap-unit`,
+				'row-gap': getSCBlockDefaultStyleValue({
+					scBlockDefaults,
+					prefix,
+					target: 'row-gap',
 					breakpoint,
-					attributes: obj,
-				})}`,
+					fallbackValue: `${rowGapProps}${rowGapUnit}`,
+				}),
 			}),
 			...(!isNil(columnGap) && {
-				'column-gap': `${columnGap}${getLastBreakpointAttribute({
-					target: `${prefix}column-gap-unit`,
+				'column-gap': getSCBlockDefaultStyleValue({
+					scBlockDefaults,
+					prefix,
+					target: 'column-gap',
 					breakpoint,
-					attributes: obj,
-				})}`,
+					fallbackValue: `${columnGap}${columnGapUnit}`,
+				}),
 			}),
 		};
 

--- a/src/extensions/styles/helpers/getMarginPaddingStyles.js
+++ b/src/extensions/styles/helpers/getMarginPaddingStyles.js
@@ -3,6 +3,7 @@
  */
 import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttribute';
 import { isValidNumber } from '@extensions/styles/utils';
+import { getSCBlockDefaultStyleValue } from '@extensions/style-cards/blockDefaults';
 
 /**
  * General
@@ -12,6 +13,7 @@ const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 const getMarginPaddingStyles = ({ obj, prefix = '' }) => {
 	const keyWords = ['top', 'right', 'bottom', 'left'];
 	const response = {};
+	const scBlockDefaults = obj.__scBlockDefaults || {};
 
 	for (const breakpoint of breakpoints) {
 		response[breakpoint] = {};
@@ -47,10 +49,19 @@ const getMarginPaddingStyles = ({ obj, prefix = '' }) => {
 							? lastUnit || unit
 							: unit || lastUnit;
 
-						response[breakpoint][`${type}-${key}`] =
+						const fallbackValue =
 							useValue === 'auto'
 								? 'auto'
 								: `${useValue}${useUnit}`;
+
+						response[breakpoint][`${type}-${key}`] =
+							getSCBlockDefaultStyleValue({
+								scBlockDefaults,
+								prefix,
+								target: `${type}-${key}`,
+								breakpoint,
+								fallbackValue,
+							});
 					}
 				}
 

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -4,7 +4,7 @@
 import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttribute';
 import getDefaultAttribute from '@extensions/styles/getDefaultAttribute';
 import { isValidNumber } from '@extensions/styles/utils';
-import { debugSCBlockDefaults } from '@extensions/style-cards/blockDefaults';
+import { getSCBlockDefaultStyleValue } from '@extensions/style-cards/blockDefaults';
 
 /**
  * External dependencies
@@ -24,35 +24,6 @@ const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 const getSizeStyles = (obj, prefix = '') => {
 	const response = {};
 	const scBlockDefaults = obj.__scBlockDefaults || {};
-
-	const getSCBlockDefaultValue = (target, breakpoint, fallbackValue) => {
-		const meta = scBlockDefaults[`${prefix}${target}-${breakpoint}`];
-
-		if (!meta?.cssVar) {
-			debugSCBlockDefaults('size style fallback', {
-				target,
-				breakpoint,
-				fallbackValue,
-				prefix,
-				meta,
-				availableMetaKeys: Object.keys(scBlockDefaults),
-			});
-			return fallbackValue;
-		}
-
-		const value = `var(${meta.cssVar}, ${meta.fallback || fallbackValue})`;
-
-		debugSCBlockDefaults('size style css var', {
-			target,
-			breakpoint,
-			fallbackValue,
-			prefix,
-			meta,
-			value,
-		});
-
-		return value;
-	};
 
 	const getValue = (target, breakpoint) => {
 		let fullWidthNormalStyles = {};
@@ -157,7 +128,13 @@ const getSizeStyles = (obj, prefix = '') => {
 				return {
 					[target]:
 						auto ||
-						getSCBlockDefaultValue(target, breakpoint, num + unit),
+						getSCBlockDefaultStyleValue({
+							scBlockDefaults,
+							prefix,
+							target,
+							breakpoint,
+							fallbackValue: num + unit,
+						}),
 					...fullWidthNormalStyles,
 				};
 		}

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -4,6 +4,7 @@
 import getLastBreakpointAttribute from '@extensions/styles/getLastBreakpointAttribute';
 import getDefaultAttribute from '@extensions/styles/getDefaultAttribute';
 import { isValidNumber } from '@extensions/styles/utils';
+import { debugSCBlockDefaults } from '@extensions/style-cards/blockDefaults';
 
 /**
  * External dependencies
@@ -27,9 +28,30 @@ const getSizeStyles = (obj, prefix = '') => {
 	const getSCBlockDefaultValue = (target, breakpoint, fallbackValue) => {
 		const meta = scBlockDefaults[`${prefix}${target}-${breakpoint}`];
 
-		if (!meta?.cssVar) return fallbackValue;
+		if (!meta?.cssVar) {
+			debugSCBlockDefaults('size style fallback', {
+				target,
+				breakpoint,
+				fallbackValue,
+				prefix,
+				meta,
+				availableMetaKeys: Object.keys(scBlockDefaults),
+			});
+			return fallbackValue;
+		}
 
-		return `var(${meta.cssVar}, ${meta.fallback || fallbackValue})`;
+		const value = `var(${meta.cssVar}, ${meta.fallback || fallbackValue})`;
+
+		debugSCBlockDefaults('size style css var', {
+			target,
+			breakpoint,
+			fallbackValue,
+			prefix,
+			meta,
+			value,
+		});
+
+		return value;
 	};
 
 	const getValue = (target, breakpoint) => {

--- a/src/extensions/styles/helpers/getSizeStyles.js
+++ b/src/extensions/styles/helpers/getSizeStyles.js
@@ -22,6 +22,15 @@ const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
  */
 const getSizeStyles = (obj, prefix = '') => {
 	const response = {};
+	const scBlockDefaults = obj.__scBlockDefaults || {};
+
+	const getSCBlockDefaultValue = (target, breakpoint, fallbackValue) => {
+		const meta = scBlockDefaults[`${prefix}${target}-${breakpoint}`];
+
+		if (!meta?.cssVar) return fallbackValue;
+
+		return `var(${meta.cssVar}, ${meta.fallback || fallbackValue})`;
+	};
 
 	const getValue = (target, breakpoint) => {
 		let fullWidthNormalStyles = {};
@@ -124,7 +133,9 @@ const getSizeStyles = (obj, prefix = '') => {
 
 			if (isValidNumber(num) && !isNil(unit))
 				return {
-					[target]: auto || num + unit,
+					[target]:
+						auto ||
+						getSCBlockDefaultValue(target, breakpoint, num + unit),
 					...fullWidthNormalStyles,
 				};
 		}

--- a/src/extensions/styles/helpers/test/getFlexStyles.js
+++ b/src/extensions/styles/helpers/test/getFlexStyles.js
@@ -147,4 +147,47 @@ describe('getFlexStyles', () => {
 			},
 		});
 	});
+
+	it('should use Style Card block default CSS variables for row spacing defaults', () => {
+		const obj = {
+			'row-gap': '30',
+			'row-gap-unit': 'px',
+			'column-gap': '4',
+			'column-gap-unit': '%',
+			'flex-wrap': 'wrap',
+			__scBlockDefaults: {
+				'row-gap-general': {
+					blockName: 'row-maxi',
+					blockStyle: 'light',
+					cssVar: '--maxi-light-block-default-row-maxi-row-gap-general',
+					fallback: '20px',
+				},
+				'column-gap-general': {
+					blockName: 'row-maxi',
+					blockStyle: 'light',
+					cssVar:
+						'--maxi-light-block-default-row-maxi-column-gap-general',
+					fallback: '2.5%',
+				},
+				'flex-wrap-general': {
+					blockName: 'row-maxi',
+					blockStyle: 'light',
+					cssVar:
+						'--maxi-light-block-default-row-maxi-flex-wrap-general',
+					fallback: 'wrap',
+				},
+			},
+		};
+
+		const result = getFlexStyles(obj);
+
+		expect(result.general).toEqual({
+			'flex-wrap':
+				'var(--maxi-light-block-default-row-maxi-flex-wrap-general, wrap)',
+			'row-gap':
+				'var(--maxi-light-block-default-row-maxi-row-gap-general, 20px)',
+			'column-gap':
+				'var(--maxi-light-block-default-row-maxi-column-gap-general, 2.5%)',
+		});
+	});
 });

--- a/src/extensions/styles/helpers/test/getMarginPaddingStyles.js
+++ b/src/extensions/styles/helpers/test/getMarginPaddingStyles.js
@@ -220,4 +220,26 @@ describe('getMarginPaddingStyles', () => {
 		});
 		expect(result).toMatchSnapshot();
 	});
+
+	it('uses Style Card block default CSS variables for default-like padding values', () => {
+		const result = getMarginPaddingStyles({
+			obj: {
+				'padding-top-general': '80',
+				'padding-top-unit-general': 'px',
+				__scBlockDefaults: {
+					'padding-top-general': {
+						blockName: 'container-maxi',
+						blockStyle: 'light',
+						cssVar:
+							'--maxi-light-block-default-container-maxi-padding-top-general',
+						fallback: '100px',
+					},
+				},
+			},
+		});
+
+		expect(result.general['padding-top']).toBe(
+			'var(--maxi-light-block-default-container-maxi-padding-top-general, 100px)'
+		);
+	});
 });

--- a/src/extensions/styles/helpers/test/getSizeStyles.js
+++ b/src/extensions/styles/helpers/test/getSizeStyles.js
@@ -515,4 +515,24 @@ describe('getSizeStyles', () => {
 		const result = getSizeStyles(object);
 		expect(result).toMatchSnapshot();
 	});
+
+	it('uses Style Card block default CSS variables for default-like size values', () => {
+		const result = getSizeStyles({
+			'size-advanced-options': true,
+			'max-width-xl': '1280',
+			'max-width-unit-xl': 'px',
+			__scBlockDefaults: {
+				'max-width-xl': {
+					blockName: 'row-maxi',
+					blockStyle: 'light',
+					cssVar: '--maxi-light-block-default-row-maxi-max-width-xl',
+					fallback: '1170px',
+				},
+			},
+		});
+
+		expect(result.xl['max-width']).toBe(
+			'var(--maxi-light-block-default-row-maxi-max-width-xl, 1170px)'
+		);
+	});
 });

--- a/src/extensions/styles/test/getGroupAttributes.js
+++ b/src/extensions/styles/test/getGroupAttributes.js
@@ -1,4 +1,8 @@
 import getGroupAttributes from '@extensions/styles/getGroupAttributes';
+import {
+	getBlockDefaultKey,
+	setActiveStyleCardValueForBlockDefaults,
+} from '@extensions/style-cards/blockDefaults';
 
 const attributes = {
 	extraClassName: '',
@@ -167,6 +171,10 @@ const attributes = {
 };
 
 describe('getGroupAttributes', () => {
+	afterEach(() => {
+		setActiveStyleCardValueForBlockDefaults(null);
+	});
+
 	it('Return basic attributes from string', () => {
 		expect(getGroupAttributes(attributes, 'border')).toMatchSnapshot();
 	});
@@ -201,5 +209,64 @@ describe('getGroupAttributes', () => {
 		expect(
 			getGroupAttributes(attributes, 'border', false, 'icon-')
 		).toMatchSnapshot();
+	});
+
+	it('can return raw group attributes without Style Card block defaults for UI controls', () => {
+		setActiveStyleCardValueForBlockDefaults({
+			light: {
+				styleCard: {
+					blockDefaults: {
+						[getBlockDefaultKey(
+							'container-maxi',
+							'padding-top-general'
+						)]: '20',
+						[getBlockDefaultKey(
+							'container-maxi',
+							'padding-top-unit-general'
+						)]: 'px',
+					},
+				},
+				defaultStyleCard: {
+					blockDefaults: {},
+				},
+			},
+			dark: {
+				styleCard: {
+					blockDefaults: {},
+				},
+				defaultStyleCard: {
+					blockDefaults: {},
+				},
+			},
+		});
+
+		const containerAttributes = {
+			uniqueID: 'container-maxi-test-u',
+			blockStyle: 'light',
+			'padding-top-general': '150',
+			'padding-top-unit-general': 'px',
+			'padding-top-xxl': '200',
+			'padding-top-xl': '150',
+			'padding-top-s': '60',
+			'padding-top-xs': '40',
+		};
+
+		const rawAttributes = getGroupAttributes(
+			containerAttributes,
+			'padding'
+		);
+		const styleAttributes = getGroupAttributes(
+			containerAttributes,
+			'padding',
+			false,
+			'',
+			false,
+			true
+		);
+
+		expect(rawAttributes['padding-top-general']).toBe('150');
+		expect(rawAttributes.__scBlockDefaults).toBeUndefined();
+		expect(styleAttributes['padding-top-general']).toBe('20');
+		expect(styleAttributes.__scBlockDefaults).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Summary
- Adds focused Style Card Advanced globals for site-wide Container and Row layout defaults.
- Keeps Tone globals responsible for existing colour, typography, button, divider, icon, link, heading, and navigation settings.
- Fixes the rendered CSS path so Advanced globals padding/margin/size changes affect editor and frontend output, not only sidebar values and editor indicators.

## What changed
- Reduced Advanced globals to `Container layout` and `Row layout` only.
- Reused the existing Maxi inspector controls for `Height / Width`, `Margin / Padding`, and Row spacing instead of hand-rendered flat padding/margin number rows.
- Removed Dark tone overrides from the Advanced globals UI.
- Added Style Card block-default metadata through the size, margin/padding, and flex style helpers so Container and Row layout defaults can output CSS variables.
- Preserved custom block values by only applying Style Card defaults to unchanged/library-default layout sequences.
- Updated editor refresh handling so Style Card block-default changes invalidate block style caches and use the latest Style Card snapshot immediately.
- Added focused debugging for local Style Card block defaults.
- Added regression tests for Style Card block defaults, sync behavior, helper output, editor UI behavior, Container frontend CSS output, and Row layout defaults.

## Why / root cause
- The previous implementation could update the Style Card values and editor indicators without producing the correct rendered CSS fallback. If the CSS variable was stale or missing, the generated block rule could fall back to the old library/default padding instead of the new Style Card value.
- Advanced globals also became too broad during iteration and duplicated settings that already belonged in Tone globals. The current scope keeps Advanced globals focused on layout defaults only.

## Testing
- `npm test -- src/extensions/style-cards/test/blockDefaults.js src/extensions/style-cards/test/getSCVariablesObject.js src/extensions/style-cards/test/syncTypography.js src/editor/style-cards/test/maxiStyleCardsTab.js src/extensions/styles/helpers/test/getSizeStyles.js src/extensions/styles/helpers/test/getMarginPaddingStyles.js src/extensions/styles/helpers/test/getFlexStyles.js src/blocks/container-maxi/test/styles.js src/blocks/row-maxi/test/styles.js --runInBand`
- `npm test -- src/extensions/style-cards/test/updateSCOnEditor.js --runInBand`
- `git diff --cached --check`
- `git diff --check`
- `npm run build`
- WAMP plugin path verified as a junction to `C:\Users\kyra\maxi-blocks`.
- `Invoke-WebRequest -UseBasicParsing http://localhost/maxi-blocks-local/` returned `200`.

Build passed with the existing webpack asset-size warnings. The in-app browser visual check could not run because the local browser bridge still fails with the Windows sandbox startup issue.

## Manual test steps
1. Hard refresh the WP editor after building this branch.
2. Open Style Card editor > Advanced globals > Container layout > Margin / Padding.
3. Change XL padding top/bottom to an obvious value, for example `200px`.
4. Select a matching Container block and confirm the rendered spacing changes, not only the overlay indicator.
5. Save/update the page and hard refresh the frontend.
6. Confirm the frontend Container spacing uses the updated Style Card value.
7. Repeat for Row layout spacing/padding.
8. Check a block with custom non-library layout values and confirm those custom values are preserved.

Closes https://github.com/maxi-blocks/maxi-blocks/issues/5971