### PR TITLE
Fix DC links :: false 404 for pagination on hidden items  

### DIFF
--- a/core/class-maxi-dynamic-content.php
+++ b/core/class-maxi-dynamic-content.php
@@ -910,6 +910,8 @@ class MaxiBlocks_DynamicContent
         }
 
         if (in_array($block_name, self::$link_only_blocks)) {
+            $content = self::render_dc_classes($attributes, $content);
+            $content = self::strip_placeholder_links($content);
             return $content;
         } elseif ($block_name !== 'image-maxi') {
             $content = self::render_dc_content($attributes, $content, $block_name);
@@ -918,7 +920,7 @@ class MaxiBlocks_DynamicContent
         }
 
         $content = self::render_dc_classes($attributes, $content);
-        $content = str_replace('$link-to-replace', '', $content);
+        $content = self::strip_placeholder_links($content);
 
         return $content;
     }
@@ -1463,6 +1465,35 @@ class MaxiBlocks_DynamicContent
 
             return $content;
         }
+
+        return $content;
+    }
+
+    /**
+     * Strips anchor wrappers whose href was never resolved from the
+     * $link-to-replace placeholder, then clears any remaining placeholder
+     * occurrences (e.g. in title attributes). Unresolved placeholders appear
+     * on hidden context-loop items that have no backing post and would
+     * otherwise cause 404 errors for crawlers.
+     *
+     * @param string $content Block HTML content.
+     * @return string Cleaned content.
+     */
+    private static function strip_placeholder_links($content)
+    {
+        if (strpos($content, '$link-to-replace') === false) {
+            return $content;
+        }
+
+        // Remove anchor wrappers whose href was never resolved, keeping inner content
+        $content = preg_replace(
+            '/<a\b[^>]*href="\$link-to-replace"[^>]*>(.*?)<\/a>/s',
+            '$1',
+            $content,
+        );
+
+        // Clear any remaining placeholder occurrences (e.g. in title attributes)
+        $content = str_replace('$link-to-replace', '', $content);
 
         return $content;
     }

--- a/e2e-tests/components/dynamic-content/post.spec.js
+++ b/e2e-tests/components/dynamic-content/post.spec.js
@@ -142,10 +142,14 @@ describe('Dynamic content', () => {
 
 		// Check frontend
 		const previewPage = await openPreviewPage(page);
+		await previewPage
+			.waitForNavigation({ waitUntil: 'networkidle0', timeout: 30000 })
+			.catch(() => {});
 		await previewPage.waitForSelector(
 			'.text-dc-title-1.maxi-text-block .maxi-text-block__content',
 			{
 				visible: true,
+				timeout: 30000,
 			}
 		);
 
@@ -159,7 +163,7 @@ describe('Dynamic content', () => {
 				);
 				return el && el.innerText === expected;
 			},
-			{ timeout: 15000 },
+			{ timeout: 30000 },
 			expectedResults.title
 		);
 


### PR DESCRIPTION
# Description

## Problem
Hidden dynamic content items (context loop blocks without a backing post) were rendering anchor tags with href="$link-to-replace" in the page source. Crawlers followed these broken URLs, generating 404 reports.

This happens on paginated blogs when the last page has fewer posts than the pattern expects — empty slots render as hidden blocks but their link wrappers retained the unresolved placeholder.

**Reproduction:** Use a blog pattern with 4+ posts per page, but only 3 posts in the category. The hidden slot outputs:

```<a class="maxi-block--hidden maxi-link-wrapper" href="$link-to-replace" target="_self">```

## Root cause
In render_dc(), link-only blocks (group-maxi, column-maxi, row-maxi, slide-maxi, pane-maxi) had an early return that skipped both render_dc_classes() and the $link-to-replace cleanup:

``` 
if (in_array($block_name, self::$link_only_blocks)) {
    return $content; // ← skipped all cleanup
}
```
When render_dc_link() couldn't resolve a post (empty slot), the placeholder stayed in the HTML and was never stripped.

# Fix
Link-only blocks now run render_dc_classes() and placeholder cleanup before returning.

Introduced strip_placeholder_links() which removes the entire <a> wrapper (not just the placeholder text) when the href was never resolved. This prevents crawlers from seeing any link — empty href="" would still cause self-referencing link issues.

The method also clears remaining placeholders in other attributes (e.g. title).

Fixes #6290 

# Testing
Navigate to a paginated blog page where the last page has fewer posts than the pattern layout expects.

Inspect the page source — hidden blocks should no longer contain $link-to-replace or any anchor wrapper.

Verify visible DC blocks with resolved links still work correctly.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of placeholder links in dynamic content blocks to ensure cleaner rendering and prevent unresolved links from appearing in the output.

* **Tests**
  * Enhanced test stability for dynamic content functionality with optimized timing for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->