### PR TITLE
Add Image Maxi filter controls

### DIFF
--- a/src/blocks/image-maxi/attributes.js
+++ b/src/blocks/image-maxi/attributes.js
@@ -13,7 +13,6 @@ import {
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
-	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
 } from './components/filter-tab/constants';
@@ -188,7 +187,7 @@ const attributes = {
 	...hoverAttributesCreator({
 		obj: imageFilterAttributes,
 		newAttr: {
-			[IMAGE_FILTER_STATUS_HOVER]: {
+			'image-filter-status-hover': {
 				type: 'boolean',
 				default: false,
 			},

--- a/src/blocks/image-maxi/attributes.js
+++ b/src/blocks/image-maxi/attributes.js
@@ -8,6 +8,13 @@ import {
 	transitionAttributesCreator,
 } from '@extensions/styles';
 import { customCss, transition } from './data';
+import {
+	IMAGE_FILTER_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	getDropShadowAttribute,
+	getFilterAttribute,
+} from './components/filter-tab/constants';
 
 /**
  * Attributes
@@ -148,6 +155,33 @@ const attributes = {
 	...attributesData.hoverMargin,
 	...attributesData.hoverPadding,
 	...attributesData.hoverTitleTypography,
+	...breakpointAttributesCreator({
+		obj: {
+			...IMAGE_FILTER_CONTROLS.reduce((acc, { key, defaultValue }) => {
+				acc[getFilterAttribute(key)] = {
+					type: 'number',
+					default: defaultValue,
+				};
+
+				return acc;
+			}, {}),
+			...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce(
+				(acc, { key, defaultValue }) => {
+					acc[getDropShadowAttribute(key)] = {
+						type: 'number',
+						default: defaultValue,
+					};
+
+					return acc;
+				},
+				{}
+			),
+			[getDropShadowAttribute('color')]: {
+				type: 'string',
+				default: IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+			},
+		},
+	}),
 	...prefixAttributesCreator({ obj: attributesData.border, prefix }),
 	...prefixAttributesCreator({ obj: attributesData.borderHover, prefix }),
 	...prefixAttributesCreator({ obj: attributesData.borderRadius, prefix }),

--- a/src/blocks/image-maxi/attributes.js
+++ b/src/blocks/image-maxi/attributes.js
@@ -4,6 +4,7 @@
 import * as attributesData from '@extensions/styles/defaults/index';
 import {
 	breakpointAttributesCreator,
+	hoverAttributesCreator,
 	prefixAttributesCreator,
 	transitionAttributesCreator,
 } from '@extensions/styles';
@@ -12,6 +13,7 @@ import {
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
 } from './components/filter-tab/constants';
@@ -20,6 +22,33 @@ import {
  * Attributes
  */
 const prefix = 'image-';
+const imageFilterAttributes = breakpointAttributesCreator({
+	obj: {
+		...IMAGE_FILTER_CONTROLS.reduce((acc, { key, defaultValue }) => {
+			acc[getFilterAttribute(key)] = {
+				type: 'number',
+				default: defaultValue,
+			};
+
+			return acc;
+		}, {}),
+		...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce(
+			(acc, { key, defaultValue }) => {
+				acc[getDropShadowAttribute(key)] = {
+					type: 'number',
+					default: defaultValue,
+				};
+
+				return acc;
+			},
+			{}
+		),
+		[getDropShadowAttribute('color')]: {
+			type: 'string',
+			default: IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+		},
+	},
+});
 const attributes = {
 	...attributesData.global,
 
@@ -155,30 +184,13 @@ const attributes = {
 	...attributesData.hoverMargin,
 	...attributesData.hoverPadding,
 	...attributesData.hoverTitleTypography,
-	...breakpointAttributesCreator({
-		obj: {
-			...IMAGE_FILTER_CONTROLS.reduce((acc, { key, defaultValue }) => {
-				acc[getFilterAttribute(key)] = {
-					type: 'number',
-					default: defaultValue,
-				};
-
-				return acc;
-			}, {}),
-			...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce(
-				(acc, { key, defaultValue }) => {
-					acc[getDropShadowAttribute(key)] = {
-						type: 'number',
-						default: defaultValue,
-					};
-
-					return acc;
-				},
-				{}
-			),
-			[getDropShadowAttribute('color')]: {
-				type: 'string',
-				default: IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+	...imageFilterAttributes,
+	...hoverAttributesCreator({
+		obj: imageFilterAttributes,
+		newAttr: {
+			[IMAGE_FILTER_STATUS_HOVER]: {
+				type: 'boolean',
+				default: false,
 			},
 		},
 	}),

--- a/src/blocks/image-maxi/components/filter-tab/constants.js
+++ b/src/blocks/image-maxi/components/filter-tab/constants.js
@@ -1,4 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 export const FILTER_BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+export const IMAGE_FILTER_LABELS = {
+	blur: __('Blur', 'maxi-blocks'),
+	brightness: __('Brightness', 'maxi-blocks'),
+	contrast: __('Contrast', 'maxi-blocks'),
+	grayscale: __('Grayscale', 'maxi-blocks'),
+	'hue-rotate': __('Hue rotate', 'maxi-blocks'),
+	invert: __('Invert', 'maxi-blocks'),
+	opacity: __('Opacity', 'maxi-blocks'),
+	saturate: __('Saturate', 'maxi-blocks'),
+	sepia: __('Sepia', 'maxi-blocks'),
+};
+
+export const IMAGE_FILTER_DROP_SHADOW_LABELS = {
+	horizontal: __('Horizontal shadow', 'maxi-blocks'),
+	vertical: __('Vertical shadow', 'maxi-blocks'),
+	blur: __('Shadow blur', 'maxi-blocks'),
+};
 
 export const IMAGE_FILTER_CONTROLS = [
 	{

--- a/src/blocks/image-maxi/components/filter-tab/constants.js
+++ b/src/blocks/image-maxi/components/filter-tab/constants.js
@@ -114,6 +114,8 @@ export const getFilterAttribute = key => `image-filter-${key}`;
 
 export const getDropShadowAttribute = key => `image-filter-drop-shadow-${key}`;
 
+export const IMAGE_FILTER_STATUS_HOVER = 'image-filter-status-hover';
+
 export const IMAGE_FILTER_ATTRIBUTE_KEYS = FILTER_BREAKPOINTS.flatMap(
 	breakpoint => [
 		...IMAGE_FILTER_CONTROLS.map(
@@ -125,3 +127,13 @@ export const IMAGE_FILTER_ATTRIBUTE_KEYS = FILTER_BREAKPOINTS.flatMap(
 		`${getDropShadowAttribute('color')}-${breakpoint}`,
 	]
 );
+
+export const IMAGE_FILTER_HOVER_ATTRIBUTE_KEYS = [
+	IMAGE_FILTER_STATUS_HOVER,
+	...IMAGE_FILTER_ATTRIBUTE_KEYS.map(key => `${key}-hover`),
+];
+
+export const IMAGE_FILTER_ALL_ATTRIBUTE_KEYS = [
+	...IMAGE_FILTER_ATTRIBUTE_KEYS,
+	...IMAGE_FILTER_HOVER_ATTRIBUTE_KEYS,
+];

--- a/src/blocks/image-maxi/components/filter-tab/constants.js
+++ b/src/blocks/image-maxi/components/filter-tab/constants.js
@@ -1,0 +1,127 @@
+export const FILTER_BREAKPOINTS = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+export const IMAGE_FILTER_CONTROLS = [
+	{
+		key: 'blur',
+		cssFunction: 'blur',
+		unit: 'px',
+		defaultValue: 0,
+		min: 0,
+		max: 100,
+		step: 1,
+	},
+	{
+		key: 'brightness',
+		cssFunction: 'brightness',
+		unit: '%',
+		defaultValue: 100,
+		min: 0,
+		max: 300,
+		step: 1,
+	},
+	{
+		key: 'contrast',
+		cssFunction: 'contrast',
+		unit: '%',
+		defaultValue: 100,
+		min: 0,
+		max: 300,
+		step: 1,
+	},
+	{
+		key: 'grayscale',
+		cssFunction: 'grayscale',
+		unit: '%',
+		defaultValue: 0,
+		min: 0,
+		max: 100,
+		step: 1,
+	},
+	{
+		key: 'hue-rotate',
+		cssFunction: 'hue-rotate',
+		unit: 'deg',
+		defaultValue: 0,
+		min: 0,
+		max: 360,
+		step: 1,
+	},
+	{
+		key: 'invert',
+		cssFunction: 'invert',
+		unit: '%',
+		defaultValue: 0,
+		min: 0,
+		max: 100,
+		step: 1,
+	},
+	{
+		key: 'opacity',
+		cssFunction: 'opacity',
+		unit: '%',
+		defaultValue: 100,
+		min: 0,
+		max: 100,
+		step: 1,
+	},
+	{
+		key: 'saturate',
+		cssFunction: 'saturate',
+		unit: '%',
+		defaultValue: 100,
+		min: 0,
+		max: 300,
+		step: 1,
+	},
+	{
+		key: 'sepia',
+		cssFunction: 'sepia',
+		unit: '%',
+		defaultValue: 0,
+		min: 0,
+		max: 100,
+		step: 1,
+	},
+];
+
+export const IMAGE_FILTER_DROP_SHADOW_CONTROLS = [
+	{
+		key: 'horizontal',
+		defaultValue: 0,
+		min: -200,
+		max: 200,
+		step: 1,
+	},
+	{
+		key: 'vertical',
+		defaultValue: 0,
+		min: -200,
+		max: 200,
+		step: 1,
+	},
+	{
+		key: 'blur',
+		defaultValue: 0,
+		min: 0,
+		max: 200,
+		step: 1,
+	},
+];
+
+export const IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT = 'rgba(0,0,0,0.35)';
+
+export const getFilterAttribute = key => `image-filter-${key}`;
+
+export const getDropShadowAttribute = key => `image-filter-drop-shadow-${key}`;
+
+export const IMAGE_FILTER_ATTRIBUTE_KEYS = FILTER_BREAKPOINTS.flatMap(
+	breakpoint => [
+		...IMAGE_FILTER_CONTROLS.map(
+			({ key }) => `${getFilterAttribute(key)}-${breakpoint}`
+		),
+		...IMAGE_FILTER_DROP_SHADOW_CONTROLS.map(
+			({ key }) => `${getDropShadowAttribute(key)}-${breakpoint}`
+		),
+		`${getDropShadowAttribute('color')}-${breakpoint}`,
+	]
+);

--- a/src/blocks/image-maxi/components/filter-tab/index.js
+++ b/src/blocks/image-maxi/components/filter-tab/index.js
@@ -21,29 +21,13 @@ import {
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_LABELS,
 	IMAGE_FILTER_HOVER_ATTRIBUTE_KEYS,
+	IMAGE_FILTER_LABELS,
 	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
 } from './constants';
-
-const filterLabels = {
-	blur: __('Blur', 'maxi-blocks'),
-	brightness: __('Brightness', 'maxi-blocks'),
-	contrast: __('Contrast', 'maxi-blocks'),
-	grayscale: __('Grayscale', 'maxi-blocks'),
-	'hue-rotate': __('Hue rotate', 'maxi-blocks'),
-	invert: __('Invert', 'maxi-blocks'),
-	opacity: __('Opacity', 'maxi-blocks'),
-	saturate: __('Saturate', 'maxi-blocks'),
-	sepia: __('Sepia', 'maxi-blocks'),
-};
-
-const dropShadowLabels = {
-	horizontal: __('Horizontal shadow', 'maxi-blocks'),
-	vertical: __('Vertical shadow', 'maxi-blocks'),
-	blur: __('Shadow blur', 'maxi-blocks'),
-};
 
 const FilterControls = props => {
 	const {
@@ -90,7 +74,7 @@ const FilterControls = props => {
 					return (
 						<AdvancedNumberControl
 							key={key}
-							label={`${filterLabels[key]} (${unit})`}
+							label={`${IMAGE_FILTER_LABELS[key]} (${unit})`}
 							value={props[attributeKey]}
 							placeholder={getResponsiveValue(target)}
 							onChangeValue={(val, meta) =>
@@ -114,7 +98,7 @@ const FilterControls = props => {
 					return (
 						<AdvancedNumberControl
 							key={key}
-							label={`${dropShadowLabels[key]} (px)`}
+							label={`${IMAGE_FILTER_DROP_SHADOW_LABELS[key]} (px)`}
 							value={props[attributeKey]}
 							placeholder={getResponsiveValue(target)}
 							onChangeValue={(val, meta) =>

--- a/src/blocks/image-maxi/components/filter-tab/index.js
+++ b/src/blocks/image-maxi/components/filter-tab/index.js
@@ -1,0 +1,142 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AdvancedNumberControl from '@components/advanced-number-control';
+import ColorControl from '@components/color-control';
+import {
+	getDefaultAttribute,
+	getLastBreakpointAttribute,
+} from '@extensions/styles';
+import {
+	IMAGE_FILTER_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	getDropShadowAttribute,
+	getFilterAttribute,
+} from './constants';
+
+const filterLabels = {
+	blur: __('Blur', 'maxi-blocks'),
+	brightness: __('Brightness', 'maxi-blocks'),
+	contrast: __('Contrast', 'maxi-blocks'),
+	grayscale: __('Grayscale', 'maxi-blocks'),
+	'hue-rotate': __('Hue rotate', 'maxi-blocks'),
+	invert: __('Invert', 'maxi-blocks'),
+	opacity: __('Opacity', 'maxi-blocks'),
+	saturate: __('Saturate', 'maxi-blocks'),
+	sepia: __('Sepia', 'maxi-blocks'),
+};
+
+const dropShadowLabels = {
+	horizontal: __('Horizontal shadow', 'maxi-blocks'),
+	vertical: __('Vertical shadow', 'maxi-blocks'),
+	blur: __('Shadow blur', 'maxi-blocks'),
+};
+
+const FilterTab = props => {
+	const { blockStyle, breakpoint, clientId, onChange } = props;
+
+	const getResponsiveValue = target =>
+		getLastBreakpointAttribute({
+			target,
+			breakpoint,
+			attributes: props,
+		});
+
+	const getAttributeKey = target => `${target}-${breakpoint}`;
+
+	const onChangeNumber = (target, val, meta) =>
+		onChange({
+			[getAttributeKey(target)]:
+				val !== undefined && val !== '' ? val : '',
+			meta,
+		});
+
+	const onReset = target =>
+		onChange({
+			[getAttributeKey(target)]: getDefaultAttribute(
+				getAttributeKey(target)
+			),
+			isReset: true,
+		});
+
+	return (
+		<div className='maxi-image-filter-control'>
+			{IMAGE_FILTER_CONTROLS.map(
+				({ key, unit, defaultValue, min, max, step }) => {
+					const target = getFilterAttribute(key);
+					const attributeKey = getAttributeKey(target);
+
+					return (
+						<AdvancedNumberControl
+							key={key}
+							label={`${filterLabels[key]} (${unit})`}
+							value={props[attributeKey]}
+							placeholder={getResponsiveValue(target)}
+							onChangeValue={(val, meta) =>
+								onChangeNumber(target, val, meta)
+							}
+							min={min}
+							max={max}
+							step={step}
+							onReset={() => onReset(target)}
+							initialPosition={defaultValue}
+						/>
+					);
+				}
+			)}
+			<hr />
+			{IMAGE_FILTER_DROP_SHADOW_CONTROLS.map(
+				({ key, defaultValue, min, max, step }) => {
+					const target = getDropShadowAttribute(key);
+					const attributeKey = getAttributeKey(target);
+
+					return (
+						<AdvancedNumberControl
+							key={key}
+							label={`${dropShadowLabels[key]} (px)`}
+							value={props[attributeKey]}
+							placeholder={getResponsiveValue(target)}
+							onChangeValue={(val, meta) =>
+								onChangeNumber(target, val, meta)
+							}
+							min={min}
+							max={max}
+							step={step}
+							onReset={() => onReset(target)}
+							initialPosition={defaultValue}
+						/>
+					);
+				}
+			)}
+			<ColorControl
+				label={__('Drop shadow colour', 'maxi-blocks')}
+				paletteStatus={false}
+				paletteSCStatus={false}
+				paletteOpacity={1}
+				color={
+					getResponsiveValue(getDropShadowAttribute('color')) ||
+					IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT
+				}
+				disablePalette
+				blockStyle={blockStyle}
+				clientId={clientId}
+				deviceType={breakpoint}
+				onChange={({ color }) =>
+					onChange({
+						[getAttributeKey(getDropShadowAttribute('color'))]:
+							color,
+					})
+				}
+				onReset={() => onReset(getDropShadowAttribute('color'))}
+			/>
+		</div>
+	);
+};
+
+export default FilterTab;

--- a/src/blocks/image-maxi/components/filter-tab/index.js
+++ b/src/blocks/image-maxi/components/filter-tab/index.js
@@ -8,14 +8,21 @@ import { __ } from '@wordpress/i18n';
  */
 import AdvancedNumberControl from '@components/advanced-number-control';
 import ColorControl from '@components/color-control';
+import ManageHoverTransitions from '@components/manage-hover-transitions';
+import SettingTabsControl from '@components/setting-tabs-control';
+import ToggleSwitch from '@components/toggle-switch';
 import {
+	getAttributeKey,
 	getDefaultAttribute,
 	getLastBreakpointAttribute,
 } from '@extensions/styles';
 import {
+	IMAGE_FILTER_ATTRIBUTE_KEYS,
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	IMAGE_FILTER_HOVER_ATTRIBUTE_KEYS,
+	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
 } from './constants';
@@ -38,29 +45,37 @@ const dropShadowLabels = {
 	blur: __('Shadow blur', 'maxi-blocks'),
 };
 
-const FilterTab = props => {
-	const { blockStyle, breakpoint, clientId, onChange } = props;
+const FilterControls = props => {
+	const {
+		blockStyle,
+		breakpoint,
+		clientId,
+		isHover = false,
+		onChange,
+	} = props;
 
 	const getResponsiveValue = target =>
 		getLastBreakpointAttribute({
 			target,
 			breakpoint,
 			attributes: props,
+			isHover,
 		});
 
-	const getAttributeKey = target => `${target}-${breakpoint}`;
+	const getStateAttributeKey = target =>
+		getAttributeKey(target, isHover, false, breakpoint);
 
 	const onChangeNumber = (target, val, meta) =>
 		onChange({
-			[getAttributeKey(target)]:
+			[getStateAttributeKey(target)]:
 				val !== undefined && val !== '' ? val : '',
 			meta,
 		});
 
 	const onReset = target =>
 		onChange({
-			[getAttributeKey(target)]: getDefaultAttribute(
-				getAttributeKey(target)
+			[getStateAttributeKey(target)]: getDefaultAttribute(
+				getStateAttributeKey(target)
 			),
 			isReset: true,
 		});
@@ -70,7 +85,7 @@ const FilterTab = props => {
 			{IMAGE_FILTER_CONTROLS.map(
 				({ key, unit, defaultValue, min, max, step }) => {
 					const target = getFilterAttribute(key);
-					const attributeKey = getAttributeKey(target);
+					const attributeKey = getStateAttributeKey(target);
 
 					return (
 						<AdvancedNumberControl
@@ -94,7 +109,7 @@ const FilterTab = props => {
 			{IMAGE_FILTER_DROP_SHADOW_CONTROLS.map(
 				({ key, defaultValue, min, max, step }) => {
 					const target = getDropShadowAttribute(key);
-					const attributeKey = getAttributeKey(target);
+					const attributeKey = getStateAttributeKey(target);
 
 					return (
 						<AdvancedNumberControl
@@ -129,13 +144,56 @@ const FilterTab = props => {
 				deviceType={breakpoint}
 				onChange={({ color }) =>
 					onChange({
-						[getAttributeKey(getDropShadowAttribute('color'))]:
+						[getStateAttributeKey(getDropShadowAttribute('color'))]:
 							color,
 					})
 				}
 				onReset={() => onReset(getDropShadowAttribute('color'))}
 			/>
 		</div>
+	);
+};
+
+const FilterTab = props => {
+	const { onChange } = props;
+	const hoverStatus = props[IMAGE_FILTER_STATUS_HOVER];
+
+	return (
+		<SettingTabsControl
+			items={[
+				{
+					label: __('Normal', 'maxi-blocks'),
+					indicatorProps: IMAGE_FILTER_ATTRIBUTE_KEYS,
+					content: <FilterControls {...props} />,
+				},
+				{
+					label: __('Hover', 'maxi-blocks'),
+					indicatorProps: hoverStatus
+						? IMAGE_FILTER_HOVER_ATTRIBUTE_KEYS
+						: [],
+					extraIndicators: [IMAGE_FILTER_STATUS_HOVER],
+					content: (
+						<>
+							<ManageHoverTransitions />
+							<ToggleSwitch
+								label={__('Enable filter hover', 'maxi-blocks')}
+								selected={hoverStatus}
+								className='maxi-image-filter-status-hover'
+								onChange={val =>
+									onChange({
+										[IMAGE_FILTER_STATUS_HOVER]: val,
+									})
+								}
+							/>
+							{hoverStatus && (
+								<FilterControls {...props} isHover />
+							)}
+						</>
+					),
+				},
+			]}
+			depth={2}
+		/>
 	);
 };
 

--- a/src/blocks/image-maxi/components/filter-tab/test/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/test/utils.js
@@ -181,6 +181,19 @@ describe('Image Maxi filter composition with hover effects', () => {
 		});
 	});
 
+	it('records an explicit reset so the general filter does not leak down', () => {
+		const filter = composeImageFilterWithEffect(
+			{
+				'image-filter-brightness-general': 125,
+				'image-filter-brightness-s': 100,
+			},
+			'blur(0)'
+		);
+
+		expect(filter.general).toEqual({ filter: 'brightness(125%) blur(0)' });
+		expect(filter.s).toEqual({ filter: 'blur(0)' });
+	});
+
 	it('uses hover filter values when hover is requested', () => {
 		const filter = composeImageFilterWithEffect(
 			{

--- a/src/blocks/image-maxi/components/filter-tab/test/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/test/utils.js
@@ -71,6 +71,25 @@ describe('Image Maxi filter styles', () => {
 		});
 	});
 
+	it('combines filter controls and drop-shadow in declaration order', () => {
+		const styles = getImageFilterStyles({
+			'image-filter-blur-general': 4,
+			'image-filter-brightness-general': 125,
+			'image-filter-drop-shadow-horizontal-general': 2,
+			'image-filter-drop-shadow-vertical-general': 6,
+			'image-filter-drop-shadow-blur-general': 8,
+			'image-filter-drop-shadow-color-general': 'rgba(0,0,0,0.35)',
+		});
+
+		expect(styles).toEqual({
+			filter: {
+				general: {
+					filter: 'blur(4px) brightness(125%) drop-shadow(2px 6px 8px rgba(0,0,0,0.35))',
+				},
+			},
+		});
+	});
+
 	it('does not emit neutral filter values', () => {
 		const styles = getImageFilterStyles({
 			'image-filter-blur-general': 0,

--- a/src/blocks/image-maxi/components/filter-tab/test/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/test/utils.js
@@ -1,17 +1,32 @@
 const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
 
 jest.mock('@extensions/styles', () => ({
-	getLastBreakpointAttribute: jest.fn(({ target, breakpoint, attributes }) => {
-		const breakpointIndex = breakpoints.indexOf(breakpoint);
+	getLastBreakpointAttribute: jest.fn(
+		({ target, breakpoint, attributes, isHover = false }) => {
+			const breakpointIndex = breakpoints.indexOf(breakpoint);
 
-		for (let index = breakpointIndex; index >= 0; index -= 1) {
-			const value = attributes[`${target}-${breakpoints[index]}`];
+			for (let index = breakpointIndex; index >= 0; index -= 1) {
+				const value =
+					attributes[
+						`${target}-${breakpoints[index]}${
+							isHover ? '-hover' : ''
+						}`
+					];
 
-			if (value !== undefined && value !== '') return value;
+				if (value !== undefined && value !== '') return value;
+			}
+
+			if (isHover) {
+				for (let index = breakpointIndex; index >= 0; index -= 1) {
+					const value = attributes[`${target}-${breakpoints[index]}`];
+
+					if (value !== undefined && value !== '') return value;
+				}
+			}
+
+			return attributes[target];
 		}
-
-		return attributes[target];
-	}),
+	),
 }));
 
 import { getImageFilterStyles } from '../utils';
@@ -81,5 +96,32 @@ describe('Image Maxi filter styles', () => {
 		expect(styles.filter.xxl).toEqual({
 			filter: 'blur(4px) brightness(125%)',
 		});
+	});
+
+	it('builds hover filter styles from hover attributes', () => {
+		const styles = getImageFilterStyles(
+			{
+				'image-filter-blur-general': 4,
+				'image-filter-blur-general-hover': 8,
+				'image-filter-brightness-general-hover': 125,
+			},
+			true
+		);
+
+		expect(styles.filter.general).toEqual({
+			filter: 'blur(8px) brightness(125%)',
+		});
+	});
+
+	it('clears an inherited normal filter when hover is explicitly neutral', () => {
+		const styles = getImageFilterStyles(
+			{
+				'image-filter-blur-general': 4,
+				'image-filter-blur-general-hover': 0,
+			},
+			true
+		);
+
+		expect(styles.filter.general).toEqual({ filter: 'none' });
 	});
 });

--- a/src/blocks/image-maxi/components/filter-tab/test/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/test/utils.js
@@ -29,7 +29,10 @@ jest.mock('@extensions/styles', () => ({
 	),
 }));
 
-import { getImageFilterStyles } from '../utils';
+import {
+	composeImageFilterWithEffect,
+	getImageFilterStyles,
+} from '../utils';
 
 describe('Image Maxi filter styles', () => {
 	it('builds a combined CSS filter from non-default image filter controls', () => {
@@ -142,5 +145,54 @@ describe('Image Maxi filter styles', () => {
 		);
 
 		expect(styles.filter.general).toEqual({ filter: 'none' });
+	});
+});
+
+describe('Image Maxi filter composition with hover effects', () => {
+	it('appends the blur effect to the user filter at general', () => {
+		const filter = composeImageFilterWithEffect(
+			{ 'image-filter-brightness-general': 125 },
+			'blur(0)'
+		);
+
+		expect(filter.general).toEqual({
+			filter: 'brightness(125%) blur(0)',
+		});
+	});
+
+	it('emits the blur effect alone when no filter is set', () => {
+		const filter = composeImageFilterWithEffect({}, 'blur(5px)');
+
+		expect(filter.general).toEqual({ filter: 'blur(5px)' });
+	});
+
+	it('composes responsive filter overrides with the effect', () => {
+		const filter = composeImageFilterWithEffect(
+			{
+				'image-filter-brightness-general': 125,
+				'image-filter-contrast-s': 80,
+			},
+			'blur(0)'
+		);
+
+		expect(filter.general).toEqual({ filter: 'brightness(125%) blur(0)' });
+		expect(filter.s).toEqual({
+			filter: 'brightness(125%) contrast(80%) blur(0)',
+		});
+	});
+
+	it('uses hover filter values when hover is requested', () => {
+		const filter = composeImageFilterWithEffect(
+			{
+				'image-filter-brightness-general': 125,
+				'image-filter-brightness-general-hover': 150,
+			},
+			'blur(5px)',
+			true
+		);
+
+		expect(filter.general).toEqual({
+			filter: 'brightness(150%) blur(5px)',
+		});
 	});
 });

--- a/src/blocks/image-maxi/components/filter-tab/test/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/test/utils.js
@@ -1,0 +1,85 @@
+const breakpoints = ['general', 'xxl', 'xl', 'l', 'm', 's', 'xs'];
+
+jest.mock('@extensions/styles', () => ({
+	getLastBreakpointAttribute: jest.fn(({ target, breakpoint, attributes }) => {
+		const breakpointIndex = breakpoints.indexOf(breakpoint);
+
+		for (let index = breakpointIndex; index >= 0; index -= 1) {
+			const value = attributes[`${target}-${breakpoints[index]}`];
+
+			if (value !== undefined && value !== '') return value;
+		}
+
+		return attributes[target];
+	}),
+}));
+
+import { getImageFilterStyles } from '../utils';
+
+describe('Image Maxi filter styles', () => {
+	it('builds a combined CSS filter from non-default image filter controls', () => {
+		const styles = getImageFilterStyles({
+			'image-filter-blur-general': 4,
+			'image-filter-brightness-general': 125,
+			'image-filter-contrast-general': 80,
+			'image-filter-grayscale-general': 30,
+			'image-filter-hue-rotate-general': 45,
+			'image-filter-invert-general': 10,
+			'image-filter-opacity-general': 90,
+			'image-filter-saturate-general': 150,
+			'image-filter-sepia-general': 20,
+		});
+
+		expect(styles).toEqual({
+			filter: {
+				general: {
+					filter: 'blur(4px) brightness(125%) contrast(80%) grayscale(30%) hue-rotate(45deg) invert(10%) opacity(90%) saturate(150%) sepia(20%)',
+				},
+			},
+		});
+	});
+
+	it('adds drop-shadow to the same filter declaration', () => {
+		const styles = getImageFilterStyles({
+			'image-filter-drop-shadow-horizontal-general': 2,
+			'image-filter-drop-shadow-vertical-general': 6,
+			'image-filter-drop-shadow-blur-general': 8,
+			'image-filter-drop-shadow-color-general': 'rgba(0,0,0,0.35)',
+		});
+
+		expect(styles).toEqual({
+			filter: {
+				general: {
+					filter: 'drop-shadow(2px 6px 8px rgba(0,0,0,0.35))',
+				},
+			},
+		});
+	});
+
+	it('does not emit neutral filter values', () => {
+		const styles = getImageFilterStyles({
+			'image-filter-blur-general': 0,
+			'image-filter-brightness-general': 100,
+			'image-filter-contrast-general': 100,
+			'image-filter-grayscale-general': 0,
+			'image-filter-hue-rotate-general': 0,
+			'image-filter-invert-general': 0,
+			'image-filter-opacity-general': 100,
+			'image-filter-saturate-general': 100,
+			'image-filter-sepia-general': 0,
+		});
+
+		expect(styles).toEqual({});
+	});
+
+	it('keeps inherited filter functions when a breakpoint changes one value', () => {
+		const styles = getImageFilterStyles({
+			'image-filter-blur-general': 4,
+			'image-filter-brightness-xxl': 125,
+		});
+
+		expect(styles.filter.xxl).toEqual({
+			filter: 'blur(4px) brightness(125%)',
+		});
+	});
+});

--- a/src/blocks/image-maxi/components/filter-tab/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/utils.js
@@ -1,0 +1,130 @@
+/**
+ * Internal dependencies
+ */
+import { getLastBreakpointAttribute } from '@extensions/styles';
+import {
+	FILTER_BREAKPOINTS,
+	IMAGE_FILTER_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT,
+	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	getDropShadowAttribute,
+	getFilterAttribute,
+} from './constants';
+
+/**
+ * External dependencies
+ */
+import { isNil, isNumber } from 'lodash';
+
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const getNumber = value => {
+	if (isNumber(value)) return value;
+	if (value === '' || isNil(value)) return undefined;
+
+	const parsed = Number(value);
+
+	return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const getFilterNumber = (props, target, breakpoint) =>
+	getNumber(
+		getLastBreakpointAttribute({
+			target,
+			breakpoint,
+			attributes: props,
+		})
+	);
+
+const hasExplicitBreakpointValue = (props, target, breakpoint) =>
+	hasOwn(props, `${target}-${breakpoint}`) &&
+	!isNil(props[`${target}-${breakpoint}`]) &&
+	props[`${target}-${breakpoint}`] !== '';
+
+const hasExplicitFilterValue = (props, breakpoint) =>
+	IMAGE_FILTER_CONTROLS.some(({ key }) =>
+		hasExplicitBreakpointValue(props, getFilterAttribute(key), breakpoint)
+	) ||
+	IMAGE_FILTER_DROP_SHADOW_CONTROLS.some(({ key }) =>
+		hasExplicitBreakpointValue(
+			props,
+			getDropShadowAttribute(key),
+			breakpoint
+		)
+	) ||
+	hasExplicitBreakpointValue(
+		props,
+		getDropShadowAttribute('color'),
+		breakpoint
+	);
+
+export const getImageFilterValue = (props, breakpoint) => {
+	const filterFunctions = IMAGE_FILTER_CONTROLS.reduce(
+		(acc, { key, cssFunction, unit, defaultValue }) => {
+			const value = getFilterNumber(
+				props,
+				getFilterAttribute(key),
+				breakpoint
+			);
+
+			if (!isNil(value) && value !== defaultValue) {
+				acc.push(`${cssFunction}(${value}${unit})`);
+			}
+
+			return acc;
+		},
+		[]
+	);
+
+	const dropShadowValues = IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce(
+		(acc, { key, defaultValue }) => {
+			const value = getFilterNumber(
+				props,
+				getDropShadowAttribute(key),
+				breakpoint
+			);
+
+			acc[key] = isNil(value) ? defaultValue : value;
+
+			return acc;
+		},
+		{}
+	);
+	const hasDropShadow = IMAGE_FILTER_DROP_SHADOW_CONTROLS.some(
+		({ key, defaultValue }) => dropShadowValues[key] !== defaultValue
+	);
+
+	if (hasDropShadow) {
+		const color =
+			getLastBreakpointAttribute({
+				target: getDropShadowAttribute('color'),
+				breakpoint,
+				attributes: props,
+			}) || IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT;
+
+		filterFunctions.push(
+			`drop-shadow(${dropShadowValues.horizontal}px ${dropShadowValues.vertical}px ${dropShadowValues.blur}px ${color})`
+		);
+	}
+
+	return filterFunctions.join(' ');
+};
+
+export const getImageFilterStyles = props => {
+	const response = {};
+
+	FILTER_BREAKPOINTS.forEach(breakpoint => {
+		const filter = getImageFilterValue(props, breakpoint);
+
+		if (breakpoint === 'general') {
+			if (filter) response[breakpoint] = { filter };
+			return;
+		}
+
+		if (hasExplicitFilterValue(props, breakpoint)) {
+			response[breakpoint] = { filter: filter || 'none' };
+		}
+	});
+
+	return Object.keys(response).length ? { filter: response } : {};
+};

--- a/src/blocks/image-maxi/components/filter-tab/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/utils.js
@@ -176,8 +176,15 @@ export const composeImageFilterWithEffect = (
 		const filter = getImageFilterValue(props, breakpoint, isHover);
 
 		// The effect only emits at `general`, so non-general breakpoints only
-		// need composing when the user set a filter override there.
-		if (breakpoint !== 'general' && !filter) return;
+		// need composing when the user explicitly set a filter there. We check
+		// for an explicit value rather than `filter` truthiness so an explicit
+		// reset to defaults (empty filter string) still records the override
+		// and stops the general filter from leaking down to smaller screens.
+		if (
+			breakpoint !== 'general' &&
+			!hasExplicitFilterValue(props, breakpoint, isHover)
+		)
+			return;
 
 		response[breakpoint] = {
 			filter: [filter, effectFilter].filter(Boolean).join(' '),

--- a/src/blocks/image-maxi/components/filter-tab/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/utils.js
@@ -155,3 +155,34 @@ export const getImageFilterStyles = (props, isHover = false) => {
 
 	return Object.keys(response).length ? { filter: response } : {};
 };
+
+/**
+ * Composes the user's image filter with a hover-effect filter declaration
+ * (e.g. the Basic > Blur effect's `blur(0)` / `blur(Npx)`). The hover-effect
+ * selectors are more specific than the wrapper image selector, so the effect's
+ * standalone `filter` would otherwise override the filter controls. Appending
+ * the effect to the user's filter keeps both working together.
+ *
+ * Returns a breakpoint-keyed object ready to assign to a `filter` style entry.
+ */
+export const composeImageFilterWithEffect = (
+	props,
+	effectFilter,
+	isHover = false
+) => {
+	const response = {};
+
+	FILTER_BREAKPOINTS.forEach(breakpoint => {
+		const filter = getImageFilterValue(props, breakpoint, isHover);
+
+		// The effect only emits at `general`, so non-general breakpoints only
+		// need composing when the user set a filter override there.
+		if (breakpoint !== 'general' && !filter) return;
+
+		response[breakpoint] = {
+			filter: [filter, effectFilter].filter(Boolean).join(' '),
+		};
+	});
+
+	return response;
+};

--- a/src/blocks/image-maxi/components/filter-tab/utils.js
+++ b/src/blocks/image-maxi/components/filter-tab/utils.js
@@ -27,44 +27,62 @@ const getNumber = value => {
 	return Number.isNaN(parsed) ? undefined : parsed;
 };
 
-const getFilterNumber = (props, target, breakpoint) =>
+const getFilterNumber = (props, target, breakpoint, isHover = false) =>
 	getNumber(
 		getLastBreakpointAttribute({
 			target,
 			breakpoint,
 			attributes: props,
+			isHover,
 		})
 	);
 
-const hasExplicitBreakpointValue = (props, target, breakpoint) =>
-	hasOwn(props, `${target}-${breakpoint}`) &&
-	!isNil(props[`${target}-${breakpoint}`]) &&
-	props[`${target}-${breakpoint}`] !== '';
+const getStateAttributeKey = (target, breakpoint, isHover = false) =>
+	`${target}-${breakpoint}${isHover ? '-hover' : ''}`;
 
-const hasExplicitFilterValue = (props, breakpoint) =>
+const hasExplicitBreakpointValue = (
+	props,
+	target,
+	breakpoint,
+	isHover = false
+) => {
+	const key = getStateAttributeKey(target, breakpoint, isHover);
+
+	return hasOwn(props, key) && !isNil(props[key]) && props[key] !== '';
+};
+
+const hasExplicitFilterValue = (props, breakpoint, isHover = false) =>
 	IMAGE_FILTER_CONTROLS.some(({ key }) =>
-		hasExplicitBreakpointValue(props, getFilterAttribute(key), breakpoint)
+		hasExplicitBreakpointValue(
+			props,
+			getFilterAttribute(key),
+			breakpoint,
+			isHover
+		)
 	) ||
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS.some(({ key }) =>
 		hasExplicitBreakpointValue(
 			props,
 			getDropShadowAttribute(key),
-			breakpoint
+			breakpoint,
+			isHover
 		)
 	) ||
 	hasExplicitBreakpointValue(
 		props,
 		getDropShadowAttribute('color'),
-		breakpoint
+		breakpoint,
+		isHover
 	);
 
-export const getImageFilterValue = (props, breakpoint) => {
+export const getImageFilterValue = (props, breakpoint, isHover = false) => {
 	const filterFunctions = IMAGE_FILTER_CONTROLS.reduce(
 		(acc, { key, cssFunction, unit, defaultValue }) => {
 			const value = getFilterNumber(
 				props,
 				getFilterAttribute(key),
-				breakpoint
+				breakpoint,
+				isHover
 			);
 
 			if (!isNil(value) && value !== defaultValue) {
@@ -81,7 +99,8 @@ export const getImageFilterValue = (props, breakpoint) => {
 			const value = getFilterNumber(
 				props,
 				getDropShadowAttribute(key),
-				breakpoint
+				breakpoint,
+				isHover
 			);
 
 			acc[key] = isNil(value) ? defaultValue : value;
@@ -100,6 +119,7 @@ export const getImageFilterValue = (props, breakpoint) => {
 				target: getDropShadowAttribute('color'),
 				breakpoint,
 				attributes: props,
+				isHover,
 			}) || IMAGE_FILTER_DROP_SHADOW_COLOR_DEFAULT;
 
 		filterFunctions.push(
@@ -110,18 +130,25 @@ export const getImageFilterValue = (props, breakpoint) => {
 	return filterFunctions.join(' ');
 };
 
-export const getImageFilterStyles = props => {
+export const getImageFilterStyles = (props, isHover = false) => {
 	const response = {};
 
 	FILTER_BREAKPOINTS.forEach(breakpoint => {
-		const filter = getImageFilterValue(props, breakpoint);
+		const filter = getImageFilterValue(props, breakpoint, isHover);
+		const hasExplicitValue = hasExplicitFilterValue(
+			props,
+			breakpoint,
+			isHover
+		);
 
 		if (breakpoint === 'general') {
-			if (filter) response[breakpoint] = { filter };
+			if (filter || (isHover && hasExplicitValue)) {
+				response[breakpoint] = { filter: filter || 'none' };
+			}
 			return;
 		}
 
-		if (hasExplicitFilterValue(props, breakpoint)) {
+		if (hasExplicitValue) {
 			response[breakpoint] = { filter: filter || 'none' };
 		}
 	});

--- a/src/blocks/image-maxi/components/index.js
+++ b/src/blocks/image-maxi/components/index.js
@@ -1,2 +1,3 @@
 export { default as HoverEffectControl } from './hover-effect-control';
 export { default as DimensionTab } from './dimension-tab';
+export { default as FilterTab } from './filter-tab';

--- a/src/blocks/image-maxi/data.js
+++ b/src/blocks/image-maxi/data.js
@@ -25,6 +25,7 @@ import { getEditorWrapper } from '@extensions/dom';
 import {
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
 } from './components/filter-tab/constants';
@@ -204,6 +205,41 @@ const copyPasteMapping = {
 				[__('Drop shadow colour', 'maxi-blocks')]: {
 					props: getDropShadowAttribute('color'),
 					hasBreakpoints: true,
+				},
+				[__('Filter hover state', 'maxi-blocks')]:
+					IMAGE_FILTER_STATUS_HOVER,
+				...IMAGE_FILTER_CONTROLS.reduce((acc, { key }) => {
+					acc[
+						`${filterCopyPasteLabels[key]} ${__(
+							'hover',
+							'maxi-blocks'
+						)}`
+					] = {
+						props: getFilterAttribute(key),
+						hasBreakpoints: true,
+						isHover: true,
+					};
+
+					return acc;
+				}, {}),
+				...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce((acc, { key }) => {
+					acc[
+						`${dropShadowCopyPasteLabels[key]} ${__(
+							'hover',
+							'maxi-blocks'
+						)}`
+					] = {
+						props: getDropShadowAttribute(key),
+						hasBreakpoints: true,
+						isHover: true,
+					};
+
+					return acc;
+				}, {}),
+				[__('Drop shadow colour hover', 'maxi-blocks')]: {
+					props: getDropShadowAttribute('color'),
+					hasBreakpoints: true,
+					isHover: true,
 				},
 			},
 		},

--- a/src/blocks/image-maxi/data.js
+++ b/src/blocks/image-maxi/data.js
@@ -25,6 +25,8 @@ import { getEditorWrapper } from '@extensions/dom';
 import {
 	IMAGE_FILTER_CONTROLS,
 	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_LABELS,
+	IMAGE_FILTER_LABELS,
 	IMAGE_FILTER_STATUS_HOVER,
 	getDropShadowAttribute,
 	getFilterAttribute,
@@ -38,22 +40,6 @@ const imageClass = `${blockClass}__image`;
 const imageWrapperClass = `${blockClass}-wrapper`;
 
 const prefix = 'image-';
-const filterCopyPasteLabels = {
-	blur: __('Blur', 'maxi-blocks'),
-	brightness: __('Brightness', 'maxi-blocks'),
-	contrast: __('Contrast', 'maxi-blocks'),
-	grayscale: __('Grayscale', 'maxi-blocks'),
-	'hue-rotate': __('Hue rotate', 'maxi-blocks'),
-	invert: __('Invert', 'maxi-blocks'),
-	opacity: __('Opacity', 'maxi-blocks'),
-	saturate: __('Saturate', 'maxi-blocks'),
-	sepia: __('Sepia', 'maxi-blocks'),
-};
-const dropShadowCopyPasteLabels = {
-	horizontal: __('Drop shadow horizontal', 'maxi-blocks'),
-	vertical: __('Drop shadow vertical', 'maxi-blocks'),
-	blur: __('Drop shadow blur', 'maxi-blocks'),
-};
 
 /**
  * Data object
@@ -187,7 +173,7 @@ const copyPasteMapping = {
 		[__('Filters', 'maxi-blocks')]: {
 			group: {
 				...IMAGE_FILTER_CONTROLS.reduce((acc, { key }) => {
-					acc[filterCopyPasteLabels[key]] = {
+					acc[IMAGE_FILTER_LABELS[key]] = {
 						props: getFilterAttribute(key),
 						hasBreakpoints: true,
 					};
@@ -195,7 +181,7 @@ const copyPasteMapping = {
 					return acc;
 				}, {}),
 				...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce((acc, { key }) => {
-					acc[dropShadowCopyPasteLabels[key]] = {
+					acc[IMAGE_FILTER_DROP_SHADOW_LABELS[key]] = {
 						props: getDropShadowAttribute(key),
 						hasBreakpoints: true,
 					};
@@ -211,7 +197,7 @@ const copyPasteMapping = {
 				},
 				...IMAGE_FILTER_CONTROLS.reduce((acc, { key }) => {
 					acc[
-						`${filterCopyPasteLabels[key]} ${__(
+						`${IMAGE_FILTER_LABELS[key]} ${__(
 							'hover',
 							'maxi-blocks'
 						)}`
@@ -225,7 +211,7 @@ const copyPasteMapping = {
 				}, {}),
 				...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce((acc, { key }) => {
 					acc[
-						`${dropShadowCopyPasteLabels[key]} ${__(
+						`${IMAGE_FILTER_DROP_SHADOW_LABELS[key]} ${__(
 							'hover',
 							'maxi-blocks'
 						)}`

--- a/src/blocks/image-maxi/data.js
+++ b/src/blocks/image-maxi/data.js
@@ -206,8 +206,9 @@ const copyPasteMapping = {
 					props: getDropShadowAttribute('color'),
 					hasBreakpoints: true,
 				},
-				[__('Filter hover state', 'maxi-blocks')]:
-					IMAGE_FILTER_STATUS_HOVER,
+				[__('Filter hover state', 'maxi-blocks')]: {
+					props: 'image-filter-status-hover',
+				},
 				...IMAGE_FILTER_CONTROLS.reduce((acc, { key }) => {
 					acc[
 						`${filterCopyPasteLabels[key]} ${__(
@@ -334,6 +335,7 @@ const transition = {
 			title: __('Filter', 'maxi-blocks'),
 			target: [`${imageWrapperClass} img`, `${imageWrapperClass} svg`],
 			property: 'filter',
+			hoverProp: IMAGE_FILTER_STATUS_HOVER,
 		},
 	},
 };

--- a/src/blocks/image-maxi/data.js
+++ b/src/blocks/image-maxi/data.js
@@ -22,6 +22,12 @@ import { getGroupAttributes } from '@extensions/styles';
 import { getCanvasSettings, getAdvancedSettings } from '@extensions/relations';
 import transitionDefault from '@extensions/styles/transitions/transitionDefault';
 import { getEditorWrapper } from '@extensions/dom';
+import {
+	IMAGE_FILTER_CONTROLS,
+	IMAGE_FILTER_DROP_SHADOW_CONTROLS,
+	getDropShadowAttribute,
+	getFilterAttribute,
+} from './components/filter-tab/constants';
 
 /**
  * Classnames
@@ -31,6 +37,22 @@ const imageClass = `${blockClass}__image`;
 const imageWrapperClass = `${blockClass}-wrapper`;
 
 const prefix = 'image-';
+const filterCopyPasteLabels = {
+	blur: __('Blur', 'maxi-blocks'),
+	brightness: __('Brightness', 'maxi-blocks'),
+	contrast: __('Contrast', 'maxi-blocks'),
+	grayscale: __('Grayscale', 'maxi-blocks'),
+	'hue-rotate': __('Hue rotate', 'maxi-blocks'),
+	invert: __('Invert', 'maxi-blocks'),
+	opacity: __('Opacity', 'maxi-blocks'),
+	saturate: __('Saturate', 'maxi-blocks'),
+	sepia: __('Sepia', 'maxi-blocks'),
+};
+const dropShadowCopyPasteLabels = {
+	horizontal: __('Drop shadow horizontal', 'maxi-blocks'),
+	vertical: __('Drop shadow vertical', 'maxi-blocks'),
+	blur: __('Drop shadow blur', 'maxi-blocks'),
+};
 
 /**
  * Data object
@@ -161,6 +183,30 @@ const copyPasteMapping = {
 				},
 			},
 		},
+		[__('Filters', 'maxi-blocks')]: {
+			group: {
+				...IMAGE_FILTER_CONTROLS.reduce((acc, { key }) => {
+					acc[filterCopyPasteLabels[key]] = {
+						props: getFilterAttribute(key),
+						hasBreakpoints: true,
+					};
+
+					return acc;
+				}, {}),
+				...IMAGE_FILTER_DROP_SHADOW_CONTROLS.reduce((acc, { key }) => {
+					acc[dropShadowCopyPasteLabels[key]] = {
+						props: getDropShadowAttribute(key),
+						hasBreakpoints: true,
+					};
+
+					return acc;
+				}, {}),
+				[__('Drop shadow colour', 'maxi-blocks')]: {
+					props: getDropShadowAttribute('color'),
+					hasBreakpoints: true,
+				},
+			},
+		},
 		[__('Clip path', 'maxi-blocks')]: {
 			groupAttributes: ['clipPath', 'clipPathHover'],
 		},
@@ -247,6 +293,11 @@ const transition = {
 			target: [`${imageWrapperClass} img`, `${imageWrapperClass} svg`],
 			property: 'clip-path',
 			hoverProp: 'clip-path-status-hover',
+		},
+		filter: {
+			title: __('Filter', 'maxi-blocks'),
+			target: [`${imageWrapperClass} img`, `${imageWrapperClass} svg`],
+			property: 'filter',
 		},
 	},
 };

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -24,6 +24,7 @@ import SelectControl from '@components/select-control';
 import SettingTabsControl from '@components/setting-tabs-control';
 import TypographyControl from '@components/typography-control';
 import DimensionTab from './components/dimension-tab';
+import FilterTab from './components/filter-tab';
 import HoverEffectControl from './components/hover-effect-control';
 import InfoBox from '@components/info-box';
 import {
@@ -35,6 +36,7 @@ import * as inspectorTabs from '@components/inspector-tabs';
 import { ariaLabelsCategories, customCss } from './data';
 import { withMaxiInspector } from '@extensions/inspector';
 import { transitionFilterEffects } from './components/hover-effect-control/constants';
+import { IMAGE_FILTER_ATTRIBUTE_KEYS } from './components/filter-tab/constants';
 
 /**
  * Inspector
@@ -510,6 +512,21 @@ const Inspector = props => {
 								]}
 							/>
 						),
+					},
+					{
+						label: __('Filters', 'maxi-blocks'),
+						content: (
+							<ResponsiveTabsControl breakpoint={deviceType}>
+								<FilterTab
+									{...attributes}
+									onChange={maxiSetAttributes}
+									breakpoint={deviceType}
+									blockStyle={blockStyle}
+									clientId={clientId}
+								/>
+							</ResponsiveTabsControl>
+						),
+						indicatorProps: IMAGE_FILTER_ATTRIBUTE_KEYS,
 					},
 					{
 						label: __('Canvas', 'maxi-blocks'),

--- a/src/blocks/image-maxi/inspector.js
+++ b/src/blocks/image-maxi/inspector.js
@@ -36,7 +36,7 @@ import * as inspectorTabs from '@components/inspector-tabs';
 import { ariaLabelsCategories, customCss } from './data';
 import { withMaxiInspector } from '@extensions/inspector';
 import { transitionFilterEffects } from './components/hover-effect-control/constants';
-import { IMAGE_FILTER_ATTRIBUTE_KEYS } from './components/filter-tab/constants';
+import { IMAGE_FILTER_ALL_ATTRIBUTE_KEYS } from './components/filter-tab/constants';
 
 /**
  * Inspector
@@ -490,6 +490,24 @@ const Inspector = props => {
 										props,
 										selector: '.maxi-image-block__image',
 									}),
+									{
+										label: __('Filters', 'maxi-blocks'),
+										content: (
+											<ResponsiveTabsControl
+												breakpoint={deviceType}
+											>
+												<FilterTab
+													{...attributes}
+													onChange={maxiSetAttributes}
+													breakpoint={deviceType}
+													blockStyle={blockStyle}
+													clientId={clientId}
+												/>
+											</ResponsiveTabsControl>
+										),
+										indicatorProps:
+											IMAGE_FILTER_ALL_ATTRIBUTE_KEYS,
+									},
 									...inspectorTabs.border({
 										props,
 										prefix: 'image-',
@@ -512,21 +530,6 @@ const Inspector = props => {
 								]}
 							/>
 						),
-					},
-					{
-						label: __('Filters', 'maxi-blocks'),
-						content: (
-							<ResponsiveTabsControl breakpoint={deviceType}>
-								<FilterTab
-									{...attributes}
-									onChange={maxiSetAttributes}
-									breakpoint={deviceType}
-									blockStyle={blockStyle}
-									clientId={clientId}
-								/>
-							</ResponsiveTabsControl>
-						),
-						indicatorProps: IMAGE_FILTER_ATTRIBUTE_KEYS,
 					},
 					{
 						label: __('Canvas', 'maxi-blocks'),

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -35,7 +35,10 @@ import {
 	transitionDurationEffects,
 	transitionFilterEffects,
 } from './components/hover-effect-control/constants';
-import { getImageFilterStyles } from './components/filter-tab/utils';
+import {
+	composeImageFilterWithEffect,
+	getImageFilterStyles,
+} from './components/filter-tab/utils';
 import data from './data';
 
 /**
@@ -684,9 +687,10 @@ const getImagePreviewObject = props => {
 				};
 				break;
 			case 'blur':
-				response.filter = {
-					general: { filter: 'blur(0)' },
-				};
+				response.filter = composeImageFilterWithEffect(
+					props,
+					'blur(0)'
+				);
 				break;
 			default:
 				response.transform = { general: { transform: '' } };
@@ -748,11 +752,11 @@ const getImageHoverPreviewObject = props => {
 				};
 				break;
 			case 'blur':
-				response.filter = {
-					general: {
-						filter: `blur(${props['hover-basic-blur-value']}px)`,
-					},
-				};
+				response.filter = composeImageFilterWithEffect(
+					props,
+					`blur(${props['hover-basic-blur-value']}px)`,
+					props['image-filter-status-hover']
+				);
 				break;
 			default:
 				response.transform = { general: { transform: '' } };

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -49,9 +49,7 @@ const filterStylesByStatus = (styles, statusTarget, props) => {
 	if (!styles) return null;
 
 	const filtered = Object.fromEntries(
-		Object.entries(styles).filter(
-			([key]) => !breakpoints.includes(key)
-		)
+		Object.entries(styles).filter(([key]) => !breakpoints.includes(key))
 	);
 
 	breakpoints.forEach(breakpoint => {
@@ -531,6 +529,8 @@ const getHoverImageObject = props => {
 				isHover: true,
 			}),
 		}),
+		...(props['image-filter-status-hover'] &&
+			getImageFilterStyles(props, true)),
 	};
 };
 

--- a/src/blocks/image-maxi/styles.js
+++ b/src/blocks/image-maxi/styles.js
@@ -35,6 +35,7 @@ import {
 	transitionDurationEffects,
 	transitionFilterEffects,
 } from './components/hover-effect-control/constants';
+import { getImageFilterStyles } from './components/filter-tab/utils';
 import data from './data';
 
 /**
@@ -476,6 +477,7 @@ const getImageObject = props => {
 				...getGroupAttributes(props, 'clipPath'),
 			},
 		}),
+		...getImageFilterStyles(props),
 		...(imgWidth &&
 			!fitParentSize &&
 			getImgWidthStyles(

--- a/src/blocks/image-maxi/test/inspector.spec.js
+++ b/src/blocks/image-maxi/test/inspector.spec.js
@@ -5,6 +5,7 @@ import Inspector from '@blocks/image-maxi/inspector';
 import { getGroupAttributes } from '@extensions/styles';
 
 const mockAlignmentControl = jest.fn(() => null);
+const mockAccordionControl = jest.fn();
 const mockFilterTab = jest.fn(() => null);
 const mockTypographyControl = jest.fn(() => null);
 
@@ -55,8 +56,12 @@ jest.mock('../data', () => ({
 jest.mock('@components/accordion-control', () => {
 	const React = require('react');
 
-	return ({ items = [] }) =>
-		React.createElement(
+	return props => {
+		const { items = [] } = props;
+
+		mockAccordionControl(props);
+
+		return React.createElement(
 			React.Fragment,
 			null,
 			items
@@ -69,6 +74,7 @@ jest.mock('@components/accordion-control', () => {
 					)
 				)
 		);
+	};
 });
 
 jest.mock('@components/setting-tabs-control', () => {
@@ -122,9 +128,9 @@ jest.mock('@components/inspector-tabs', () => ({
 	ariaLabel: jest.fn(() => []),
 	blockBackground: jest.fn(() => []),
 	blockSettings: jest.fn(() => null),
-	border: jest.fn(() => []),
+	border: jest.fn(() => [{ label: 'Border', content: null }]),
 	boxShadow: jest.fn(() => []),
-	clipPath: jest.fn(() => []),
+	clipPath: jest.fn(() => [{ label: 'Clip-path', content: null }]),
 	customClasses: jest.fn(() => []),
 	customCss: jest.fn(() => []),
 	dc: jest.fn(() => []),
@@ -219,6 +225,21 @@ describe('Image Maxi caption inspector', () => {
 				clientId: 'client-id',
 				onChange: props.maxiSetAttributes,
 			})
+		);
+
+		const settingsAccordion = mockAccordionControl.mock.calls.find(
+			([{ items = [] }]) =>
+				items.filter(Boolean).some(item => item.label === 'Filters')
+		)?.[0];
+		const labels = settingsAccordion.items
+			.filter(Boolean)
+			.map(item => item.label);
+
+		expect(labels.indexOf('Clip-path')).toBeLessThan(
+			labels.indexOf('Filters')
+		);
+		expect(labels.indexOf('Filters')).toBeLessThan(
+			labels.indexOf('Border')
 		);
 	});
 });

--- a/src/blocks/image-maxi/test/inspector.spec.js
+++ b/src/blocks/image-maxi/test/inspector.spec.js
@@ -5,6 +5,7 @@ import Inspector from '@blocks/image-maxi/inspector';
 import { getGroupAttributes } from '@extensions/styles';
 
 const mockAlignmentControl = jest.fn(() => null);
+const mockFilterTab = jest.fn(() => null);
 const mockTypographyControl = jest.fn(() => null);
 
 global.TextDecoder = TextDecoder;
@@ -108,6 +109,9 @@ jest.mock('@components/image-alt-control', () => () => null);
 jest.mock('@components/image-shape', () => () => null);
 jest.mock('@components/select-control', () => () => null);
 jest.mock('@blocks/image-maxi/components/dimension-tab', () => () => null);
+jest.mock('@blocks/image-maxi/components/filter-tab', () => props =>
+	mockFilterTab(props)
+);
 jest.mock('@blocks/image-maxi/components/hover-effect-control', () => () => null);
 jest.mock('@components/info-box', () => () => null);
 
@@ -199,6 +203,21 @@ describe('Image Maxi caption inspector', () => {
 				isRichTextActive: false,
 				textLevel: 'p',
 				useBlockLevelFallback: true,
+			})
+		);
+	});
+
+	it('wires the image filter tab to Image Maxi attributes', () => {
+		const props = getProps();
+
+		renderToStaticMarkup(React.createElement(Inspector, props));
+
+		expect(mockFilterTab).toHaveBeenCalledWith(
+			expect.objectContaining({
+				breakpoint: 'general',
+				blockStyle: 'light',
+				clientId: 'client-id',
+				onChange: props.maxiSetAttributes,
 			})
 		);
 	});

--- a/src/blocks/image-maxi/test/inspector.spec.js
+++ b/src/blocks/image-maxi/test/inspector.spec.js
@@ -231,9 +231,14 @@ describe('Image Maxi caption inspector', () => {
 			([{ items = [] }]) =>
 				items.filter(Boolean).some(item => item.label === 'Filters')
 		)?.[0];
+		expect(settingsAccordion).toBeTruthy();
+
 		const labels = settingsAccordion.items
 			.filter(Boolean)
 			.map(item => item.label);
+		expect(labels).toEqual(
+			expect.arrayContaining(['Clip-path', 'Filters', 'Border'])
+		);
 
 		expect(labels.indexOf('Clip-path')).toBeLessThan(
 			labels.indexOf('Filters')


### PR DESCRIPTION
## Summary
Adds CSS filter controls to Image Maxi and moves them into the Settings accordion between Clip-path and Border.

fixes https://github.com/maxi-blocks/maxi-blocks/issues/5127

## What changed
- Added Image Maxi filter controls for blur, brightness, contrast, grayscale, hue rotate, invert, opacity, saturate, sepia, and drop-shadow.
- Moved Filters out of the top inspector tabs and into Settings below Clip-path and above Border.
- Added Normal and Hover filter settings, including an Enable filter hover toggle and hover transition shortcut.
- Added responsive and hover attributes, style generation, copy/paste mappings, and inspector indicators for the new filter settings.
- Added focused unit coverage for filter style generation and inspector placement.

## Why / root cause
Image Maxi did not expose CSS filter controls in the requested Settings location, and hover-specific filter values were not available for images. The fix follows the existing responsive and hover attribute conventions so normal and hover filters can be stored, rendered, copied, and indicated consistently.

## Testing
- `git diff --check origin/master..HEAD`
- `npm test -- src/blocks/image-maxi --runInBand` passed: 4 suites, 13 tests.
- `npm run build` passed with the existing asset-size warnings.
- WAMP smoke checks returned 200 OK for `/wp-json/` and the front page before push.

## Manual testing
1. Open the local WAMP site and edit a page with an Image Maxi block.
2. Select the Image Maxi block and open Settings.
3. Confirm Filters appears below Clip-path and above Border.
4. Open Filters > Normal, change filter values, and confirm the image updates.
5. Open Filters > Hover, enable filter hover, set different values, and confirm hover output changes in preview or frontend.
6. Save, reload the editor, and confirm normal and hover filter values persist.
7. Check breakpoint tabs for filter values and confirm responsive overrides behave as expected.

## Closing issue link
No related issue URL was provided in the thread, so this PR does not include a closing keyword yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Filters** panel with responsive numeric controls for common image CSS filters, plus **drop-shadow** controls including color.
  * Included a **Hover** mode with enable toggle and transition-aware filter styling.
  * Extended copy/paste mappings to support saving and applying filter and hover filter settings.
* **Tests**
  * Added/updated unit tests covering filter-string generation, drop-shadow behavior, hover overrides, effect composition, and inspector panel wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->