### PR TITLE
Fix: duplicated/pasted blocks reuse an existing `uniqueID` on every other copy

### DIFF
--- a/src/extensions/maxi-block/getIsIDTrulyUnique.js
+++ b/src/extensions/maxi-block/getIsIDTrulyUnique.js
@@ -25,6 +25,7 @@ const getIsIDTrulyUnique = (id, repeatCount = 1, clientId = null) => {
 		isUniqueIDInCache,
 		getLastInsertedBlocks,
 		getUniqueIDCount,
+		getUniqueIDClientIds,
 	} = select('maxiBlocks/blocks');
 
 	// If cache is loaded, use O(1) lookup for site-wide check
@@ -43,7 +44,22 @@ const getIsIDTrulyUnique = (id, repeatCount = 1, clientId = null) => {
 		const lastChangedBlocks = getLastInsertedBlocks() || [];
 		const isNewInsertion = clientId && lastChangedBlocks.includes(clientId);
 
-		let isUnique = currentEditorCount <= repeatCount;
+		// A freshly inserted/copied block registers its own uniqueID into the
+		// store asynchronously (batchBlockDispatcher), so at this point it is
+		// NOT yet reflected in `currentEditorCount`. If we don't account for
+		// it, a copy that collides with exactly one existing block reads
+		// count=1 and is wrongly considered unique (it keeps the duplicate ID).
+		// Count the block itself as an extra occupant when it's a new insertion
+		// that isn't registered yet, matching the tree-traversal fallback which
+		// already includes the block in its count.
+		const registeredClientIds =
+			(clientId && getUniqueIDClientIds?.(id)) || [];
+		const isSelfRegistered =
+			clientId && registeredClientIds.includes(clientId);
+		const pendingSelf = isNewInsertion && !isSelfRegistered ? 1 : 0;
+		const effectiveCount = currentEditorCount + pendingSelf;
+
+		let isUnique = effectiveCount <= repeatCount;
 
 		if (existsInDB && currentEditorCount === 0) {
 			// ID exists in DB but not in current editor

--- a/src/extensions/maxi-block/test/getIsIDTrulyUnique.js
+++ b/src/extensions/maxi-block/test/getIsIDTrulyUnique.js
@@ -787,10 +787,11 @@ describe('getIsIDTrulyUnique', () => {
 			// First check: original ID exists in editor
 			expect(getIsIDTrulyUnique(originalId)).toBe(true);
 
-			// Second check: when copy tries to use same ID
-			// It's in current editor (count=1) but also being inserted
-			// Should still pass the editorCount check since count<=1
-			expect(getIsIDTrulyUnique(originalId, 1, newClientId)).toBe(true);
+			// Second check: when a copy tries to reuse the same ID.
+			// The original already occupies the ID (count=1) and the copy's own
+			// registration is still pending (batched), so the copy must be
+			// counted as an extra occupant → NOT unique → regenerate.
+			expect(getIsIDTrulyUnique(originalId, 1, newClientId)).toBe(false);
 		});
 
 		it('Scenario: User pastes block from another page into dirty post', () => {


### PR DESCRIPTION
## Summary

Duplicating a block that was itself just duplicated produced a block with a **non-unique `uniqueID`** — it kept the id of the block it was copied from instead of generating a fresh one. The problem alternated: copies 1, 3, 5… got new ids, while copies 2, 4, 6… silently reused an existing id.

Because `uniqueID` drives CSS generation, relations (Interaction Builder), and per-block style targeting, two blocks sharing an id means edits/styles on one leak onto the other.

## How to reproduce

1. Add any Maxi block (e.g. a **Button**).
2. Click **Duplicate** in the toolbar → the copy gets a new `uniqueID` ✅.
3. With that copy selected, click **Duplicate** again → this copy keeps the **same** `uniqueID` as the block it was duplicated from ❌.
4. Keep duplicating the most-recently-created block. You'll see the pattern: every **other** duplicate fails to get a unique id.

The same race applies to pasting a copied block (Ctrl/Cmd+V) repeatedly, since pasted blocks run through the identical mount-time check.

### Evidence (from temporary debug logging)

```
clientId 0745b463 → idToCheck 48cecde0, count=2 → NOT unique → regenerated to 5eba8b66
clientId aad7e691 → idToCheck 5eba8b66, count=1 → "unique"  → KEPT 5eba8b66   ← collision!
clientId c5217780 → idToCheck 5eba8b66, count=2 → NOT unique → regenerated to 34430827
clientId 2b03b8a1 → idToCheck 34430827, count=1 → "unique"  → KEPT 34430827   ← collision!
```

## Root cause

On mount, every Maxi block runs `uniqueIDChecker()` (the only caller, in `maxiBlockComponent.js` constructor), which calls `getIsIDTrulyUnique(id, 1, clientId)`. In the cache path, uniqueness was decided from `getUniqueIDCount(id)` — the number of blocks **already registered** in the store under that id — using `count <= repeatCount` (`repeatCount = 1`).

However, a freshly inserted/copied block registers its **own** id into the store **asynchronously**, via `batchBlockDispatcher` (a deferred `setTimeout`, `BATCH_DELAY = 10ms`). `uniqueIDChecker` runs **synchronously in the constructor, before** that registration. So the block never counted itself:

- A copy colliding with exactly one existing block read `count = 1`.
- `1 <= 1` → declared **unique** → it kept the duplicate id.

The whether-it-collides outcome depended on batch-flush timing relative to the next mount, which is what produced the "every other copy" parity.

The tree-traversal fallback (used when the cache isn't loaded) never had this bug, because the block is already present in the editor tree when that path counts occurrences — i.e. it includes the block itself.

## The fix

`src/extensions/maxi-block/getIsIDTrulyUnique.js` now counts the current block as an occupant when it's a new insertion that isn't registered yet — mirroring the tree-traversal semantics:

```js
// A freshly inserted/copied block registers its own uniqueID into the
// store asynchronously (batchBlockDispatcher), so it is NOT yet reflected
// in `currentEditorCount`. Count it as an extra occupant so a copy that
// collides with an existing block is detected as non-unique.
const registeredClientIds = (clientId && getUniqueIDClientIds?.(id)) || [];
const isSelfRegistered = clientId && registeredClientIds.includes(clientId);
const pendingSelf = isNewInsertion && !isSelfRegistered ? 1 : 0;
const effectiveCount = currentEditorCount + pendingSelf;

let isUnique = effectiveCount <= repeatCount;
```

The `isSelfRegistered` guard (via the existing `getUniqueIDClientIds` selector) prevents spuriously regenerating a perfectly valid id if the checker runs again after the block has already been registered (e.g. a re-mount).

## Why this is safe

- **Genuinely new/unique block:** `currentEditorCount = 0`, `pendingSelf = 1` → `effectiveCount = 1 <= 1` → keeps its id. ✅
- **Copy colliding with one existing block:** `currentEditorCount = 1`, `pendingSelf = 1` → `effectiveCount = 2 > 1` → regenerates. ✅ (was the bug)
- **Loading a saved post / duplicating a page:** these are not "new insertions" (`isNewInsertion = false`) → `pendingSelf = 0` → ids are preserved as before. ✅
- **Paste from another page:** still handled by the existing `existsInDB && currentEditorCount === 0 && isNewInsertion` branch → regenerates. ✅

## Scope

- Block **copy/paste** uses the same mount-time `uniqueIDChecker` path (the `copy-paste` extension only copies *styles* and explicitly excludes `uniqueID`), so it is covered by the same fix — verified there is no separate uniqueID-generation path for paste.

## Testing

- Updated `src/extensions/maxi-block/test/getIsIDTrulyUnique.js` — the "User copies block within same page" scenario had been **asserting the buggy behavior** (`toBe(true)`); it now correctly expects the copy to regenerate (`toBe(false)`).
- `getIsIDTrulyUnique` suite: **21/21 pass**.
- `copy-paste` suite: **46/46 pass**.
- Manual: rebuild (`npm start`), then repeatedly duplicate the most-recently-created block — every copy now receives a unique `uniqueID`.

## Files changed

- `src/extensions/maxi-block/getIsIDTrulyUnique.js` — count the pending self-registration of new insertions.
- `src/extensions/maxi-block/test/getIsIDTrulyUnique.js` — corrected the test that encoded the bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unique ID validation for newly copied or inserted blocks. The system now accurately accounts for pending block registrations when determining uniqueness, ensuring correct behavior during block duplication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->